### PR TITLE
🐻 feat: Connect Tennisbear import preview API

### DIFF
--- a/lib/features/doubles_scheduler/infrastructure/tennisbear_import_preview_api_client.dart
+++ b/lib/features/doubles_scheduler/infrastructure/tennisbear_import_preview_api_client.dart
@@ -1,0 +1,239 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+class TennisbearImportPreviewApiException implements Exception {
+  TennisbearImportPreviewApiException({
+    required this.statusCode,
+    required this.message,
+    this.body,
+  });
+
+  final int statusCode;
+  final String message;
+  final Map<String, dynamic>? body;
+
+  @override
+  String toString() => message;
+}
+
+class TennisbearImportPreviewApiClient {
+  TennisbearImportPreviewApiClient({
+    required this.baseUrl,
+    http.Client? httpClient,
+  }) : _httpClient = httpClient ?? http.Client();
+
+  final String baseUrl;
+  final http.Client _httpClient;
+
+  Future<TennisbearImportPreviewResponse> preview({
+    required String sourceUrl,
+  }) async {
+    final uri = _buildUri('/api/v1/imports/tennisbear-event:preview');
+
+    final response = await _httpClient.post(
+      uri,
+      headers: const {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: jsonEncode({
+        'source_url': sourceUrl,
+      }),
+    );
+
+    final decoded = _decodeJsonObject(response);
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw TennisbearImportPreviewApiException(
+        statusCode: response.statusCode,
+        message: decoded['message']?.toString() ?? 'イベント情報の取得に失敗しました',
+        body: decoded,
+      );
+    }
+
+    return TennisbearImportPreviewResponse.fromJson(decoded);
+  }
+
+  Uri _buildUri(String path) {
+    final normalizedBaseUrl = baseUrl.endsWith('/') ? baseUrl : '$baseUrl/';
+    return Uri.parse(normalizedBaseUrl).resolve(
+      path.startsWith('/') ? path.substring(1) : path,
+    );
+  }
+
+  Map<String, dynamic> _decodeJsonObject(http.Response response) {
+    if (response.bodyBytes.isEmpty) {
+      return <String, dynamic>{};
+    }
+
+    final text = utf8.decode(response.bodyBytes).trim();
+    if (text.isEmpty) {
+      return <String, dynamic>{};
+    }
+
+    final dynamic decoded = jsonDecode(text);
+    if (decoded is Map<String, dynamic>) {
+      return decoded;
+    }
+
+    throw TennisbearImportPreviewApiException(
+      statusCode: response.statusCode,
+      message: 'response is not a JSON object',
+    );
+  }
+}
+
+class TennisbearImportPreviewResponse {
+  TennisbearImportPreviewResponse({
+    required this.sourceType,
+    required this.sourceUrl,
+    required this.sourceEventId,
+    required this.participantCandidates,
+    this.eventCandidate,
+    this.participantSummary,
+    this.warnings = const [],
+  });
+
+  factory TennisbearImportPreviewResponse.fromJson(Map<String, dynamic> json) {
+    return TennisbearImportPreviewResponse(
+      sourceType: json['source_type']?.toString() ?? '',
+      sourceUrl: json['source_url']?.toString() ?? '',
+      sourceEventId: json['source_event_id']?.toString() ?? '',
+      eventCandidate: json['event_candidate'] is Map<String, dynamic>
+          ? TennisbearEventCandidate.fromJson(
+              json['event_candidate'] as Map<String, dynamic>,
+            )
+          : null,
+      participantSummary: json['participant_summary'] is Map<String, dynamic>
+          ? TennisbearParticipantSummary.fromJson(
+              json['participant_summary'] as Map<String, dynamic>,
+            )
+          : null,
+      participantCandidates: _asObjectList(json['participant_candidates'])
+          .map(TennisbearParticipantCandidate.fromJson)
+          .toList(growable: false),
+      warnings: _asObjectList(json['warnings'])
+          .map(TennisbearImportPreviewWarning.fromJson)
+          .toList(growable: false),
+    );
+  }
+
+  final String sourceType;
+  final String sourceUrl;
+  final String sourceEventId;
+  final TennisbearEventCandidate? eventCandidate;
+  final TennisbearParticipantSummary? participantSummary;
+  final List<TennisbearParticipantCandidate> participantCandidates;
+  final List<TennisbearImportPreviewWarning> warnings;
+}
+
+class TennisbearEventCandidate {
+  TennisbearEventCandidate({
+    required this.title,
+    required this.eventDate,
+    required this.startTime,
+    required this.endTime,
+    required this.location,
+    required this.courtCount,
+    required this.notes,
+  });
+
+  factory TennisbearEventCandidate.fromJson(Map<String, dynamic> json) {
+    return TennisbearEventCandidate(
+      title: json['title']?.toString() ?? '',
+      eventDate: json['event_date']?.toString() ?? '',
+      startTime: json['start_time']?.toString() ?? '',
+      endTime: json['end_time']?.toString() ?? '',
+      location: json['location']?.toString() ?? '',
+      courtCount: int.tryParse(json['court_count']?.toString() ?? '') ?? 0,
+      notes: json['notes']?.toString() ?? '',
+    );
+  }
+
+  final String title;
+  final String eventDate;
+  final String startTime;
+  final String endTime;
+  final String location;
+  final int courtCount;
+  final String notes;
+}
+
+class TennisbearParticipantSummary {
+  TennisbearParticipantSummary({
+    required this.currentCount,
+    required this.capacity,
+    required this.isPrivate,
+  });
+
+  factory TennisbearParticipantSummary.fromJson(Map<String, dynamic> json) {
+    return TennisbearParticipantSummary(
+      currentCount: int.tryParse(json['current_count']?.toString() ?? '') ?? 0,
+      capacity: int.tryParse(json['capacity']?.toString() ?? '') ?? 0,
+      isPrivate: json['is_private'] == true,
+    );
+  }
+
+  final int currentCount;
+  final int capacity;
+  final bool isPrivate;
+}
+
+class TennisbearParticipantCandidate {
+  TennisbearParticipantCandidate({
+    required this.displayName,
+    required this.orderNo,
+    required this.status,
+    required this.userId,
+    required this.profileUrl,
+    required this.sourceText,
+  });
+
+  factory TennisbearParticipantCandidate.fromJson(Map<String, dynamic> json) {
+    return TennisbearParticipantCandidate(
+      displayName: json['display_name']?.toString() ?? '',
+      orderNo: int.tryParse(json['order_no']?.toString() ?? '') ?? 0,
+      status: json['status']?.toString() ?? '',
+      userId: json['user_id']?.toString() ?? '',
+      profileUrl: json['profile_url']?.toString() ?? '',
+      sourceText: json['source_text']?.toString() ?? '',
+    );
+  }
+
+  final String displayName;
+  final int orderNo;
+  final String status;
+  final String userId;
+  final String profileUrl;
+  final String sourceText;
+}
+
+class TennisbearImportPreviewWarning {
+  TennisbearImportPreviewWarning({
+    required this.code,
+    required this.message,
+    required this.target,
+  });
+
+  factory TennisbearImportPreviewWarning.fromJson(Map<String, dynamic> json) {
+    return TennisbearImportPreviewWarning(
+      code: json['code']?.toString() ?? '',
+      message: json['message']?.toString() ?? '',
+      target: json['target']?.toString() ?? '',
+    );
+  }
+
+  final String code;
+  final String message;
+  final String target;
+}
+
+List<Map<String, dynamic>> _asObjectList(Object? value) {
+  if (value is! List) return const [];
+
+  return value
+      .whereType<Map>()
+      .map((e) => e.map((key, value) => MapEntry(key.toString(), value)))
+      .toList(growable: false);
+}

