### PR TITLE
♻️ feat: Restore schedule from share URL

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,17 +1,25 @@
 import 'package:flutter/material.dart';
-import 'theme/app_theme.dart';
+
 import '../features/doubles_scheduler/presentation/event_setup_page.dart';
+import '../features/doubles_scheduler/presentation/restored_schedule_page.dart';
+import 'theme/app_theme.dart';
 
 class App extends StatelessWidget {
   const App({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final publicId = Uri.base.queryParameters['sid']?.trim();
+
+    final home = publicId == null || publicId.isEmpty
+        ? const EventSetupPage()
+        : RestoredSchedulePage(publicId: publicId);
+
     return MaterialApp(
       title: 'Lanske',
       debugShowCheckedModeBanner: true,
       theme: appTheme,
-      home: const EventSetupPage(),
+      home: home,
     );
   }
 }

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -1,0 +1,691 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:srp_lanske/app/config/app_config.dart';
+import 'package:srp_lanske/shared/repositories/app_repositories.dart';
+
+import '../application/generated_schedule_service.dart';
+import '../domain/participant_draft.dart';
+import '../domain/public_id.dart';
+import '../domain/saved_event_models.dart';
+import '../infrastructure/generated_schedule_api_client.dart';
+import 'models/event_draft.dart';
+
+class RestoredSchedulePage extends StatefulWidget {
+  const RestoredSchedulePage({
+    super.key,
+    required this.publicId,
+  });
+
+  final String publicId;
+
+  @override
+  State<RestoredSchedulePage> createState() => _RestoredSchedulePageState();
+}
+
+class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
+  late final GeneratedScheduleService _service;
+
+  bool _isLoading = true;
+  bool _isAdopting = false;
+  String? _errorMessage;
+
+  SavedEventAggregate? _savedEvent;
+  String? _generatedScheduleId;
+  Map<String, dynamic>? _scheduleResponse;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _service = GeneratedScheduleService(
+      GeneratedScheduleApiClient(
+        baseUrl: AppConfig.coreApiBaseUrl,
+      ),
+    );
+
+    _restore();
+  }
+
+  bool get _isAdopted => _scheduleResponse?['adopted'] == true;
+
+  bool get _hasAdoptedSchedule {
+    return _isAdopted || (_savedEvent?.event.hasAdoptedSchedule ?? false);
+  }
+
+  String get _pageTitle {
+    return _savedEvent?.event.title ?? '共有対戦表';
+  }
+
+  String get _eventStatusLabel {
+    final event = _savedEvent?.event;
+    if (event == null) return '-';
+
+    if (event.hasAdoptedSchedule) {
+      return '採用済み';
+    }
+
+    final generatedScheduleId = event.displayGeneratedScheduleId;
+    if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
+      return '未生成';
+    }
+
+    if (_scheduleResponse == null && _errorMessage != null) {
+      return '取得失敗';
+    }
+
+    return '生成済み';
+  }
+
+  String get _generateButtonLabel {
+    final generatedScheduleId = _savedEvent?.event.displayGeneratedScheduleId;
+    return generatedScheduleId == null || generatedScheduleId.isEmpty
+        ? '生成'
+        : '再生成';
+  }
+
+  List<SavedEventParticipant> get _orderedParticipants {
+    final participants = _savedEvent?.participants.toList() ?? const [];
+    if (participants.isEmpty) return const [];
+
+    return participants.toList()
+      ..sort((a, b) => a.orderNo.compareTo(b.orderNo));
+  }
+
+  Map<String, String> get _playerNameById {
+    return {
+      for (final participant in _orderedParticipants)
+        participant.id: participant.displayName,
+    };
+  }
+
+  Future<void> _restore() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    final publicId = widget.publicId.trim().toUpperCase();
+
+    if (!isValidPublicId(publicId)) {
+      if (!mounted) return;
+
+      setState(() {
+        _isLoading = false;
+        _errorMessage = '共有URLが正しくありません';
+      });
+      return;
+    }
+
+    try {
+      final aggregate = await appEventRepository.findByPublicId(publicId);
+      if (!mounted) return;
+
+      if (aggregate == null) {
+        setState(() {
+          _savedEvent = null;
+          _scheduleResponse = null;
+          _generatedScheduleId = null;
+          _errorMessage = '対戦表が見つかりません';
+          _isLoading = false;
+        });
+        return;
+      }
+
+      final generatedScheduleId = aggregate.event.displayGeneratedScheduleId;
+
+      setState(() {
+        _savedEvent = aggregate;
+        _generatedScheduleId = generatedScheduleId;
+      });
+
+      if (aggregate.participants.isEmpty) {
+        setState(() {
+          _errorMessage = '参加者情報がありません';
+          _isLoading = false;
+        });
+        return;
+      }
+
+      if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
+        setState(() {
+          _errorMessage = 'まだ対戦表が生成されていません';
+          _isLoading = false;
+        });
+        return;
+      }
+
+      await _fetchSchedule(generatedScheduleId);
+    } catch (e) {
+      if (!mounted) return;
+
+      setState(() {
+        _savedEvent = null;
+        _scheduleResponse = null;
+        _generatedScheduleId = null;
+        _errorMessage = '共有情報を取得できませんでした: $e';
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _fetchSchedule(String generatedScheduleId) async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final response = await _service.getById(generatedScheduleId);
+      if (!mounted) return;
+
+      setState(() {
+        _scheduleResponse = response;
+        _generatedScheduleId = response['generated_schedule_id']?.toString() ??
+            generatedScheduleId;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+
+      setState(() {
+        _scheduleResponse = null;
+        _errorMessage = '対戦表を取得できませんでした: $e';
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _reloadSchedule() async {
+    final generatedScheduleId =
+        _generatedScheduleId ?? _savedEvent?.event.displayGeneratedScheduleId;
+
+    if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
+      _showMessage('再取得する generated_schedule_id がありません');
+      return;
+    }
+
+    await _fetchSchedule(generatedScheduleId);
+  }
+
+  Future<void> _generateSchedule() async {
+    final savedEvent = _savedEvent;
+    if (savedEvent == null) {
+      _showMessage('再生成するイベント情報がありません');
+      return;
+    }
+
+    if (_hasAdoptedSchedule) {
+      _showMessage('採用済みのため再生成できません');
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final draft = _buildDraft(savedEvent);
+      final response = await _service.generateFromDraft(draft);
+      if (!mounted) return;
+
+      final generatedScheduleId = response['generated_schedule_id']?.toString();
+
+      var nextSavedEvent = savedEvent;
+      if (generatedScheduleId != null && generatedScheduleId.isNotEmpty) {
+        final updatedEvent =
+            await appEventRepository.updateCurrentGeneratedScheduleId(
+          eventId: savedEvent.event.id,
+          generatedScheduleId: generatedScheduleId,
+        );
+
+        nextSavedEvent = _replaceSavedEvent(savedEvent, updatedEvent);
+      }
+
+      if (!mounted) return;
+
+      setState(() {
+        _savedEvent = nextSavedEvent;
+        _scheduleResponse = response;
+        _generatedScheduleId = generatedScheduleId;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+
+      setState(() {
+        _errorMessage = e.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _adoptSchedule() async {
+    final savedEvent = _savedEvent;
+    final generatedScheduleId = _generatedScheduleId;
+
+    if (savedEvent == null) {
+      _showMessage('採用するイベント情報がありません');
+      return;
+    }
+
+    if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
+      _showMessage('採用する generated_schedule_id がありません');
+      return;
+    }
+
+    if (_isAdopting || _hasAdoptedSchedule) return;
+
+    setState(() {
+      _isAdopting = true;
+      _errorMessage = null;
+    });
+
+    try {
+      await _service.adopt(generatedScheduleId);
+
+      final updatedEvent =
+          await appEventRepository.updateAdoptedGeneratedScheduleId(
+        eventId: savedEvent.event.id,
+        generatedScheduleId: generatedScheduleId,
+      );
+
+      if (!mounted) return;
+
+      setState(() {
+        _savedEvent = _replaceSavedEvent(savedEvent, updatedEvent);
+      });
+
+      _showMessage('採用しました');
+      await _reloadSchedule();
+    } catch (e) {
+      if (!mounted) return;
+
+      setState(() {
+        _errorMessage = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isAdopting = false;
+        });
+      }
+    }
+  }
+
+  EventDraft _buildDraft(SavedEventAggregate aggregate) {
+    return EventDraft(
+      url: aggregate.event.sourceUrl ?? '',
+      courts: aggregate.event.courtCount,
+      eventName: aggregate.event.title,
+      participants: _orderedParticipants.map((participant) {
+        return ParticipantDraft(
+          id: participant.id,
+          displayName: participant.displayName,
+        );
+      }).toList(growable: false),
+    );
+  }
+
+  SavedEventAggregate _replaceSavedEvent(
+    SavedEventAggregate aggregate,
+    SavedEvent event,
+  ) {
+    return SavedEventAggregate(
+      event: event,
+      participants: aggregate.participants,
+      share: aggregate.share,
+      importRecord: aggregate.importRecord,
+    );
+  }
+
+  String _buildShareUrl() {
+    final publicId = _savedEvent?.event.publicId ?? widget.publicId;
+
+    return Uri.base.replace(
+      queryParameters: {
+        ...Uri.base.queryParameters,
+        'sid': publicId,
+      },
+    ).toString();
+  }
+
+  Future<void> _copyShareUrl() async {
+    await Clipboard.setData(ClipboardData(text: _buildShareUrl()));
+    _showMessage('共有URLをコピーしました');
+  }
+
+  void _showMessage(String message) {
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.hideCurrentSnackBar();
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(message),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
+  List<Map<String, dynamic>> _asObjectList(Object? value) {
+    if (value is! List) return const [];
+
+    return value
+        .whereType<Map>()
+        .map((e) => e.map((key, value) => MapEntry(key.toString(), value)))
+        .toList(growable: false);
+  }
+
+  List<int> _asIntList(Object? value) {
+    if (value is! List) return const [];
+
+    return value
+        .map((e) {
+          if (e is int) return e;
+          return int.tryParse(e.toString());
+        })
+        .whereType<int>()
+        .toList(growable: false);
+  }
+
+  Map<int, String> _buildSlotToPlayerId() {
+    final assignment = _asObjectList(_scheduleResponse?['assignment']);
+
+    return {
+      for (final row in assignment)
+        if (row['slot_number'] != null && row['player_id'] != null)
+          int.parse(row['slot_number'].toString()): row['player_id'].toString(),
+    };
+  }
+
+  String _playerLabelFromId(String playerId) {
+    return _playerNameById[playerId] ?? playerId;
+  }
+
+  String _playerLabelFromSlot(int slotNumber, Map<int, String> slotToPlayerId) {
+    final playerId = slotToPlayerId[slotNumber];
+    if (playerId == null) return 'slot:$slotNumber';
+    return _playerLabelFromId(playerId);
+  }
+
+  String _formatTeamFromSlots(
+    List<int> slots,
+    Map<int, String> slotToPlayerId,
+  ) {
+    if (slots.isEmpty) return '-';
+
+    return slots
+        .map((slot) => '$slot: ${_playerLabelFromSlot(slot, slotToPlayerId)}')
+        .join(' / ');
+  }
+
+  String _formatRestPlayersBySlots(
+    List<int> slotNumbers,
+    Map<int, String> slotToPlayerId,
+  ) {
+    if (slotNumbers.isEmpty) return '-';
+
+    return slotNumbers
+        .map((slot) => '$slot: ${_playerLabelFromSlot(slot, slotToPlayerId)}')
+        .join(' / ');
+  }
+
+  Widget _buildSectionCard({
+    required String title,
+    required Widget child,
+  }) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: 16,
+              ),
+            ),
+            const SizedBox(height: 12),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSummaryCard() {
+    final savedEvent = _savedEvent;
+    if (savedEvent == null) {
+      return _buildSectionCard(
+        title: '共有URL',
+        child: Text('共有ID: ${widget.publicId}'),
+      );
+    }
+
+    final event = savedEvent.event;
+
+    return _buildSectionCard(
+      title: 'イベント情報',
+      child: Wrap(
+        spacing: 16,
+        runSpacing: 8,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          Text('イベント名: ${event.title}'),
+          Text('面数: ${event.courtCount}'),
+          Text('人数: ${savedEvent.participants.length}'),
+          Text('共有ID: ${event.publicId}'),
+          Text('状態: $_eventStatusLabel'),
+          OutlinedButton.icon(
+            onPressed: _copyShareUrl,
+            icon: const Icon(Icons.copy),
+            label: const Text('共有URLをコピー'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPlayersCard() {
+    final participants = _orderedParticipants;
+
+    if (participants.isEmpty) {
+      return _buildSectionCard(
+        title: '参加者',
+        child: const Text('参加者情報がありません'),
+      );
+    }
+
+    return _buildSectionCard(
+      title: '参加者',
+      child: Wrap(
+        spacing: 6,
+        runSpacing: 6,
+        children: participants.map((participant) {
+          return Chip(
+            label: Text('${participant.orderNo}: ${participant.displayName}'),
+          );
+        }).toList(growable: false),
+      ),
+    );
+  }
+
+  Widget _buildActionButtons() {
+    if (_hasAdoptedSchedule) {
+      return Wrap(
+        spacing: 12,
+        runSpacing: 12,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          const Chip(
+            avatar: Icon(Icons.check),
+            label: Text('採用済み'),
+          ),
+          FilledButton.tonalIcon(
+            onPressed: _isLoading ? null : _reloadSchedule,
+            icon: const Icon(Icons.download),
+            label: const Text('再取得'),
+          ),
+        ],
+      );
+    }
+
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      children: [
+        FilledButton.icon(
+          onPressed: _isLoading ? null : _generateSchedule,
+          icon: const Icon(Icons.refresh),
+          label: Text(_generateButtonLabel),
+        ),
+        FilledButton.tonalIcon(
+          onPressed: (_isLoading || _generatedScheduleId == null)
+              ? null
+              : _reloadSchedule,
+          icon: const Icon(Icons.download),
+          label: const Text('再取得'),
+        ),
+        FilledButton(
+          onPressed: (_isLoading ||
+                  _isAdopting ||
+                  _generatedScheduleId == null ||
+                  _scheduleResponse == null ||
+                  _hasAdoptedSchedule)
+              ? null
+              : _adoptSchedule,
+          child: _isAdopting
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('採用'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildScheduleRounds() {
+    final rounds = _asObjectList(_scheduleResponse?['rounds']);
+    final slotToPlayerId = _buildSlotToPlayerId();
+
+    if (_scheduleResponse == null) {
+      return const Text('対戦表を取得できていません');
+    }
+
+    if (rounds.isEmpty) {
+      return const Text('対戦表データがありません');
+    }
+
+    return Column(
+      children: rounds.map((round) {
+        final roundNumber = round['round_number']?.toString() ?? '-';
+        final restSlotNumbers = _asIntList(round['rest_slot_numbers']);
+        final courts = _asObjectList(round['courts']);
+
+        return Card(
+          margin: const EdgeInsets.only(bottom: 12),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '第$roundNumber試合',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 18,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                ...courts.map((court) {
+                  final courtNumber = court['court_number']?.toString() ?? '-';
+                  final team1Slots = _asIntList(court['team1_player_slots']);
+                  final team2Slots = _asIntList(court['team2_player_slots']);
+
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'コート$courtNumber',
+                          style: const TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 14,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          '${_formatTeamFromSlots(team1Slots, slotToPlayerId)}  vs  ${_formatTeamFromSlots(team2Slots, slotToPlayerId)}',
+                        ),
+                      ],
+                    ),
+                  );
+                }),
+                const Divider(),
+                Text(
+                  '休憩: ${_formatRestPlayersBySlots(restSlotNumbers, slotToPlayerId)}',
+                ),
+              ],
+            ),
+          ),
+        );
+      }).toList(growable: false),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final showInitialLoading = _isLoading && _savedEvent == null;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_pageTitle),
+      ),
+      body: SafeArea(
+        child: showInitialLoading
+            ? const Center(
+                child: CircularProgressIndicator(),
+              )
+            : ListView(
+                padding: const EdgeInsets.all(16),
+                children: [
+                  _buildSummaryCard(),
+                  const SizedBox(height: 12),
+                  if (_savedEvent != null) ...[
+                    _buildPlayersCard(),
+                    const SizedBox(height: 12),
+                    _buildSectionCard(
+                      title: '操作',
+                      child: _buildActionButtons(),
+                    ),
+                    const SizedBox(height: 12),
+                    _buildSectionCard(
+                      title: '対戦表',
+                      child: _isLoading
+                          ? const Center(
+                              child: Padding(
+                                padding: EdgeInsets.all(16),
+                                child: CircularProgressIndicator(),
+                              ),
+                            )
+                          : _buildScheduleRounds(),
+                    ),
+                  ],
+                  if (_errorMessage != null) ...[
+                    const SizedBox(height: 12),
+                    _buildSectionCard(
+                      title: 'エラー',
+                      child: Text(_errorMessage!),
+                    ),
+                  ],
+                  const SizedBox(height: 80),
+                ],
+              ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 概要

共有URL / リロードから event / participant / generated_schedule を復元できるようにしました。

`?sid={public_id}` が指定されている場合は、通常のイベント入力画面ではなく共有対戦表の復元画面を表示します。

## 対応内容

- 起動時に `sid` query parameter を読み取り、共有対戦表復元画面へ分岐
- `RestoredSchedulePage` を追加
- `public_id` から event aggregate を取得
- participant を `orderNo` 順で復元
- `adoptedGeneratedScheduleId ?? currentGeneratedScheduleId` を使って core get API から対戦表を取得
- 共有URLから復元した状態で、再取得 / 再生成 / 採用を実行できるように対応
- 採用済み event では採用・再生成操作を抑止
- 未生成 / 取得失敗 / public_id 不正 / event 未存在 / core get 失敗時の最低限の表示を追加

## 確認内容

- `flutter analyze`
- `flutter test`

### 手動確認

- 生成済み event の共有URL `?sid={public_id}` から event / participant / 対戦表を復元できること
- 採用済み event の共有URLを開くと「採用済み」として表示されること
- 採用済み event では採用・再生成操作ができないこと
- 未生成 event では「未生成」と表示され、生成操作ができること
- 不正な public_id 形式で「共有URLが正しくありません」と表示されること
- 存在しない public_id で「対戦表が見つかりません」と表示されること
- core get API 失敗時も event / participant は表示され、対戦表取得失敗として表示されること
- core get API 失敗時は採用操作ができないこと
- 共有URL上でリロードしても Firestore に保存済みの event / participant / generated_schedule_ref から復元できること

## 今回やらないこと

- `?sid=` から `/sid/{public_id}` 等への URL 形式変更
- 旧 `?sid=` 形式の長期互換対応
- AppBar / ハンバーガーメニュー等の共通ナビゲーション
- TOP / 対戦表一覧 / マイページ / 設定への共通導線
- 対戦表一覧での共有アクセス履歴・自作対戦表の区別表示
- 共有リンク期限切れ時の詳細 UI
- 対戦表 UI の共通 widget 化
- エラー文言・通知の本格整理

これらは #11 に後続候補として整理し、フェーズ3後半または共有URL MVP の手動スモークテスト前に扱いを判断します。

Closes #18