### PR TITLE
🔗 feat: Link events to public and generated schedule ids

### DIFF
--- a/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
+++ b/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
@@ -1,13 +1,17 @@
 import 'package:uuid/uuid.dart';
 
 import '../application/event_repository.dart';
+import '../domain/public_id.dart';
 import '../domain/saved_event_models.dart';
 import '../presentation/models/event_draft.dart';
 
 class InMemoryEventRepository implements EventRepository {
-  InMemoryEventRepository();
+  InMemoryEventRepository({
+    String Function()? publicIdGenerator,
+  }) : _publicIdGenerator = publicIdGenerator ?? generatePublicId;
 
   final _uuid = const Uuid();
+  final String Function() _publicIdGenerator;
 
   final Map<String, SavedEvent> _eventsById = {};
   final Map<String, String> _eventIdByPublicId = {};
@@ -19,7 +23,7 @@ class InMemoryEventRepository implements EventRepository {
   Future<SavedEventAggregate> createFromDraft(EventDraft draft) async {
     final now = DateTime.now();
     final eventId = _uuid.v4();
-    final publicId = _uuid.v4();
+    final publicId = _generateUniquePublicId();
 
     final event = SavedEvent(
       id: eventId,
@@ -143,5 +147,21 @@ class InMemoryEventRepository implements EventRepository {
 
     _eventsById[eventId] = updated;
     return updated;
+  }
+
+  String _generateUniquePublicId() {
+    for (var attempt = 0; attempt < 10; attempt += 1) {
+      final candidate = _publicIdGenerator();
+
+      if (!isValidPublicId(candidate)) {
+        throw StateError('invalid public_id generated: $candidate');
+      }
+
+      if (!_eventIdByPublicId.containsKey(candidate)) {
+        return candidate;
+      }
+    }
+
+    throw StateError('failed to generate unique public_id');
   }
 }

--- a/lib/features/doubles_scheduler/domain/public_id.dart
+++ b/lib/features/doubles_scheduler/domain/public_id.dart
@@ -1,0 +1,19 @@
+import 'dart:math';
+
+const publicIdAlphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const publicIdLength = 8;
+
+final Random _secureRandom = Random.secure();
+
+String generatePublicId({Random? random}) {
+  final source = random ?? _secureRandom;
+
+  return List.generate(
+    publicIdLength,
+    (_) => publicIdAlphabet[source.nextInt(publicIdAlphabet.length)],
+  ).join();
+}
+
+bool isValidPublicId(String value) {
+  return RegExp(r'^[0-9A-Z]{8}$').hasMatch(value);
+}

--- a/lib/features/doubles_scheduler/domain/saved_event_models.dart
+++ b/lib/features/doubles_scheduler/domain/saved_event_models.dart
@@ -46,6 +46,15 @@ class SavedEvent {
   final DateTime createdAt;
   final DateTime updatedAt;
 
+  String? get displayGeneratedScheduleId {
+    return adoptedGeneratedScheduleId ?? currentGeneratedScheduleId;
+  }
+
+  bool get hasAdoptedSchedule {
+    return status == SavedEventStatus.adopted ||
+        adoptedGeneratedScheduleId != null;
+  }
+
   SavedEvent copyWith({
     String? title,
     DateTime? eventDate,

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -26,6 +26,10 @@ class _SchedulePageState extends State<SchedulePage> {
   bool _isLoading = true;
   bool _isAdopting = false;
 
+  bool get _hasAdoptedSchedule {
+    return _isAdopted || (_savedEvent?.event.hasAdoptedSchedule ?? false);
+  }
+
   String? _errorMessage;
   String? _generatedScheduleId;
   Map<String, dynamic>? _scheduleResponse;
@@ -383,7 +387,8 @@ class _SchedulePageState extends State<SchedulePage> {
       runSpacing: 12,
       children: [
         FilledButton.icon(
-          onPressed: _isLoading ? null : _generateSchedule,
+          onPressed:
+              (_isLoading || _hasAdoptedSchedule) ? null : _generateSchedule,
           icon: const Icon(Icons.refresh),
           label: const Text('再生成'),
         ),
@@ -398,7 +403,7 @@ class _SchedulePageState extends State<SchedulePage> {
           onPressed: (_isLoading ||
                   _isAdopting ||
                   _generatedScheduleId == null ||
-                  _isAdopted)
+                  _hasAdoptedSchedule)
               ? null
               : _adoptSchedule,
           child: _isAdopting

--- a/test/features/doubles_scheduler/data/in_memory_event_repository_test.dart
+++ b/test/features/doubles_scheduler/data/in_memory_event_repository_test.dart
@@ -102,5 +102,93 @@ void main() {
       final found = await repository.findByPublicId(created.event.publicId);
       expect(found!.event.adoptedGeneratedScheduleId, 'generated-1');
     });
+
+    test('creates public id with eight uppercase alphanumeric chars', () async {
+      final repository = InMemoryEventRepository();
+
+      final aggregate = await repository.createFromDraft(buildDraft());
+
+      expect(aggregate.event.publicId, hasLength(8));
+      expect(
+        RegExp(r'^[0-9A-Z]{8}$').hasMatch(aggregate.event.publicId),
+        isTrue,
+      );
+      expect(aggregate.share.publicId, aggregate.event.publicId);
+    });
+
+    test('retries when generated public id collides', () async {
+      final candidates = ['AAAAAAAA', 'AAAAAAAA', 'BBBBBBBB'];
+      var index = 0;
+
+      final repository = InMemoryEventRepository(
+        publicIdGenerator: () => candidates[index++],
+      );
+
+      final first = await repository.createFromDraft(buildDraft());
+      final second = await repository.createFromDraft(buildDraft());
+
+      expect(first.event.publicId, 'AAAAAAAA');
+      expect(second.event.publicId, 'BBBBBBBB');
+      expect(index, 3);
+    });
+
+    test('throws when public id generation keeps colliding', () async {
+      final repository = InMemoryEventRepository(
+        publicIdGenerator: () => 'AAAAAAAA',
+      );
+
+      await repository.createFromDraft(buildDraft());
+
+      expect(
+        () => repository.createFromDraft(buildDraft()),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('overwrites current generated schedule id when regenerated', () async {
+      final repository = InMemoryEventRepository();
+
+      final created = await repository.createFromDraft(buildDraft());
+
+      await repository.updateCurrentGeneratedScheduleId(
+        eventId: created.event.id,
+        generatedScheduleId: 'generated-1',
+      );
+
+      final updated = await repository.updateCurrentGeneratedScheduleId(
+        eventId: created.event.id,
+        generatedScheduleId: 'generated-2',
+      );
+
+      expect(updated.currentGeneratedScheduleId, 'generated-2');
+      expect(updated.adoptedGeneratedScheduleId, isNull);
+      expect(updated.displayGeneratedScheduleId, 'generated-2');
+      expect(updated.status, SavedEventStatus.generated);
+    });
+
+    test('uses adopted generated schedule id as display target', () async {
+      final repository = InMemoryEventRepository();
+
+      final created = await repository.createFromDraft(buildDraft());
+
+      final generated = await repository.updateCurrentGeneratedScheduleId(
+        eventId: created.event.id,
+        generatedScheduleId: 'generated-1',
+      );
+
+      expect(generated.displayGeneratedScheduleId, 'generated-1');
+      expect(generated.hasAdoptedSchedule, isFalse);
+
+      final adopted = await repository.updateAdoptedGeneratedScheduleId(
+        eventId: created.event.id,
+        generatedScheduleId: 'generated-1',
+      );
+
+      expect(adopted.currentGeneratedScheduleId, 'generated-1');
+      expect(adopted.adoptedGeneratedScheduleId, 'generated-1');
+      expect(adopted.displayGeneratedScheduleId, 'generated-1');
+      expect(adopted.hasAdoptedSchedule, isTrue);
+      expect(adopted.status, SavedEventStatus.adopted);
+    });
   });
 }


### PR DESCRIPTION
## 概要

event に共有URL用の `public_id` と、core 側 `generated_schedule_id` の参照を紐づけました。

これにより、生成済み event が以下の情報を保持できるようになります。

- 共有URL用の短縮 `public_id`
- 最後に表示している `currentGeneratedScheduleId`
- 採用済みの `adoptedGeneratedScheduleId`

Closes #17

## 対応内容

- `public_id` を UUID から `[0-9A-Z]{8}` の短縮IDに変更
- `public_id` 生成時、既存 ID と衝突した場合は最大10回リトライするように変更
- `currentGeneratedScheduleId` を generate / 再生成時の表示対象 schedule として保存
- 再生成時は `currentGeneratedScheduleId` を新しい `generated_schedule_id` で上書き
- adopt 成功時に `adoptedGeneratedScheduleId` を保存
- 表示対象 schedule id を `adoptedGeneratedScheduleId ?? currentGeneratedScheduleId` として扱う getter を追加
- 採用済み判定用の getter を追加
- 採用済みの場合、再生成 / 採用操作ができないように制御
- Repository の public_id / generated_schedule_id / adopted schedule 周りのテストを追加・補強

## 確認内容

- `dart format lib test`
- `flutter test`
- 動作確認 OK
  - event 作成時に 8文字 public_id が発行されること
  - 共有URLが `sid=<public_id>` になること
  - generate 成功後に `currentGeneratedScheduleId` が保存されること
  - 再生成時に `currentGeneratedScheduleId` が上書きされること
  - adopt 成功後に `adoptedGeneratedScheduleId` が保存されること
  - adopt 後に再生成 / 採用操作ができないこと

## docs / OpenAPI

- docs 更新不要
  - 既存の #12 docs に今回の方針は整理済み
- OpenAPI 更新不要
  - web 側の保存モデル・参照更新のみで、core API 仕様変更はなし

## 補足

`public_id` は共有URL用の公開IDであり、内部 event id とは分離しています。

web 側には generated schedule 本体は保存せず、core 側の `generated_schedule_id` を参照として保持します。