--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:srp_lanske/app/config/app_config.dart';
 import 'package:srp_lanske/shared/utils/number_label_mapper.dart';
 
 import '../domain/participant_draft.dart';
+import '../infrastructure/tennisbear_import_preview_api_client.dart';
 import 'models/event_draft.dart';
 import 'schedule_page.dart';
 
@@ -26,6 +28,8 @@ class _EventSetupPageState extends State<EventSetupPage> {
   final List<String> _defaultDisplayNames = [];
   final List<String?> _sourceDisplayNames = [];
 
+  late final TennisbearImportPreviewApiClient _tennisbearImportPreviewClient;
+
   bool _isLoadingEvent = false;
   bool _loadedFromUrl = false;
 
@@ -37,6 +41,11 @@ class _EventSetupPageState extends State<EventSetupPage> {
   @override
   void initState() {
     super.initState();
+
+    _tennisbearImportPreviewClient = TennisbearImportPreviewApiClient(
+      baseUrl: AppConfig.coreApiBaseUrl,
+    );
+
     _syncPlayersWithinRange(resetToDefault: true);
     _syncDisplayNameControllers();
   }
@@ -221,6 +230,12 @@ class _EventSetupPageState extends State<EventSetupPage> {
 
     FocusScope.of(context).unfocus();
 
+    final sourceUrl = _urlController.text.trim();
+    if (sourceUrl.isEmpty) {
+      _showMessage('URLを入力してください');
+      return;
+    }
+
     setState(() {
       _isLoadingEvent = true;
     });
@@ -228,18 +243,9 @@ class _EventSetupPageState extends State<EventSetupPage> {
     final startedAt = DateTime.now();
 
     try {
-      // TODO: URLからイベント情報を取得するAPI/パーサ処理に置き換える
-      final mockFuture = Future<Map<String, dynamic>>.delayed(
-        const Duration(milliseconds: 150),
-        () => {
-          'eventName': 'らんすけ公園庭球場 ${DateTime.now().toIso8601String()}',
-          'courts': 1,
-          'players': 6,
-          'playerNames': ['らん助', 'すけ太', 'もか', 'ゆき', 'はる', 'あお'],
-        },
+      final preview = await _tennisbearImportPreviewClient.preview(
+        sourceUrl: sourceUrl,
       );
-
-      final mockData = await mockFuture;
 
       final elapsed = DateTime.now().difference(startedAt);
       const minLoading = Duration(milliseconds: 500);
@@ -249,25 +255,38 @@ class _EventSetupPageState extends State<EventSetupPage> {
 
       if (!mounted) return;
 
+      final participantNames = _participantNamesFromPreview(preview);
+      final participantCount = participantNames.isNotEmpty
+          ? participantNames.length
+          : (preview.participantSummary?.currentCount ?? 0);
+
       setState(() {
         _loadedFromUrl = true;
 
-        _courts = (mockData['courts'] as int).clamp(1, 10);
+        if (participantCount > 0) {
+          _courts = _inferCourtsForPlayers(participantCount);
+        }
+
+        final eventCourtCount = preview.eventCandidate?.courtCount ?? 0;
+        if (eventCourtCount > 0) {
+          _courts = eventCourtCount.clamp(1, 10);
+        }
+
         _syncCourtsController();
 
-        final mockPlayers = mockData['players'] as int;
-        _playersController.text =
-            mockPlayers.clamp(_minPlayers, _maxPlayers).toString();
+        if (participantCount > 0) {
+          _playersController.text =
+              participantCount.clamp(_minPlayers, _maxPlayers).toString();
+        }
 
         _syncDisplayNameControllers();
 
-        _eventNameController.text = mockData['eventName'] as String;
+        _eventNameController.text = _eventNameFromPreview(preview);
 
-        final mockNames =
-            (mockData['playerNames'] as List<dynamic>).cast<String>();
         for (var i = 0; i < _displayNameControllers.length; i++) {
           final fallback = circledNumber(i + 1);
-          final name = i < mockNames.length ? mockNames[i] : fallback;
+          final name =
+              i < participantNames.length ? participantNames[i] : fallback;
 
           _sourceDisplayNames[i] = name;
           _defaultDisplayNames[i] = name;
@@ -275,7 +294,21 @@ class _EventSetupPageState extends State<EventSetupPage> {
         }
       });
 
-      _showMessage('イベント情報を取得しました');
+      final warnings = preview.warnings;
+      if (warnings.isEmpty) {
+        _showMessage('イベント情報を取得しました');
+      } else {
+        _showMessage('イベント情報を取得しました（一部情報は取得できませんでした）');
+      }
+    } on TennisbearImportPreviewApiException catch (e) {
+      final elapsed = DateTime.now().difference(startedAt);
+      const minLoading = Duration(milliseconds: 500);
+      if (elapsed < minLoading) {
+        await Future.delayed(minLoading - elapsed);
+      }
+
+      if (!mounted) return;
+      _showMessage(e.message);
     } catch (_) {
       final elapsed = DateTime.now().difference(startedAt);
       const minLoading = Duration(milliseconds: 500);
@@ -285,7 +318,7 @@ class _EventSetupPageState extends State<EventSetupPage> {
 
       if (!mounted) return;
       // TODO: イベント情報取得失敗時のエラーログを送る仕組みができたら、ここで例外内容も送る。adminにメール送信するのもあり。
-      _showMessage('イベント情報の取得に失敗しました');
+      _showMessage('取得できませんでした。URLを確認して再度お試しください');
     } finally {
       if (mounted) {
         setState(() {
@@ -303,6 +336,38 @@ class _EventSetupPageState extends State<EventSetupPage> {
     final mm = dateTime.minute.toString().padLeft(2, '0');
 
     return '$y/$m/$d $hh:$mm';
+  }
+
+  int _inferCourtsForPlayers(int players) {
+    final eventCourts = _courts;
+
+    if (players >= eventCourts * 4 && players <= (eventCourts * 4) + 10) {
+      return eventCourts;
+    }
+
+    for (var courts = 1; courts <= 10; courts++) {
+      if (players >= courts * 4 && players <= (courts * 4) + 10) {
+        return courts;
+      }
+    }
+
+    return eventCourts;
+  }
+
+  List<String> _participantNamesFromPreview(
+    TennisbearImportPreviewResponse preview,
+  ) {
+    return preview.participantCandidates
+        .map((candidate) => candidate.displayName.trim())
+        .where((name) => name.isNotEmpty)
+        .toList(growable: false);
+  }
+
+  String _eventNameFromPreview(TennisbearImportPreviewResponse preview) {
+    final title = preview.eventCandidate?.title.trim() ?? '';
+    if (title.isNotEmpty) return title;
+
+    return _buildEffectiveEventName();
   }
 
   String _buildEffectiveEventName() {

--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:srp_lanske/app/config/app_config.dart';
 import 'package:srp_lanske/shared/utils/number_label_mapper.dart';
 
@@ -32,11 +33,36 @@ class _EventSetupPageState extends State<EventSetupPage> {
 
   bool _isLoadingEvent = false;
   bool _loadedFromUrl = false;
+  bool _isUrlImportCompleted = false;
+  String? _importedSourceUrl;
 
   int _courts = 1;
 
   int get _minPlayers => _courts * 4;
   int get _maxPlayers => (_courts * 4) + 10;
+
+  bool get _hasUrlInput => _urlController.text.trim().isNotEmpty;
+
+  bool get _isValidTennisbearEventUrl {
+    return _isTennisbearEventUrl(_urlController.text.trim());
+  }
+
+  bool get _canPasteEventUrl {
+    if (_isLoadingEvent) return false;
+    if (_isUrlImportCompleted) return false;
+    return !_isValidTennisbearEventUrl;
+  }
+
+  bool get _canImportEventUrl {
+    if (_isLoadingEvent) return false;
+    if (_isUrlImportCompleted) return false;
+    return _isValidTennisbearEventUrl;
+  }
+
+  bool get _canClearEventUrl {
+    if (_isLoadingEvent) return false;
+    return _hasUrlInput;
+  }
 
   @override
   void initState() {
@@ -109,7 +135,7 @@ class _EventSetupPageState extends State<EventSetupPage> {
       _defaultDisplayNames.add(defaultName);
       _sourceDisplayNames.add(defaultName);
 
-      focusNode.addListener(() {
+focusNode.addListener(() {
         if (!focusNode.hasFocus) return;
 
         final currentDefault = _defaultDisplayNames[index];
@@ -183,6 +209,8 @@ class _EventSetupPageState extends State<EventSetupPage> {
     setState(() {
       _loadedFromUrl = false;
       _courts = 1;
+      _isUrlImportCompleted = false;
+      _importedSourceUrl = null;
 
       _urlController.clear();
       _eventNameController.clear();
@@ -233,6 +261,11 @@ class _EventSetupPageState extends State<EventSetupPage> {
     final sourceUrl = _urlController.text.trim();
     if (sourceUrl.isEmpty) {
       _showMessage('URLを入力してください');
+      return;
+    }
+
+    if (!_isTennisbearEventUrl(sourceUrl)) {
+      _showMessage('テニスベアのイベントURLを入力してください');
       return;
     }
 
@@ -323,6 +356,8 @@ class _EventSetupPageState extends State<EventSetupPage> {
       if (mounted) {
         setState(() {
           _isLoadingEvent = false;
+          _isUrlImportCompleted = true;
+          _importedSourceUrl = sourceUrl;
         });
       }
     }
@@ -368,6 +403,70 @@ class _EventSetupPageState extends State<EventSetupPage> {
     if (title.isNotEmpty) return title;
 
     return _buildEffectiveEventName();
+  }
+
+  bool _isTennisbearEventUrl(String value) {
+    final uri = Uri.tryParse(value);
+    if (uri == null) return false;
+
+    if (uri.scheme != 'https') return false;
+    if (uri.host != 'www.tennisbear.net' && uri.host != 'tennisbear.net') {
+      return false;
+    }
+
+    final segments = uri.pathSegments;
+    if (segments.length != 3) return false;
+    if (segments[0] != 'event' || segments[2] != 'info') return false;
+
+    return RegExp(r'^\d+$').hasMatch(segments[1]);
+  }
+
+  void _handleUrlChanged(String value) {
+    final current = value.trim();
+
+    setState(() {
+      if (_isUrlImportCompleted && current != _importedSourceUrl) {
+        _isUrlImportCompleted = false;
+        _importedSourceUrl = null;
+        _loadedFromUrl = false;
+      }
+    });
+  }
+
+  Future<void> _pasteEventUrl() async {
+    if (!_canPasteEventUrl) return;
+
+    final data = await Clipboard.getData('text/plain');
+    final text = data?.text?.trim() ?? '';
+
+    if (text.isEmpty) {
+      _showMessage('クリップボードにURLがありません');
+      return;
+    }
+
+    setState(() {
+      _isUrlImportCompleted = false;
+      _importedSourceUrl = null;
+      _loadedFromUrl = false;
+
+      _urlController.text = text;
+      _urlController.selection = TextSelection.collapsed(offset: text.length);
+    });
+
+    if (!_isTennisbearEventUrl(text)) {
+      _showMessage('テニスベアのイベントURLを貼り付けてください');
+    }
+  }
+
+  void _clearEventUrl() {
+    if (!_canClearEventUrl) return;
+
+    setState(() {
+      _urlController.clear();
+      _isUrlImportCompleted = false;
+      _importedSourceUrl = null;
+      _loadedFromUrl = false;
+    });
   }
 
   String _buildEffectiveEventName() {
@@ -432,28 +531,46 @@ class _EventSetupPageState extends State<EventSetupPage> {
   }
 
   Widget _buildUrlSection() {
+    final urlText = _urlController.text.trim();
+    final showUrlError = urlText.isNotEmpty && !_isValidTennisbearEventUrl;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         TextFormField(
           controller: _urlController,
           enabled: !_isLoadingEvent,
-          decoration: const InputDecoration(
-            labelText: 'テニスベア / テニスオフ のイベントURL',
-            border: OutlineInputBorder(),
+          onChanged: _handleUrlChanged,
+          decoration: InputDecoration(
+            labelText: 'テニスベアのイベントURL',
+            helperText: '例: https://www.tennisbear.net/event/1156506/info',
+            errorText: showUrlError ? 'テニスベアのイベントURLを入力してください' : null,
+            border: const OutlineInputBorder(),
+            suffixIcon: _hasUrlInput
+                ? IconButton(
+                    tooltip: 'URLをクリア',
+                    onPressed: _canClearEventUrl ? _clearEventUrl : null,
+                    icon: const Icon(Icons.cancel_outlined),
+                  )
+                : null,
           ),
         ),
         const SizedBox(height: 12),
-        Center(
-          child: FilledButton.tonal(
-            onPressed: _fetchEventInfo,
-            style: FilledButton.styleFrom(
-              minimumSize: Size.zero,
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        Wrap(
+          spacing: 12,
+          runSpacing: 12,
+          children: [
+            OutlinedButton.icon(
+              onPressed: _canPasteEventUrl ? _pasteEventUrl : null,
+              icon: const Icon(Icons.content_paste),
+              label: const Text('貼り付け'),
             ),
-            child: const Text('イベント情報を取得する'),
-          ),
+            FilledButton.icon(
+              onPressed: _canImportEventUrl ? _fetchEventInfo : null,
+              icon: const Icon(Icons.download),
+              label: const Text('取り込み'),
+            ),
+          ],
         ),
       ],
     );

--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -34,6 +34,7 @@ class _EventSetupPageState extends State<EventSetupPage> {
   bool _isLoadingEvent = false;
   bool _loadedFromUrl = false;
   bool _isUrlImportCompleted = false;
+
   String? _importedSourceUrl;
 
   int _courts = 1;
@@ -135,7 +136,7 @@ class _EventSetupPageState extends State<EventSetupPage> {
       _defaultDisplayNames.add(defaultName);
       _sourceDisplayNames.add(defaultName);
 
-focusNode.addListener(() {
+      focusNode.addListener(() {
         if (index >= _displayNameControllers.length) return;
 
         final controller = _displayNameControllers[index];
@@ -150,7 +151,9 @@ focusNode.addListener(() {
 
         if (controller.text.trim().isEmpty) {
           final fallback = _sourceDisplayNames[index];
-          controller.text = (fallback != null && fallback.isNotEmpty) ? fallback : currentDefault;
+          controller.text = (fallback != null && fallback.isNotEmpty)
+              ? fallback
+              : currentDefault;
         }
       });
 
@@ -305,6 +308,8 @@ focusNode.addListener(() {
 
       setState(() {
         _loadedFromUrl = true;
+        _isUrlImportCompleted = true;
+        _importedSourceUrl = sourceUrl;
 
         if (participantCount > 0) {
           _courts = _inferCourtsForPlayers(participantCount);
@@ -366,21 +371,9 @@ focusNode.addListener(() {
       if (mounted) {
         setState(() {
           _isLoadingEvent = false;
-          _isUrlImportCompleted = true;
-          _importedSourceUrl = sourceUrl;
         });
       }
     }
-  }
-
-  String _formatDateTimeLabel(DateTime dateTime) {
-    final y = dateTime.year.toString().padLeft(4, '0');
-    final m = dateTime.month.toString().padLeft(2, '0');
-    final d = dateTime.day.toString().padLeft(2, '0');
-    final hh = dateTime.hour.toString().padLeft(2, '0');
-    final mm = dateTime.minute.toString().padLeft(2, '0');
-
-    return '$y/$m/$d $hh:$mm';
   }
 
   int _inferCourtsForPlayers(int players) {
@@ -477,6 +470,16 @@ focusNode.addListener(() {
       _importedSourceUrl = null;
       _loadedFromUrl = false;
     });
+  }
+
+  String _formatDateTimeLabel(DateTime dateTime) {
+    final y = dateTime.year.toString().padLeft(4, '0');
+    final m = dateTime.month.toString().padLeft(2, '0');
+    final d = dateTime.day.toString().padLeft(2, '0');
+    final hh = dateTime.hour.toString().padLeft(2, '0');
+    final mm = dateTime.minute.toString().padLeft(2, '0');
+
+    return '$y/$m/$d $hh:$mm';
   }
 
   String _buildEffectiveEventName() {

--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -136,11 +136,21 @@ class _EventSetupPageState extends State<EventSetupPage> {
       _sourceDisplayNames.add(defaultName);
 
 focusNode.addListener(() {
-        if (!focusNode.hasFocus) return;
+        if (index >= _displayNameControllers.length) return;
 
+        final controller = _displayNameControllers[index];
         final currentDefault = _defaultDisplayNames[index];
-        if (_displayNameControllers[index].text == currentDefault) {
-          _displayNameControllers[index].clear();
+
+        if (focusNode.hasFocus) {
+          if (controller.text == currentDefault) {
+            controller.clear();
+          }
+          return;
+        }
+
+        if (controller.text.trim().isEmpty) {
+          final fallback = _sourceDisplayNames[index];
+          controller.text = (fallback != null && fallback.isNotEmpty) ? fallback : currentDefault;
         }
       });
 


### PR DESCRIPTION
## Summary

Closes #16

テニスベアのイベントURLから core の import preview API を呼び出し、取得した event / participant 候補を入力画面へ反映できるようにしました。

今回の実装では、当初Issue本文の「貼り付けテキストから候補を作る」は、作業開始時コメントの方針どおり「テニスベアURLから core API の preview 結果を取得して候補を作る」と読み替えています。

## Changes

- Tennisbear import preview API client を追加
  - `POST /api/v1/imports/tennisbear-event:preview`
  - error response の `message` を画面表示に利用
- URL入力欄から core API を呼び出す処理に差し替え
  - 既存の mock 取り込み処理を削除
  - event title をイベント名へ反映
  - participant candidates を参加者表示名へ反映
  - participant count に応じて人数を反映
- URL入力UIを調整
  - テニスベア event URL の形式チェック
  - 「貼り付け」「取り込み」ボタンを追加
  - URLクリアボタンを追加
  - 取り込み成功後は再取り込みボタンを非活性化
  - URL変更・クリア・入力リセットで再取り込み可能に戻す
- 参加者表示名入力の挙動を修正
  - フォーカス時にデフォルト名を消す
  - 未入力のままフォーカスアウトした場合は表示名を復元する

## Behavior

通常フロー:

1. テニスベアURLを入力または貼り付け
2. URL形式が正しければ「取り込み」を有効化
3. core API から event / participant 候補を取得
4. 取得結果を入力フォームへ反映
5. ユーザーが確認・編集したうえで対戦表生成へ進む

失敗時:

- core API のエラーメッセージを表示
- 想定外エラー時は以下を表示

```txt
取得できませんでした。URLを確認して再度お試しください
````

## Manual check

以下を確認済みです。

* テニスベアURLから event / participant 候補を取得できる
* 取得したイベント名が入力欄へ反映される
* 取得した参加者名が入力欄へ反映される
* 反映後に対戦表生成まで進める
* 対戦表画面で参加者名が表示される
* URL入力の貼り付け / 取り込み / クリア導線が動作する
* 参加者表示名欄で、未入力フォーカスアウト時に表示名が復元される

## Notes

* web 側では HTML parser を実装しない
* テニスベアの認証情報は扱わない
* 定期クロールやバックグラウンド取得は行わない
* 取り込み結果は候補として扱い、ユーザーが確認・編集してから生成する