### PR TITLE
🗃️ feat: Add event persistence model for share URL MVP

### DIFF
--- a/docs/web-mvp-persistence-import-restore-plan.md
+++ b/docs/web-mvp-persistence-import-restore-plan.md
@@ -659,3 +659,41 @@ share は event から独立した保存対象として扱い、有効期限を�
 ログインなしで作成された対戦表では、共有URLの有効期限が切れた場合、作成者本人でも再共有できない可能性がある。
 
 ver0.1 ではこの制約を許容し、共有URLの再発行、期限延長、ログインユーザーとの紐づけは後続で検討する。
+
+## 8. #14 実装時点の保存モデル方針
+
+#14 では、共有URL MVP の土台として、web 側の保存モデルと repository 境界を追加した。
+
+web 側では、入力中の一時モデルである `EventDraft` と、保存済み event を表す `SavedEventAggregate` を分けて扱う。
+
+`SavedEventAggregate` は、以下をまとめて扱う aggregate とする。
+
+* event
+* participant
+* import
+* share
+
+画面側から保存処理を直接扱わないよう、`EventRepository` を経由して保存・取得・更新する。
+
+MVP 初期実装では、永続化先を固定せず、`InMemoryEventRepository` を使用する。これにより、後続で Firestore 等の保存先へ差し替える場合も、画面側の呼び出しを大きく変えずに済むようにする。
+
+web 側は generated schedule 本体を保持しない。core から返された `generated_schedule_id` を参照として保持し、必要に応じて core get API で再取得する。
+
+現時点で event 側に保持する generated schedule 参照は以下。
+
+* `currentGeneratedScheduleId`
+* `adoptedGeneratedScheduleId`
+
+共有URL用の ID は、event の `publicId` として発行する。
+
+URL 上の query parameter は、当面 `sid` を使用する。
+
+例:
+
+```txt
+/?sid=<publicId>
+```
+
+将来的には、共有URLとしてより自然な形式である `/s/<id>` への移行も検討する。
+
+#14 時点では、共有URLの生成とコピーまでを実装対象に含める。一方で、共有URLからの復元処理は #18 で扱う。

--- a/lib/features/doubles_scheduler/application/event_repository.dart
+++ b/lib/features/doubles_scheduler/application/event_repository.dart
@@ -1,0 +1,20 @@
+import '../domain/saved_event_models.dart';
+import '../presentation/models/event_draft.dart';
+
+abstract class EventRepository {
+  Future<SavedEventAggregate> createFromDraft(EventDraft draft);
+
+  Future<SavedEventAggregate?> findByPublicId(String publicId);
+
+  Future<List<SavedEventParticipant>> listParticipants(String eventId);
+
+  Future<SavedEvent> updateCurrentGeneratedScheduleId({
+    required String eventId,
+    required String generatedScheduleId,
+  });
+
+  Future<SavedEvent> updateAdoptedGeneratedScheduleId({
+    required String eventId,
+    required String generatedScheduleId,
+  });
+}

--- a/lib/features/doubles_scheduler/application/generators/simple_scheduler.dart
+++ b/lib/features/doubles_scheduler/application/generators/simple_scheduler.dart
@@ -92,8 +92,9 @@ class SimpleScheduler {
         restPerRound: players.length - playersPerRound,
       );
 
-      final playingPlayers =
-          players.where((p) => !restPlayers.any((r) => r.eventNumber == p.eventNumber)).toList();
+      final playingPlayers = players
+          .where((p) => !restPlayers.any((r) => r.eventNumber == p.eventNumber))
+          .toList();
 
       final courtGroups = _buildCourtGroups(
         playingPlayers: playingPlayers,
@@ -125,7 +126,8 @@ class SimpleScheduler {
       return const [];
     }
 
-    final sorted = [...players]..sort((a, b) => a.eventNumber.compareTo(b.eventNumber));
+    final sorted = [...players]
+      ..sort((a, b) => a.eventNumber.compareTo(b.eventNumber));
 
     return sorted.reversed.take(restPerRound).toList();
   }
