### PR TITLE
🌐 feat: Configure core API base URL by environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,28 @@ lib/
 └─ shared/             # 共通部品
 ```
 
+### core API URL の指定
+
+web から接続する core API の base URL は、Flutter の `dart-define` で指定する。
+
+未指定の場合は local 開発用として `http://localhost:8080` を使用する。
+
+local core API に接続する場合:
+
+```bash
+flutter run -d web-server --web-hostname 0.0.0.0 --web-port 3000 \
+  --dart-define=LANSKE_CORE_API_BASE_URL=http://localhost:8080
+```
+
+公開用 core API に接続する場合:
+
+```bash
+flutter run -d web-server --web-hostname 0.0.0.0 --web-port 3000 \
+  --dart-define=LANSKE_CORE_API_BASE_URL=https://<core-api-url>
+```
+
+<core-api-url> には Cloud Run などの公開 core API URL を指定する。
+
 ---
 
 ## 📦 実装状況

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -227,6 +227,23 @@ features/
 * Codespacesでの開発を想定
 * 将来的にバックエンド化（Cloud Functions等）
 
+### 10.1 core API URL の環境切り替え
+
+web から接続する core API の base URL は、`AppConfig.coreApiBaseUrl` から参照する。
+
+`AppConfig.coreApiBaseUrl` は Flutter の `String.fromEnvironment` を使い、`LANSKE_CORE_API_BASE_URL` で指定する。
+
+未指定の場合は local 開発用として `http://localhost:8080` を使用する。
+
+この設定値は以下の core API 呼び出しで共通利用する。
+
+- generate
+- get
+- adopt
+
+ver0.1 では、環境別設定ファイルや secret 管理の本格化は行わず、`dart-define` による明示的な切り替えを優先する。
+
+
 ---
 
 ## 11. 設計思想

--- a/lib/app/config/app_config.dart
+++ b/lib/app/config/app_config.dart
@@ -1,3 +1,8 @@
 class AppConfig {
   static const String appName = 'Lanske';
+
+  static const String coreApiBaseUrl = String.fromEnvironment(
+    'LANSKE_CORE_API_BASE_URL',
+    defaultValue: 'http://localhost:8080',
+  );
 }

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:srp_lanske/shared/config/app_config.dart';
+import 'package:srp_lanske/app/config/app_config.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 
 import '../application/generated_schedule_service.dart';

--- a/lib/shared/config/app_config.dart
+++ b/lib/shared/config/app_config.dart
@@ -1,6 +1,0 @@
-class AppConfig {
-  static const coreApiBaseUrl = String.fromEnvironment(
-    'LANSKE_CORE_API_BASE_URL',
-    defaultValue: 'http://localhost:8080',
-  );
-}


### PR DESCRIPTION
## Summary

- `AppConfig` を `lib/app/config/app_config.dart` に統合
- core API の base URL を `LANSKE_CORE_API_BASE_URL` の `dart-define` から参照するよう整理
- `SchedulePage` から新しい `AppConfig` を参照するよう更新
- README に local / 公開 core API 向けの起動例を追加
- architecture に core API URL の環境切り替え方針を追記

## Checks

- [x] flutter analyze
- [x] flutter test
- [x] local core API URL で起動確認
- [x] 公開用 core API URL を `--dart-define` で指定して起動確認

## Notes

- 未指定時は local 開発用として `http://localhost:8080` を使用する
- ver0.1 では環境別設定ファイルや secret 管理の本格化は行わず、`dart-define` による明示的な切り替えを優先する

Closes #15