@@ -160,7 +162,8 @@ class SimpleScheduler {
       throw ArgumentError('playersOnCourt must be exactly 4.');
     }
 
-    final sorted = [...playersOnCourt]..sort((a, b) => a.eventNumber.compareTo(b.eventNumber));
+    final sorted = [...playersOnCourt]
+      ..sort((a, b) => a.eventNumber.compareTo(b.eventNumber));
 
     return ScheduledCourt(
       teamA: [sorted[0], sorted[1]],

--- a/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
+++ b/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
@@ -26,7 +26,8 @@ class InMemoryEventRepository implements EventRepository {
       publicId: publicId,
       title: draft.eventName,
       courtCount: draft.courts,
-      sourceType: draft.url.isEmpty ? EventSourceType.manual : EventSourceType.unknown,
+      sourceType:
+          draft.url.isEmpty ? EventSourceType.manual : EventSourceType.unknown,
       sourceUrl: draft.url.isEmpty ? null : draft.url,
       status: SavedEventStatus.draft,
       createdAt: now,

--- a/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
+++ b/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
@@ -1,0 +1,146 @@
+import 'package:uuid/uuid.dart';
+
+import '../application/event_repository.dart';
+import '../domain/saved_event_models.dart';
+import '../presentation/models/event_draft.dart';
+
+class InMemoryEventRepository implements EventRepository {
+  InMemoryEventRepository();
+
+  final _uuid = const Uuid();
+
+  final Map<String, SavedEvent> _eventsById = {};
+  final Map<String, String> _eventIdByPublicId = {};
+  final Map<String, List<SavedEventParticipant>> _participantsByEventId = {};
+  final Map<String, SavedEventShare> _sharesByPublicId = {};
+  final Map<String, SavedEventImport> _importsByEventId = {};
+
+  @override
+  Future<SavedEventAggregate> createFromDraft(EventDraft draft) async {
+    final now = DateTime.now();
+    final eventId = _uuid.v4();
+    final publicId = _uuid.v4();
+
+    final event = SavedEvent(
+      id: eventId,
+      publicId: publicId,
+      title: draft.eventName,
+      courtCount: draft.courts,
+      sourceType: draft.url.isEmpty ? EventSourceType.manual : EventSourceType.unknown,
+      sourceUrl: draft.url.isEmpty ? null : draft.url,
+      status: SavedEventStatus.draft,
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    final participants = draft.participants.asMap().entries.map((entry) {
+      final index = entry.key;
+      final participant = entry.value;
+
+      return SavedEventParticipant(
+        id: participant.id,
+        eventId: eventId,
+        displayName: participant.displayName,
+        orderNo: index + 1,
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      );
+    }).toList(growable: false);
+
+    final share = SavedEventShare(
+      publicId: publicId,
+      eventId: eventId,
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    final importRecord = draft.url.isEmpty
+        ? null
+        : SavedEventImport(
+            id: _uuid.v4(),
+            eventId: eventId,
+            sourceType: EventSourceType.unknown,
+            sourceUrl: draft.url,
+            createdAt: now,
+          );
+
+    _eventsById[eventId] = event;
+    _eventIdByPublicId[publicId] = eventId;
+    _participantsByEventId[eventId] = participants;
+    _sharesByPublicId[publicId] = share;
+    if (importRecord != null) {
+      _importsByEventId[eventId] = importRecord;
+    }
+
+    return SavedEventAggregate(
+      event: event,
+      participants: participants,
+      share: share,
+      importRecord: importRecord,
+    );
+  }
+
+  @override
+  Future<SavedEventAggregate?> findByPublicId(String publicId) async {
+    final eventId = _eventIdByPublicId[publicId];
+    if (eventId == null) return null;
+
+    final event = _eventsById[eventId];
+    final share = _sharesByPublicId[publicId];
+    if (event == null || share == null) return null;
+
+    return SavedEventAggregate(
+      event: event,
+      participants: _participantsByEventId[eventId] ?? const [],
+      share: share,
+      importRecord: _importsByEventId[eventId],
+    );
+  }
+
+  @override
+  Future<List<SavedEventParticipant>> listParticipants(String eventId) async {
+    return List.unmodifiable(_participantsByEventId[eventId] ?? const []);
+  }
+
+  @override
+  Future<SavedEvent> updateCurrentGeneratedScheduleId({
+    required String eventId,
+    required String generatedScheduleId,
+  }) async {
+    final event = _eventsById[eventId];
+    if (event == null) {
+      throw StateError('event not found: $eventId');
+    }
+
+    final updated = event.copyWith(
+      status: SavedEventStatus.generated,
+      currentGeneratedScheduleId: generatedScheduleId,
+      updatedAt: DateTime.now(),
+    );
+
+    _eventsById[eventId] = updated;
+    return updated;
+  }
+
+  @override
+  Future<SavedEvent> updateAdoptedGeneratedScheduleId({
+    required String eventId,
+    required String generatedScheduleId,
+  }) async {
+    final event = _eventsById[eventId];
+    if (event == null) {
+      throw StateError('event not found: $eventId');
+    }
+
+    final updated = event.copyWith(
+      status: SavedEventStatus.adopted,
+      currentGeneratedScheduleId: generatedScheduleId,
+      adoptedGeneratedScheduleId: generatedScheduleId,
+      updatedAt: DateTime.now(),
+    );
+
+    _eventsById[eventId] = updated;
+    return updated;
+  }
+}

--- a/lib/features/doubles_scheduler/domain/saved_event_models.dart
+++ b/lib/features/doubles_scheduler/domain/saved_event_models.dart
@@ -72,8 +72,10 @@ class SavedEvent {
       sourceType: sourceType ?? this.sourceType,
       sourceUrl: sourceUrl ?? this.sourceUrl,
       status: status ?? this.status,
-      currentGeneratedScheduleId: currentGeneratedScheduleId ?? this.currentGeneratedScheduleId,
-      adoptedGeneratedScheduleId: adoptedGeneratedScheduleId ?? this.adoptedGeneratedScheduleId,
+      currentGeneratedScheduleId:
+          currentGeneratedScheduleId ?? this.currentGeneratedScheduleId,
+      adoptedGeneratedScheduleId:
+          adoptedGeneratedScheduleId ?? this.adoptedGeneratedScheduleId,
       createdAt: createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );

--- a/lib/features/doubles_scheduler/domain/saved_event_models.dart
+++ b/lib/features/doubles_scheduler/domain/saved_event_models.dart
@@ -1,0 +1,155 @@
+enum EventSourceType {
+  tennisbear,
+  tennisoff,
+  manual,
+  unknown,
+}
+
+enum SavedEventStatus {
+  draft,
+  generated,
+  adopted,
+}
+
+class SavedEvent {
+  SavedEvent({
+    required this.id,
+    required this.publicId,
+    required this.title,
+    required this.courtCount,
+    required this.sourceType,
+    required this.sourceUrl,
+    required this.status,
+    required this.createdAt,
+    required this.updatedAt,
+    this.eventDate,
+    this.startTime,
+    this.endTime,
+    this.location,
+    this.currentGeneratedScheduleId,
+    this.adoptedGeneratedScheduleId,
+  });
+
+  final String id;
+  final String publicId;
+  final String title;
+  final DateTime? eventDate;
+  final String? startTime;
+  final String? endTime;
+  final String? location;
+  final int courtCount;
+  final EventSourceType sourceType;
+  final String? sourceUrl;
+  final SavedEventStatus status;
+  final String? currentGeneratedScheduleId;
+  final String? adoptedGeneratedScheduleId;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  SavedEvent copyWith({
+    String? title,
+    DateTime? eventDate,
+    String? startTime,
+    String? endTime,
+    String? location,
+    int? courtCount,
+    EventSourceType? sourceType,
+    String? sourceUrl,
+    SavedEventStatus? status,
+    String? currentGeneratedScheduleId,
+    String? adoptedGeneratedScheduleId,
+    DateTime? updatedAt,
+  }) {
+    return SavedEvent(
+      id: id,
+      publicId: publicId,
+      title: title ?? this.title,
+      eventDate: eventDate ?? this.eventDate,
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      location: location ?? this.location,
+      courtCount: courtCount ?? this.courtCount,
+      sourceType: sourceType ?? this.sourceType,
+      sourceUrl: sourceUrl ?? this.sourceUrl,
+      status: status ?? this.status,
+      currentGeneratedScheduleId: currentGeneratedScheduleId ?? this.currentGeneratedScheduleId,
+      adoptedGeneratedScheduleId: adoptedGeneratedScheduleId ?? this.adoptedGeneratedScheduleId,
+      createdAt: createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+}
+
+class SavedEventParticipant {
+  SavedEventParticipant({
+    required this.id,
+    required this.eventId,
+    required this.displayName,
+    required this.orderNo,
+    required this.status,
+    required this.createdAt,
+    required this.updatedAt,
+    this.sourceText,
+  });
+
+  final String id;
+  final String eventId;
+  final String displayName;
+  final int orderNo;
+  final String status;
+  final String? sourceText;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+}
+
+class SavedEventImport {
+  SavedEventImport({
+    required this.id,
+    required this.eventId,
+    required this.sourceType,
+    required this.createdAt,
+    this.sourceUrl,
+    this.pastedText,
+    this.parsedEventJson,
+    this.parsedParticipantsJson,
+    this.confirmedAt,
+  });
+
+  final String id;
+  final String eventId;
+  final EventSourceType sourceType;
+  final String? sourceUrl;
+  final String? pastedText;
+  final Map<String, dynamic>? parsedEventJson;
+  final List<Map<String, dynamic>>? parsedParticipantsJson;
+  final DateTime? confirmedAt;
+  final DateTime createdAt;
+}
+
+class SavedEventShare {
+  SavedEventShare({
+    required this.publicId,
+    required this.eventId,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String publicId;
+  final String eventId;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+}
+
+class SavedEventAggregate {
+  SavedEventAggregate({
+    required this.event,
+    required this.participants,
+    required this.share,
+    this.importRecord,
+  });
+
+  final SavedEvent event;
+  final List<SavedEventParticipant> participants;
+  final SavedEventShare share;
+  final SavedEventImport? importRecord;
+}

--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -153,8 +153,10 @@ class _EventSetupPageState extends State<EventSetupPage> {
     });
   }
 
-  void _decrementCourts() => _setCourts(_courts - 1, resetPlayersToDefault: true);
-  void _incrementCourts() => _setCourts(_courts + 1, resetPlayersToDefault: true);
+  void _decrementCourts() =>
+      _setCourts(_courts - 1, resetPlayersToDefault: true);
+  void _incrementCourts() =>
+      _setCourts(_courts + 1, resetPlayersToDefault: true);
 
   void _decrementPlayers() {
     final current = int.tryParse(_playersController.text) ?? _minPlayers;
@@ -254,13 +256,15 @@ class _EventSetupPageState extends State<EventSetupPage> {
         _syncCourtsController();
 
         final mockPlayers = mockData['players'] as int;
-        _playersController.text = mockPlayers.clamp(_minPlayers, _maxPlayers).toString();
+        _playersController.text =
+            mockPlayers.clamp(_minPlayers, _maxPlayers).toString();
 
         _syncDisplayNameControllers();
 
         _eventNameController.text = mockData['eventName'] as String;
 
-        final mockNames = (mockData['playerNames'] as List<dynamic>).cast<String>();
+        final mockNames =
+            (mockData['playerNames'] as List<dynamic>).cast<String>();
         for (var i = 0; i < _displayNameControllers.length; i++) {
           final fallback = circledNumber(i + 1);
           final name = i < mockNames.length ? mockNames[i] : fallback;
@@ -447,7 +451,8 @@ class _EventSetupPageState extends State<EventSetupPage> {
               onPressed: _isLoadingEvent ? null : _resetInputs,
               style: FilledButton.styleFrom(
                 minimumSize: Size.zero,
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
                 tapTargetSize: MaterialTapTargetSize.shrinkWrap,
               ),
               child: const Text(
@@ -460,7 +465,8 @@ class _EventSetupPageState extends State<EventSetupPage> {
               onPressed: _isLoadingEvent ? null : _submitForm,
               style: FilledButton.styleFrom(
                 minimumSize: Size.zero,
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
                 tapTargetSize: MaterialTapTargetSize.shrinkWrap,
               ),
               child: const Text(

--- a/lib/features/doubles_scheduler/presentation/models/event_draft.dart
+++ b/lib/features/doubles_scheduler/presentation/models/event_draft.dart
@@ -17,7 +17,8 @@ class EventDraft {
 
   int get players => participants.length;
 
-  List<String> get displayNames => participants.map((e) => e.displayName).toList(growable: false);
+  List<String> get displayNames =>
+      participants.map((e) => e.displayName).toList(growable: false);
 
   EventDraft copyWith({
     String? url,
@@ -29,7 +30,8 @@ class EventDraft {
       url: url ?? this.url,
       courts: courts ?? this.courts,
       eventName: eventName ?? this.eventName,
-      participants: participants ?? this.participants.map((e) => e.copyWith()).toList(),
+      participants:
+          participants ?? this.participants.map((e) => e.copyWith()).toList(),
     );
   }
 

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -60,7 +60,7 @@ class _SchedulePageState extends State<SchedulePage> {
     return Uri.base.replace(
       queryParameters: {
         ...Uri.base.queryParameters,
-        'public_id': publicId,
+        'sid': publicId,
       },
     ).toString();
   }

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -323,6 +323,7 @@ class _SchedulePageState extends State<SchedulePage> {
           Text('イベント名: ${widget.draft.eventName}'),
           Text('面数: ${widget.draft.courts}'),
           Text('人数: ${widget.draft.players}'),
+          if (_savedEvent != null) Text('共有ID: ${_savedEvent!.event.publicId}'),
         ],
       ),
     );

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -44,7 +44,8 @@ class _SchedulePageState extends State<SchedulePage> {
 
   Map<String, String> get _playerNameById {
     return {
-      for (final participant in widget.draft.participants) participant.id: participant.displayName,
+      for (final participant in widget.draft.participants)
+        participant.id: participant.displayName,
     };
   }
 
@@ -106,7 +107,8 @@ class _SchedulePageState extends State<SchedulePage> {
 
       setState(() {
         _scheduleResponse = response;
-        _generatedScheduleId = response['generated_schedule_id']?.toString() ?? generatedScheduleId;
+        _generatedScheduleId = response['generated_schedule_id']?.toString() ??
+            generatedScheduleId;
       });
     } catch (e) {
       if (!mounted) return;
@@ -213,13 +215,17 @@ class _SchedulePageState extends State<SchedulePage> {
     return _playerLabelFromId(playerId);
   }
 
-  String _formatTeamFromSlots(List<int> slots, Map<int, String> slotToPlayerId) {
+  String _formatTeamFromSlots(
+      List<int> slots, Map<int, String> slotToPlayerId) {
     if (slots.isEmpty) return '-';
 
-    return slots.map((slot) => '$slot: ${_playerLabelFromSlot(slot, slotToPlayerId)}').join(' / ');
+    return slots
+        .map((slot) => '$slot: ${_playerLabelFromSlot(slot, slotToPlayerId)}')
+        .join(' / ');
   }
 
-  String _formatRestPlayersBySlots(List<int> slotNumbers, Map<int, String> slotToPlayerId) {
+  String _formatRestPlayersBySlots(
+      List<int> slotNumbers, Map<int, String> slotToPlayerId) {
     if (slotNumbers.isEmpty) return '-';
 
     return slotNumbers
@@ -296,12 +302,17 @@ class _SchedulePageState extends State<SchedulePage> {
           label: const Text('再生成'),
         ),
         FilledButton.tonalIcon(
-          onPressed: (_isLoading || _generatedScheduleId == null) ? null : _reloadSchedule,
+          onPressed: (_isLoading || _generatedScheduleId == null)
+              ? null
+              : _reloadSchedule,
           icon: const Icon(Icons.download),
           label: const Text('再取得'),
         ),
         FilledButton(
-          onPressed: (_isLoading || _isAdopting || _generatedScheduleId == null || _isAdopted)
+          onPressed: (_isLoading ||
+                  _isAdopting ||
+                  _generatedScheduleId == null ||
+                  _isAdopted)
               ? null
               : _adoptSchedule,
           child: _isAdopting
@@ -376,7 +387,8 @@ class _SchedulePageState extends State<SchedulePage> {
                   );
                 }),
                 const Divider(),
-                Text('休憩: ${_formatRestPlayersBySlots(restSlotNumbers, slotToPlayerId)}'),
+                Text(
+                    '休憩: ${_formatRestPlayersBySlots(restSlotNumbers, slotToPlayerId)}'),
               ],
             ),
           ),

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:srp_lanske/shared/config/app_config.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 
@@ -50,6 +51,29 @@ class _SchedulePageState extends State<SchedulePage> {
       share: aggregate.share,
       importRecord: aggregate.importRecord,
     );
+  }
+
+  String? _buildShareUrl() {
+    final publicId = _savedEvent?.event.publicId;
+    if (publicId == null || publicId.isEmpty) return null;
+
+    return Uri.base.replace(
+      queryParameters: {
+        ...Uri.base.queryParameters,
+        'public_id': publicId,
+      },
+    ).toString();
+  }
+
+  Future<void> _copyShareUrl() async {
+    final shareUrl = _buildShareUrl();
+    if (shareUrl == null) {
+      _showMessage('共有URLを作成できませんでした');
+      return;
+    }
+
+    await Clipboard.setData(ClipboardData(text: shareUrl));
+    _showMessage('共有URLをコピーしました');
   }
 
   @override
@@ -324,6 +348,12 @@ class _SchedulePageState extends State<SchedulePage> {
           Text('面数: ${widget.draft.courts}'),
           Text('人数: ${widget.draft.players}'),
           if (_savedEvent != null) Text('共有ID: ${_savedEvent!.event.publicId}'),
+          if (_savedEvent != null)
+            OutlinedButton.icon(
+              onPressed: _copyShareUrl,
+              icon: const Icon(Icons.copy),
+              label: const Text('共有URLをコピー'),
+            ),
         ],
       ),
     );

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:srp_lanske/shared/config/app_config.dart';
+import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 
 import '../application/generated_schedule_service.dart';
+import '../domain/saved_event_models.dart';
 import '../infrastructure/generated_schedule_api_client.dart';
 import 'models/event_draft.dart';
 import 'event_list_page.dart';
@@ -26,6 +28,29 @@ class _SchedulePageState extends State<SchedulePage> {
   String? _errorMessage;
   String? _generatedScheduleId;
   Map<String, dynamic>? _scheduleResponse;
+
+  SavedEventAggregate? _savedEvent;
+
+  Future<SavedEventAggregate> _ensureSavedEvent() async {
+    final existing = _savedEvent;
+    if (existing != null) return existing;
+
+    final savedEvent = await appEventRepository.createFromDraft(widget.draft);
+    _savedEvent = savedEvent;
+    return savedEvent;
+  }
+
+  SavedEventAggregate _replaceSavedEvent(
+    SavedEventAggregate aggregate,
+    SavedEvent event,
+  ) {
+    return SavedEventAggregate(
+      event: event,
+      participants: aggregate.participants,
+      share: aggregate.share,
+      importRecord: aggregate.importRecord,
+    );
+  }
 
   @override
   void initState() {
@@ -67,12 +92,29 @@ class _SchedulePageState extends State<SchedulePage> {
     });
 
     try {
+      final savedEvent = await _ensureSavedEvent();
       final response = await _service.generateFromDraft(widget.draft);
       if (!mounted) return;
 
+      final generatedScheduleId = response['generated_schedule_id']?.toString();
+
+      var nextSavedEvent = savedEvent;
+      if (generatedScheduleId != null && generatedScheduleId.isNotEmpty) {
+        final updatedEvent =
+            await appEventRepository.updateCurrentGeneratedScheduleId(
+          eventId: savedEvent.event.id,
+          generatedScheduleId: generatedScheduleId,
+        );
+
+        nextSavedEvent = _replaceSavedEvent(savedEvent, updatedEvent);
+      }
+
+      if (!mounted) return;
+
       setState(() {
+        _savedEvent = nextSavedEvent;
         _scheduleResponse = response;
-        _generatedScheduleId = response['generated_schedule_id']?.toString();
+        _generatedScheduleId = generatedScheduleId;
       });
     } catch (e) {
       if (!mounted) return;
@@ -140,8 +182,21 @@ class _SchedulePageState extends State<SchedulePage> {
     });
 
     try {
+      final savedEvent = await _ensureSavedEvent();
+
       await _service.adopt(generatedScheduleId);
+
+      final updatedEvent =
+          await appEventRepository.updateAdoptedGeneratedScheduleId(
+        eventId: savedEvent.event.id,
+        generatedScheduleId: generatedScheduleId,
+      );
+
       if (!mounted) return;
+
+      setState(() {
+        _savedEvent = _replaceSavedEvent(savedEvent, updatedEvent);
+      });
 
       _showMessage('採用しました');
       await _reloadSchedule();

--- a/lib/shared/repositories/app_repositories.dart
+++ b/lib/shared/repositories/app_repositories.dart
@@ -1,0 +1,5 @@
+// lib/shared/repositories/app_repositories.dart
+
+import 'package:srp_lanske/features/doubles_scheduler/data/in_memory_event_repository.dart';
+
+final appEventRepository = InMemoryEventRepository();

--- a/test/features/doubles_scheduler/data/in_memory_event_repository_test.dart
+++ b/test/features/doubles_scheduler/data/in_memory_event_repository_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:srp_lanske/features/doubles_scheduler/data/in_memory_event_repository.dart';
+import 'package:srp_lanske/features/doubles_scheduler/domain/participant_draft.dart';
+import 'package:srp_lanske/features/doubles_scheduler/domain/saved_event_models.dart';
+import 'package:srp_lanske/features/doubles_scheduler/presentation/models/event_draft.dart';
+
+void main() {
+  group('InMemoryEventRepository', () {
+    EventDraft buildDraft() {
+      return EventDraft(
+        url: 'https://example.com/events/1',
+        courts: 1,
+        eventName: 'テストイベント',
+        participants: [
+          ParticipantDraft.create(displayName: '参加者1'),
+          ParticipantDraft.create(displayName: '参加者2'),
+          ParticipantDraft.create(displayName: '参加者3'),
+          ParticipantDraft.create(displayName: '参加者4'),
+          ParticipantDraft.create(displayName: '参加者5'),
+          ParticipantDraft.create(displayName: '参加者6'),
+        ],
+      );
+    }
+
+    test('creates event aggregate from draft', () async {
+      final repository = InMemoryEventRepository();
+
+      final aggregate = await repository.createFromDraft(buildDraft());
+
+      expect(aggregate.event.id, isNotEmpty);
+      expect(aggregate.event.publicId, isNotEmpty);
+      expect(aggregate.event.title, 'テストイベント');
+      expect(aggregate.event.courtCount, 1);
+      expect(aggregate.event.sourceUrl, 'https://example.com/events/1');
+      expect(aggregate.event.status, SavedEventStatus.draft);
+
+      expect(aggregate.participants, hasLength(6));
+      expect(aggregate.participants[0].displayName, '参加者1');
+      expect(aggregate.participants[0].orderNo, 1);
+      expect(aggregate.participants[5].displayName, '参加者6');
+      expect(aggregate.participants[5].orderNo, 6);
+
+      expect(aggregate.share.publicId, aggregate.event.publicId);
+      expect(aggregate.share.eventId, aggregate.event.id);
+      expect(aggregate.importRecord, isNotNull);
+    });
+
+    test('finds event aggregate by public id', () async {
+      final repository = InMemoryEventRepository();
+
+      final created = await repository.createFromDraft(buildDraft());
+      final found = await repository.findByPublicId(created.event.publicId);
+
+      expect(found, isNotNull);
+      expect(found!.event.id, created.event.id);
+      expect(found.event.publicId, created.event.publicId);
+      expect(found.event.title, created.event.title);
+      expect(found.participants, hasLength(6));
+      expect(found.share.publicId, created.share.publicId);
+    });
+
+    test('returns null when public id does not exist', () async {
+      final repository = InMemoryEventRepository();
+
+      final found = await repository.findByPublicId('missing-public-id');
+
+      expect(found, isNull);
+    });
+
+    test('updates current generated schedule id', () async {
+      final repository = InMemoryEventRepository();
+
+      final created = await repository.createFromDraft(buildDraft());
+
+      final updated = await repository.updateCurrentGeneratedScheduleId(
+        eventId: created.event.id,
+        generatedScheduleId: 'generated-1',
+      );
+
+      expect(updated.currentGeneratedScheduleId, 'generated-1');
+      expect(updated.adoptedGeneratedScheduleId, isNull);
+      expect(updated.status, SavedEventStatus.generated);
+
+      final found = await repository.findByPublicId(created.event.publicId);
+      expect(found!.event.currentGeneratedScheduleId, 'generated-1');
+    });
+
+    test('updates adopted generated schedule id', () async {
+      final repository = InMemoryEventRepository();
+
+      final created = await repository.createFromDraft(buildDraft());
+
+      final updated = await repository.updateAdoptedGeneratedScheduleId(
+        eventId: created.event.id,
+        generatedScheduleId: 'generated-1',
+      );
+
+      expect(updated.currentGeneratedScheduleId, 'generated-1');
+      expect(updated.adoptedGeneratedScheduleId, 'generated-1');
+      expect(updated.status, SavedEventStatus.adopted);
+
+      final found = await repository.findByPublicId(created.event.publicId);
+      expect(found!.event.adoptedGeneratedScheduleId, 'generated-1');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #14

共有URL MVP の土台として、web 側の event / participant / import / share 保存モデルと repository 境界を追加しました。

今回の実装では、入力中の一時モデルである `EventDraft` と、保存済み event を表す `SavedEventAggregate` を分けて扱うようにしています。

## Changes

- `SavedEvent` / `SavedEventParticipant` / `SavedEventImport` / `SavedEventShare` / `SavedEventAggregate` を追加
- `EventRepository` interface を追加
- MVP 初期実装として `InMemoryEventRepository` を追加
- `SchedulePage` から event repository を利用するように変更
- generate 成功時に `currentGeneratedScheduleId` を event に保存
- adopt 成功時に `adoptedGeneratedScheduleId` を event に保存
- 共有URLコピー導線を追加
  - query parameter は当面 `sid` を使用
  - 将来的には `/s/<id>` 形式も検討
- `InMemoryEventRepository` の単体テストを追加
- #14 実装時点の保存モデル方針を docs に追記

## Notes

- web 側は generated schedule 本体を保持せず、core が返す `generated_schedule_id` の参照のみ保持します。
- `InMemoryEventRepository` は保存モデルと repository 境界を作るための MVP 初期実装です。
- ブラウザ再起動・別端末・別タブをまたぐ永続保存は、後続の保存先整理または共有URL復元実装で扱います。
- 共有URLからの復元処理自体は #18 で扱います。

## Verification

- [x] `dart format .`
- [x] `flutter analyze`
- [x] `flutter test`
- [x] 画面起動確認
- [x] generate 後に共有IDが表示されることを確認
- [x] 共有URLコピーで `?sid=<publicId>` 形式のURLを取得できることを確認

## Docs / API

- docs 更新あり
  - `docs/web-mvp-persistence-import-restore-plan.md`
- OpenAPI 更新なし
  - web 側保存モデルと画面導線の変更のみのため