### PR TITLE
🎛️ feat: Finish generate and adopt flow

### DIFF
--- a/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
+++ b/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
@@ -118,6 +118,10 @@ class InMemoryEventRepository implements EventRepository {
       throw StateError('event not found: $eventId');
     }
 
+    if (event.hasAdoptedSchedule) {
+      throw StateError('event already adopted: $eventId');
+    }
+
     final updated = event.copyWith(
       status: SavedEventStatus.generated,
       currentGeneratedScheduleId: generatedScheduleId,

--- a/lib/features/doubles_scheduler/data/json_event_repository.dart
+++ b/lib/features/doubles_scheduler/data/json_event_repository.dart
@@ -104,7 +104,12 @@ class JsonEventRepository implements EventRepository {
       throw StateError('event not found: $eventId');
     }
 
-    final updatedEvent = aggregate.event.copyWith(
+    final event = aggregate.event;
+    if (event.hasAdoptedSchedule) {
+      throw StateError('event already adopted: $eventId');
+    }
+
+    final updatedEvent = event.copyWith(
       status: SavedEventStatus.generated,
       currentGeneratedScheduleId: generatedScheduleId,
       updatedAt: DateTime.now(),

--- a/lib/features/doubles_scheduler/domain/saved_event_models.dart
+++ b/lib/features/doubles_scheduler/domain/saved_event_models.dart
@@ -53,7 +53,8 @@ class SavedEvent {
   }
 
   bool get hasAdoptedSchedule {
-    return status == SavedEventStatus.adopted || adoptedGeneratedScheduleId != null;
+    return status == SavedEventStatus.adopted ||
+        adoptedGeneratedScheduleId != null;
   }
 
   SavedEvent copyWith({
@@ -82,8 +83,10 @@ class SavedEvent {
       sourceType: sourceType ?? this.sourceType,
       sourceUrl: sourceUrl ?? this.sourceUrl,
       status: status ?? this.status,
-      currentGeneratedScheduleId: currentGeneratedScheduleId ?? this.currentGeneratedScheduleId,
-      adoptedGeneratedScheduleId: adoptedGeneratedScheduleId ?? this.adoptedGeneratedScheduleId,
+      currentGeneratedScheduleId:
+          currentGeneratedScheduleId ?? this.currentGeneratedScheduleId,
+      adoptedGeneratedScheduleId:
+          adoptedGeneratedScheduleId ?? this.adoptedGeneratedScheduleId,
       createdAt: createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );
@@ -122,8 +125,10 @@ class SavedEvent {
       sourceType: _eventSourceTypeFromJson(json['sourceType']),
       sourceUrl: json['sourceUrl']?.toString(),
       status: _savedEventStatusFromJson(json['status']),
-      currentGeneratedScheduleId: json['currentGeneratedScheduleId']?.toString(),
-      adoptedGeneratedScheduleId: json['adoptedGeneratedScheduleId']?.toString(),
+      currentGeneratedScheduleId:
+          json['currentGeneratedScheduleId']?.toString(),
+      adoptedGeneratedScheduleId:
+          json['adoptedGeneratedScheduleId']?.toString(),
       createdAt: _dateTimeFromJson(json['createdAt']),
       updatedAt: _dateTimeFromJson(json['updatedAt']),
     );
@@ -223,7 +228,8 @@ class SavedEventImport {
       sourceUrl: json['sourceUrl']?.toString(),
       pastedText: json['pastedText']?.toString(),
       parsedEventJson: _nullableMapFromJson(json['parsedEventJson']),
-      parsedParticipantsJson: _nullableMapListFromJson(json['parsedParticipantsJson']),
+      parsedParticipantsJson:
+          _nullableMapListFromJson(json['parsedParticipantsJson']),
       confirmedAt: _nullableDateTimeFromJson(json['confirmedAt']),
       createdAt: _dateTimeFromJson(json['createdAt']),
     );
@@ -318,7 +324,9 @@ class SavedEventAggregate {
         );
       }).toList(growable: false),
       share: SavedEventShare.fromJson(shareJson),
-      importRecord: importRecordJson == null ? null : SavedEventImport.fromJson(importRecordJson),
+      importRecord: importRecordJson == null
+          ? null
+          : SavedEventImport.fromJson(importRecordJson),
     );
   }
 }

--- a/lib/features/doubles_scheduler/presentation/event_list_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_list_page.dart
@@ -19,7 +19,7 @@ class EventListPage extends StatelessWidget {
               child: Text('まだ保存された対戦表はありません'),
             )
           : ListView.separated(
-              padding: const EdgeInsets.all(16),
+              padding: const EdgeInsets.all(4),
               itemCount: items.length,
               separatorBuilder: (_, __) => const SizedBox(height: 12),
               itemBuilder: (context, index) {

--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -700,7 +700,7 @@ class _EventSetupPageState extends State<EventSetupPage> {
                 child: Opacity(
                   opacity: _isLoadingEvent ? 0.5 : 1,
                   child: ListView(
-                    padding: const EdgeInsets.all(16),
+                    padding: const EdgeInsets.all(4),
                     children: [
                       const Text(
                         'URLを貼るか、手動で面数・人数を入力してください。',

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -546,7 +546,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     final savedEvent = _savedEvent;
 
     return ListView(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(4),
       children: [
         if (savedEvent == null)
           ScheduleSectionCard(
@@ -555,8 +555,6 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           )
         else ...[
           ScheduleEventSummaryCard(
-            courtCount: savedEvent.event.courtCount,
-            participantCount: savedEvent.participants.length,
             statusLabel: _eventStatusLabel,
             onCopyShareUrl: _copyShareUrl,
             onRefresh: _reloadSchedule,
@@ -564,6 +562,8 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           ),
           const SizedBox(height: 12),
           ScheduleParticipantsCard(
+            title:
+                '面数: ${savedEvent.event.courtCount}　　参加者: ${savedEvent.participants.length}人',
             participants: _participantViewModels,
           ),
           if (!_hasAdoptedSchedule) ...[
@@ -587,13 +587,14 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
             child: _isLoading
                 ? const Center(
                     child: Padding(
-                      padding: EdgeInsets.all(16),
+                      padding: EdgeInsets.all(4),
                       child: CircularProgressIndicator(),
                     ),
                   )
                 : ScheduleRoundsView(
                     scheduleResponse: _scheduleResponse,
                     playerNameById: _playerNameById,
+                    courtCount: savedEvent.event.courtCount,
                   ),
           ),
         ],

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -419,39 +419,11 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   }
 
   Future<void> _adoptSchedule() async {
-    final latestEvent = await _refreshSavedEventForAction();
-    if (!mounted) return;
+    final displayedGeneratedScheduleId = _generatedScheduleId;
 
-    if (latestEvent == null) {
-      _showMessage('採用するイベント情報がありません');
-      return;
-    }
-
-    if (latestEvent.event.hasAdoptedSchedule) {
-      _showMessage('すでに採用済みです');
-      await _reloadSchedule();
-      return;
-    }
-
-    final latestCurrentGeneratedScheduleId =
-        latestEvent.event.currentGeneratedScheduleId;
-
-    if (latestCurrentGeneratedScheduleId != _generatedScheduleId) {
-      _showMessage('対戦表が更新されています。最新の対戦表を再取得します');
-      await _reloadSchedule();
-      return;
-    }
-
-    final savedEvent = _savedEvent;
-    final generatedScheduleId = _generatedScheduleId;
-
-    if (savedEvent == null) {
-      _showMessage('採用するイベント情報がありません');
-      return;
-    }
-
-    if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
-      _showMessage('採用するイベント情報がありません');
+    if (displayedGeneratedScheduleId == null ||
+        displayedGeneratedScheduleId.isEmpty) {
+      _showMessage('採用する generated_schedule_id がありません');
       return;
     }
 
@@ -463,18 +435,41 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     });
 
     try {
-      await _service.adopt(generatedScheduleId);
+      final latestEvent = await _refreshSavedEventForAction();
+      if (!mounted) return;
+
+      if (latestEvent == null) {
+        _showMessage('採用するイベント情報がありません');
+        return;
+      }
+
+      if (latestEvent.event.hasAdoptedSchedule) {
+        _showMessage('すでに採用済みです');
+        await _reloadSchedule();
+        return;
+      }
+
+      final latestCurrentGeneratedScheduleId =
+          latestEvent.event.currentGeneratedScheduleId;
+
+      if (latestCurrentGeneratedScheduleId != displayedGeneratedScheduleId) {
+        _showMessage('対戦表が更新されています。最新の対戦表を再取得します');
+        await _reloadSchedule();
+        return;
+      }
+
+      await _service.adopt(displayedGeneratedScheduleId);
 
       final updatedEvent =
           await appEventRepository.updateAdoptedGeneratedScheduleId(
-        eventId: savedEvent.event.id,
-        generatedScheduleId: generatedScheduleId,
+        eventId: latestEvent.event.id,
+        generatedScheduleId: displayedGeneratedScheduleId,
       );
 
       if (!mounted) return;
 
       setState(() {
-        _savedEvent = _replaceSavedEvent(savedEvent, updatedEvent);
+        _savedEvent = _replaceSavedEvent(latestEvent, updatedEvent);
       });
 
       _showMessage('採用しました');

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -453,7 +453,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           latestEvent.event.currentGeneratedScheduleId;
 
       if (latestCurrentGeneratedScheduleId != displayedGeneratedScheduleId) {
-        _showMessage('対戦表が更新されています。最新の対戦表を再取得します');
+        _showMessage('対戦表が更新されています。最新の情報に更新します');
         await _reloadSchedule();
         return;
       }
@@ -472,7 +472,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         _savedEvent = _replaceSavedEvent(latestEvent, updatedEvent);
       });
 
-      _showMessage('採用しました');
+      _showMessage('この対戦表を採用しました');
       await _reloadSchedule();
     } catch (e) {
       if (!mounted) return;

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -9,6 +9,11 @@ import '../domain/public_id.dart';
 import '../domain/saved_event_models.dart';
 import '../infrastructure/generated_schedule_api_client.dart';
 import 'models/event_draft.dart';
+import 'widgets/schedule_action_buttons.dart';
+import 'widgets/schedule_event_summary_card.dart';
+import 'widgets/schedule_participants_card.dart';
+import 'widgets/schedule_rounds_view.dart';
+import 'widgets/schedule_section_card.dart';
 
 class RestoredSchedulePage extends StatefulWidget {
   const RestoredSchedulePage({
@@ -60,11 +65,20 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     final event = _savedEvent?.event;
     if (event == null) return '-';
 
-    if (event.hasAdoptedSchedule) {
+    if (_hasAdoptedSchedule) {
       return '採用済み';
     }
 
     final generatedScheduleId = event.displayGeneratedScheduleId;
+    if (_isLoading &&
+        (generatedScheduleId == null || generatedScheduleId.isEmpty)) {
+      return '生成中';
+    }
+
+    if (_isLoading) {
+      return '処理中';
+    }
+
     if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
       return '未生成';
     }
@@ -96,6 +110,15 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       for (final participant in _orderedParticipants)
         participant.id: participant.displayName,
     };
+  }
+
+  List<ScheduleParticipantViewModel> get _participantViewModels {
+    return _orderedParticipants.map((participant) {
+      return ScheduleParticipantViewModel(
+        orderNo: participant.orderNo,
+        displayName: participant.displayName,
+      );
+    }).toList(growable: false);
   }
 
   Future<void> _restore() async {
@@ -199,12 +222,12 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     final generatedScheduleId =
         _generatedScheduleId ?? _savedEvent?.event.displayGeneratedScheduleId;
 
-    if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
+      if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
       _showMessage('再取得する generated_schedule_id がありません');
-      return;
-    }
+        return;
+      }
 
-    await _fetchSchedule(generatedScheduleId);
+      await _fetchSchedule(generatedScheduleId);
   }
 
   Future<void> _generateSchedule() async {
@@ -254,7 +277,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       if (!mounted) return;
 
       setState(() {
-        _errorMessage = e.toString();
+        _errorMessage = '対戦表を生成できませんでした: $e';
         _isLoading = false;
       });
     }
@@ -302,7 +325,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       if (!mounted) return;
 
       setState(() {
-        _errorMessage = e.toString();
+        _errorMessage = '対戦表を採用できませんでした: $e';
       });
     } finally {
       if (mounted) {
@@ -366,274 +389,71 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     );
   }
 
-  List<Map<String, dynamic>> _asObjectList(Object? value) {
-    if (value is! List) return const [];
-
-    return value
-        .whereType<Map>()
-        .map((e) => e.map((key, value) => MapEntry(key.toString(), value)))
-        .toList(growable: false);
-  }
-
-  List<int> _asIntList(Object? value) {
-    if (value is! List) return const [];
-
-    return value
-        .map((e) {
-          if (e is int) return e;
-          return int.tryParse(e.toString());
-        })
-        .whereType<int>()
-        .toList(growable: false);
-  }
-
-  Map<int, String> _buildSlotToPlayerId() {
-    final assignment = _asObjectList(_scheduleResponse?['assignment']);
-
-    return {
-      for (final row in assignment)
-        if (row['slot_number'] != null && row['player_id'] != null)
-          int.parse(row['slot_number'].toString()): row['player_id'].toString(),
-    };
-  }
-
-  String _playerLabelFromId(String playerId) {
-    return _playerNameById[playerId] ?? playerId;
-  }
-
-  String _playerLabelFromSlot(int slotNumber, Map<int, String> slotToPlayerId) {
-    final playerId = slotToPlayerId[slotNumber];
-    if (playerId == null) return 'slot:$slotNumber';
-    return _playerLabelFromId(playerId);
-  }
-
-  String _formatTeamFromSlots(
-    List<int> slots,
-    Map<int, String> slotToPlayerId,
-  ) {
-    if (slots.isEmpty) return '-';
-
-    return slots
-        .map((slot) => '$slot: ${_playerLabelFromSlot(slot, slotToPlayerId)}')
-        .join(' / ');
-  }
-
-  String _formatRestPlayersBySlots(
-    List<int> slotNumbers,
-    Map<int, String> slotToPlayerId,
-  ) {
-    if (slotNumbers.isEmpty) return '-';
-
-    return slotNumbers
-        .map((slot) => '$slot: ${_playerLabelFromSlot(slot, slotToPlayerId)}')
-        .join(' / ');
-  }
-
-  Widget _buildSectionCard({
-    required String title,
-    required Widget child,
-  }) {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              title,
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 16,
-              ),
-            ),
-            const SizedBox(height: 12),
-            child,
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildSummaryCard() {
+  Widget _buildScheduleBody() {
     final savedEvent = _savedEvent;
-    if (savedEvent == null) {
-      return _buildSectionCard(
-        title: '共有URL',
-        child: Text('共有ID: ${widget.publicId}'),
-      );
-    }
 
-    final event = savedEvent.event;
-
-    return _buildSectionCard(
-      title: 'イベント情報',
-      child: Wrap(
-        spacing: 16,
-        runSpacing: 8,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: [
-          Text('イベント名: ${event.title}'),
-          Text('面数: ${event.courtCount}'),
-          Text('人数: ${savedEvent.participants.length}'),
-          Text('共有ID: ${event.publicId}'),
-          Text('状態: $_eventStatusLabel'),
-          OutlinedButton.icon(
-            onPressed: _copyShareUrl,
-            icon: const Icon(Icons.copy),
-            label: const Text('共有URLをコピー'),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildPlayersCard() {
-    final participants = _orderedParticipants;
-
-    if (participants.isEmpty) {
-      return _buildSectionCard(
-        title: '参加者',
-        child: const Text('参加者情報がありません'),
-      );
-    }
-
-    return _buildSectionCard(
-      title: '参加者',
-      child: Wrap(
-        spacing: 6,
-        runSpacing: 6,
-        children: participants.map((participant) {
-          return Chip(
-            label: Text('${participant.orderNo}: ${participant.displayName}'),
-          );
-        }).toList(growable: false),
-      ),
-    );
-  }
-
-  Widget _buildActionButtons() {
-    if (_hasAdoptedSchedule) {
-      return Wrap(
-        spacing: 12,
-        runSpacing: 12,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: [
-          const Chip(
-            avatar: Icon(Icons.check),
-            label: Text('採用済み'),
-          ),
-          FilledButton.tonalIcon(
-            onPressed: _isLoading ? null : _reloadSchedule,
-            icon: const Icon(Icons.download),
-            label: const Text('再取得'),
-          ),
-        ],
-      );
-    }
-
-    return Wrap(
-      spacing: 12,
-      runSpacing: 12,
+    return ListView(
+      padding: const EdgeInsets.all(16),
       children: [
-        FilledButton.icon(
-          onPressed: _isLoading ? null : _generateSchedule,
-          icon: const Icon(Icons.refresh),
-          label: Text(_generateButtonLabel),
-        ),
-        FilledButton.tonalIcon(
-          onPressed: (_isLoading || _generatedScheduleId == null)
-              ? null
-              : _reloadSchedule,
-          icon: const Icon(Icons.download),
-          label: const Text('再取得'),
-        ),
-        FilledButton(
-          onPressed: (_isLoading ||
-                  _isAdopting ||
-                  _generatedScheduleId == null ||
-                  _scheduleResponse == null ||
-                  _hasAdoptedSchedule)
-              ? null
-              : _adoptSchedule,
-          child: _isAdopting
-              ? const SizedBox(
-                  width: 18,
-                  height: 18,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
-              : const Text('採用'),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildScheduleRounds() {
-    final rounds = _asObjectList(_scheduleResponse?['rounds']);
-    final slotToPlayerId = _buildSlotToPlayerId();
-
-    if (_scheduleResponse == null) {
-      return const Text('対戦表を取得できていません');
-    }
-
-    if (rounds.isEmpty) {
-      return const Text('対戦表データがありません');
-    }
-
-    return Column(
-      children: rounds.map((round) {
-        final roundNumber = round['round_number']?.toString() ?? '-';
-        final restSlotNumbers = _asIntList(round['rest_slot_numbers']);
-        final courts = _asObjectList(round['courts']);
-
-        return Card(
-          margin: const EdgeInsets.only(bottom: 12),
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  '第$roundNumber試合',
-                  style: const TextStyle(
-                    fontWeight: FontWeight.bold,
-                    fontSize: 18,
-                  ),
-                ),
-                const SizedBox(height: 12),
-                ...courts.map((court) {
-                  final courtNumber = court['court_number']?.toString() ?? '-';
-                  final team1Slots = _asIntList(court['team1_player_slots']);
-                  final team2Slots = _asIntList(court['team2_player_slots']);
-
-                  return Padding(
-                    padding: const EdgeInsets.only(bottom: 12),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'コート$courtNumber',
-                          style: const TextStyle(
-                            fontWeight: FontWeight.bold,
-                            fontSize: 14,
-                          ),
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          '${_formatTeamFromSlots(team1Slots, slotToPlayerId)}  vs  ${_formatTeamFromSlots(team2Slots, slotToPlayerId)}',
-                        ),
-                      ],
-                    ),
-                  );
-                }),
-                const Divider(),
-                Text(
-                  '休憩: ${_formatRestPlayersBySlots(restSlotNumbers, slotToPlayerId)}',
-                ),
-              ],
+        if (savedEvent == null)
+          ScheduleSectionCard(
+            title: '共有URL',
+            child: Text('共有ID: ${widget.publicId}'),
+          )
+        else ...[
+          ScheduleEventSummaryCard(
+            eventName: savedEvent.event.title,
+            courtCount: savedEvent.event.courtCount,
+            participantCount: savedEvent.participants.length,
+            publicId: savedEvent.event.publicId,
+            statusLabel: _eventStatusLabel,
+            onCopyShareUrl: _copyShareUrl,
+          ),
+          const SizedBox(height: 12),
+          ScheduleParticipantsCard(
+            participants: _participantViewModels,
+          ),
+          const SizedBox(height: 12),
+          ScheduleSectionCard(
+            title: '操作',
+            child: ScheduleActionButtons(
+              hasAdoptedSchedule: _hasAdoptedSchedule,
+              isLoading: _isLoading,
+              isAdopting: _isAdopting,
+              generateButtonLabel: _generateButtonLabel,
+              canReload: _generatedScheduleId != null,
+              canAdopt:
+                  _generatedScheduleId != null && _scheduleResponse != null,
+              onGenerate: _generateSchedule,
+              onReload: _reloadSchedule,
+              onAdopt: _adoptSchedule,
             ),
           ),
-        );
-      }).toList(growable: false),
+          const SizedBox(height: 12),
+          ScheduleSectionCard(
+            title: '対戦表',
+            child: _isLoading
+                ? const Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(16),
+                      child: CircularProgressIndicator(),
+                    ),
+                  )
+                : ScheduleRoundsView(
+                    scheduleResponse: _scheduleResponse,
+                    playerNameById: _playerNameById,
+                  ),
+          ),
+        ],
+        if (_errorMessage != null) ...[
+          const SizedBox(height: 12),
+          ScheduleSectionCard(
+            title: 'エラー',
+            child: Text(_errorMessage!),
+          ),
+        ],
+        const SizedBox(height: 80),
+      ],
     );
   }
 
@@ -650,41 +470,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
             ? const Center(
                 child: CircularProgressIndicator(),
               )
-            : ListView(
-                padding: const EdgeInsets.all(16),
-                children: [
-                  _buildSummaryCard(),
-                  const SizedBox(height: 12),
-                  if (_savedEvent != null) ...[
-                    _buildPlayersCard(),
-                    const SizedBox(height: 12),
-                    _buildSectionCard(
-                      title: '操作',
-                      child: _buildActionButtons(),
-                    ),
-                    const SizedBox(height: 12),
-                    _buildSectionCard(
-                      title: '対戦表',
-                      child: _isLoading
-                          ? const Center(
-                              child: Padding(
-                                padding: EdgeInsets.all(16),
-                                child: CircularProgressIndicator(),
-                              ),
-                            )
-                          : _buildScheduleRounds(),
-                    ),
-                  ],
-                  if (_errorMessage != null) ...[
-                    const SizedBox(height: 12),
-                    _buildSectionCard(
-                      title: 'エラー',
-                      child: Text(_errorMessage!),
-                    ),
-                  ],
-                  const SizedBox(height: 80),
-                ],
-              ),
+            : _buildScheduleBody(),
       ),
     );
   }

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -219,15 +219,59 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   }
 
   Future<void> _reloadSchedule() async {
-    final generatedScheduleId =
-        _generatedScheduleId ?? _savedEvent?.event.displayGeneratedScheduleId;
+    final publicId =
+        (_savedEvent?.event.publicId ?? widget.publicId).trim().toUpperCase();
+
+    if (!isValidPublicId(publicId)) {
+      _showMessage('共有URLが正しくありません');
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final aggregate = await appEventRepository.findByPublicId(publicId);
+      if (!mounted) return;
+
+      if (aggregate == null) {
+        setState(() {
+          _savedEvent = null;
+          _scheduleResponse = null;
+          _generatedScheduleId = null;
+          _errorMessage = '対戦表が見つかりません';
+          _isLoading = false;
+        });
+        return;
+      }
+
+      final generatedScheduleId = aggregate.event.displayGeneratedScheduleId;
+
+      setState(() {
+        _savedEvent = aggregate;
+        _generatedScheduleId = generatedScheduleId;
+      });
 
       if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
-      _showMessage('再取得する generated_schedule_id がありません');
+        setState(() {
+          _scheduleResponse = null;
+          _errorMessage = 'まだ対戦表が生成されていません';
+          _isLoading = false;
+        });
         return;
       }
 
       await _fetchSchedule(generatedScheduleId);
+    } catch (e) {
+      if (!mounted) return;
+
+      setState(() {
+        _errorMessage = '共有情報を再取得できませんでした: $e';
+        _isLoading = false;
+      });
+    }
   }
 
   Future<void> _generateSchedule() async {

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -569,7 +569,6 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           if (!_hasAdoptedSchedule) ...[
             const SizedBox(height: 12),
             ScheduleSectionCard(
-              title: '操作',
               child: ScheduleActionButtons(
                 isLoading: _isLoading,
                 isAdopting: _isAdopting,

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -555,33 +555,32 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           )
         else ...[
           ScheduleEventSummaryCard(
-            eventName: savedEvent.event.title,
             courtCount: savedEvent.event.courtCount,
             participantCount: savedEvent.participants.length,
-            publicId: savedEvent.event.publicId,
             statusLabel: _eventStatusLabel,
             onCopyShareUrl: _copyShareUrl,
+            onRefresh: _reloadSchedule,
+            canRefresh: _generatedScheduleId != null,
           ),
           const SizedBox(height: 12),
           ScheduleParticipantsCard(
             participants: _participantViewModels,
           ),
-          const SizedBox(height: 12),
-          ScheduleSectionCard(
-            title: '操作',
-            child: ScheduleActionButtons(
-              hasAdoptedSchedule: _hasAdoptedSchedule,
-              isLoading: _isLoading,
-              isAdopting: _isAdopting,
-              generateButtonLabel: _generateButtonLabel,
-              canReload: _generatedScheduleId != null,
-              canAdopt:
-                  _generatedScheduleId != null && _scheduleResponse != null,
-              onGenerate: _requestGenerateSchedule,
-              onReload: _reloadSchedule,
-              onAdopt: _adoptSchedule,
+          if (!_hasAdoptedSchedule) ...[
+            const SizedBox(height: 12),
+            ScheduleSectionCard(
+              title: '操作',
+              child: ScheduleActionButtons(
+                isLoading: _isLoading,
+                isAdopting: _isAdopting,
+                generateButtonLabel: _generateButtonLabel,
+                canAdopt:
+                    _generatedScheduleId != null && _scheduleResponse != null,
+                onGenerate: _requestGenerateSchedule,
+                onAdopt: _adoptSchedule,
+              ),
             ),
-          ),
+          ],
           const SizedBox(height: 12),
           ScheduleSectionCard(
             title: '対戦表',

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -97,6 +97,13 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         : '再生成';
   }
 
+  bool get _hasGeneratedSchedule {
+    final generatedScheduleId =
+        _savedEvent?.event.displayGeneratedScheduleId ?? _generatedScheduleId;
+
+    return generatedScheduleId != null && generatedScheduleId.isNotEmpty;
+  }
+
   List<SavedEventParticipant> get _orderedParticipants {
     final participants = _savedEvent?.participants.toList() ?? const [];
     if (participants.isEmpty) return const [];
@@ -119,6 +126,40 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         displayName: participant.displayName,
       );
     }).toList(growable: false);
+  }
+
+  Future<void> _requestGenerateSchedule() async {
+    if (!_hasGeneratedSchedule) {
+      await _generateSchedule();
+      return;
+    }
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('再生成しますか？'),
+          content: const Text(
+            '現在表示している対戦表を新しい対戦表に差し替えます。\n'
+            '共有URLから表示される未採用の対戦表も、再生成後の内容に更新されます。',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('キャンセル'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('再生成する'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (!mounted || confirmed != true) return;
+
+    await _generateSchedule();
   }
 
   Future<void> _restore() async {
@@ -468,7 +509,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
               canReload: _generatedScheduleId != null,
               canAdopt:
                   _generatedScheduleId != null && _scheduleResponse != null,
-              onGenerate: _generateSchedule,
+              onGenerate: _requestGenerateSchedule,
               onReload: _reloadSchedule,
               onAdopt: _adoptSchedule,
             ),

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -129,6 +129,15 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   }
 
   Future<void> _requestGenerateSchedule() async {
+    final latestEvent = await _refreshSavedEventForAction();
+    if (!mounted) return;
+
+    if (latestEvent?.event.hasAdoptedSchedule == true) {
+      _showMessage('採用済みのため再生成できません');
+      await _reloadSchedule();
+      return;
+    }
+
     if (!_hasGeneratedSchedule) {
       await _generateSchedule();
       return;
@@ -159,7 +168,48 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
 
     if (!mounted || confirmed != true) return;
 
+    final latestBeforeGenerate = await _refreshSavedEventForAction();
+    if (!mounted) return;
+
+    if (latestBeforeGenerate?.event.hasAdoptedSchedule == true) {
+      _showMessage('採用済みのため再生成できません');
+      await _reloadSchedule();
+      return;
+    }
+
     await _generateSchedule();
+  }
+
+  Future<SavedEventAggregate?> _refreshSavedEventForAction() async {
+    final publicId =
+        (_savedEvent?.event.publicId ?? widget.publicId).trim().toUpperCase();
+
+    if (!isValidPublicId(publicId)) {
+      setState(() {
+        _errorMessage = '共有URLが正しくありません';
+      });
+      return null;
+    }
+
+    final aggregate = await appEventRepository.findByPublicId(publicId);
+    if (!mounted) return null;
+
+    if (aggregate == null) {
+      setState(() {
+        _savedEvent = null;
+        _scheduleResponse = null;
+        _generatedScheduleId = null;
+        _errorMessage = '対戦表が見つかりません';
+      });
+      return null;
+    }
+
+    setState(() {
+      _savedEvent = aggregate;
+      _generatedScheduleId = aggregate.event.displayGeneratedScheduleId;
+    });
+
+    return aggregate;
   }
 
   Future<void> _restore() async {
@@ -369,6 +419,29 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   }
 
   Future<void> _adoptSchedule() async {
+    final latestEvent = await _refreshSavedEventForAction();
+    if (!mounted) return;
+
+    if (latestEvent == null) {
+      _showMessage('採用するイベント情報がありません');
+      return;
+    }
+
+    if (latestEvent.event.hasAdoptedSchedule) {
+      _showMessage('すでに採用済みです');
+      await _reloadSchedule();
+      return;
+    }
+
+    final latestCurrentGeneratedScheduleId =
+        latestEvent.event.currentGeneratedScheduleId;
+
+    if (latestCurrentGeneratedScheduleId != _generatedScheduleId) {
+      _showMessage('対戦表が更新されています。最新の対戦表を再取得します');
+      await _reloadSchedule();
+      return;
+    }
+
     final savedEvent = _savedEvent;
     final generatedScheduleId = _generatedScheduleId;
 
@@ -378,7 +451,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     }
 
     if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
-      _showMessage('採用する generated_schedule_id がありません');
+      _showMessage('採用するイベント情報がありません');
       return;
     }
 

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -444,11 +444,9 @@ class _SchedulePageState extends State<SchedulePage> {
 
   Widget _buildScheduleBody() {
     return ListView(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(4),
       children: [
         ScheduleEventSummaryCard(
-          courtCount: widget.draft.courts,
-          participantCount: widget.draft.players,
           statusLabel: _eventStatusLabel,
           onCopyShareUrl: _savedEvent == null ? null : _copyShareUrl,
           onRefresh: _reloadSchedule,
@@ -456,6 +454,8 @@ class _SchedulePageState extends State<SchedulePage> {
         ),
         const SizedBox(height: 12),
         ScheduleParticipantsCard(
+          title:
+              '面数: ${widget.draft.courts}　　参加者: ${widget.draft.participants.length}人',
           participants: _participantViewModels,
         ),
         const SizedBox(height: 12),
@@ -480,13 +480,14 @@ class _SchedulePageState extends State<SchedulePage> {
           child: _isLoading
               ? const Center(
                   child: Padding(
-                    padding: EdgeInsets.all(16),
+                    padding: EdgeInsets.all(4),
                     child: CircularProgressIndicator(),
                   ),
                 )
               : ScheduleRoundsView(
                   scheduleResponse: _scheduleResponse,
                   playerNameById: _playerNameById,
+                  courtCount: widget.draft.courts,
                 ),
         ),
         if (_errorMessage != null) ...[

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -358,32 +358,11 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   Future<void> _adoptSchedule() async {
-    final latestEvent = await _refreshSavedEventForAction();
-    if (!mounted) return;
+    final displayedGeneratedScheduleId = _generatedScheduleId;
 
-    if (latestEvent == null) {
-      _showMessage('採用するイベント情報がありません');
-      return;
-    }
-
-    if (latestEvent.event.hasAdoptedSchedule) {
-      _showMessage('すでに採用済みです');
-      await _reloadSchedule();
-      return;
-    }
-
-    final latestCurrentGeneratedScheduleId =
-        latestEvent.event.currentGeneratedScheduleId;
-
-    if (latestCurrentGeneratedScheduleId != _generatedScheduleId) {
-      _showMessage('対戦表が更新されています。最新の対戦表を再取得します');
-      await _reloadSchedule();
-      return;
-    }
-
-    final generatedScheduleId = _generatedScheduleId;
-    if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
-      _showMessage('採用するイベント情報がありません');
+    if (displayedGeneratedScheduleId == null ||
+        displayedGeneratedScheduleId.isEmpty) {
+      _showMessage('採用する generated_schedule_id がありません');
       return;
     }
 
@@ -395,20 +374,41 @@ class _SchedulePageState extends State<SchedulePage> {
     });
 
     try {
-      final savedEvent = await _ensureSavedEvent();
+      final latestEvent = await _refreshSavedEventForAction();
+      if (!mounted) return;
 
-      await _service.adopt(generatedScheduleId);
+      if (latestEvent == null) {
+        _showMessage('採用するイベント情報がありません');
+        return;
+      }
+
+      if (latestEvent.event.hasAdoptedSchedule) {
+        _showMessage('すでに採用済みです');
+        await _reloadSchedule();
+        return;
+      }
+
+      final latestCurrentGeneratedScheduleId =
+          latestEvent.event.currentGeneratedScheduleId;
+
+      if (latestCurrentGeneratedScheduleId != displayedGeneratedScheduleId) {
+        _showMessage('対戦表が更新されています。最新の対戦表を再取得します');
+        await _reloadSchedule();
+        return;
+      }
+
+      await _service.adopt(displayedGeneratedScheduleId);
 
       final updatedEvent =
           await appEventRepository.updateAdoptedGeneratedScheduleId(
-        eventId: savedEvent.event.id,
-        generatedScheduleId: generatedScheduleId,
+        eventId: latestEvent.event.id,
+        generatedScheduleId: displayedGeneratedScheduleId,
       );
 
       if (!mounted) return;
 
       setState(() {
-        _savedEvent = _replaceSavedEvent(savedEvent, updatedEvent);
+        _savedEvent = _replaceSavedEvent(latestEvent, updatedEvent);
       });
 
       _showMessage('採用しました');

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -447,32 +447,33 @@ class _SchedulePageState extends State<SchedulePage> {
       padding: const EdgeInsets.all(16),
       children: [
         ScheduleEventSummaryCard(
-          eventName: widget.draft.eventName,
           courtCount: widget.draft.courts,
           participantCount: widget.draft.players,
-          publicId: _savedEvent?.event.publicId,
           statusLabel: _eventStatusLabel,
           onCopyShareUrl: _savedEvent == null ? null : _copyShareUrl,
+          onRefresh: _reloadSchedule,
+          canRefresh: _generatedScheduleId != null,
         ),
         const SizedBox(height: 12),
         ScheduleParticipantsCard(
           participants: _participantViewModels,
         ),
         const SizedBox(height: 12),
-        ScheduleSectionCard(
-          title: '操作',
-          child: ScheduleActionButtons(
-            hasAdoptedSchedule: _hasAdoptedSchedule,
-            isLoading: _isLoading,
-            isAdopting: _isAdopting,
-            generateButtonLabel: _generateButtonLabel,
-            canReload: _generatedScheduleId != null,
-            canAdopt: _generatedScheduleId != null && _scheduleResponse != null,
-            onGenerate: _requestGenerateSchedule,
-            onReload: _reloadSchedule,
-            onAdopt: _adoptSchedule,
+        if (!_hasAdoptedSchedule) ...[
+          const SizedBox(height: 12),
+          ScheduleSectionCard(
+            title: '操作',
+            child: ScheduleActionButtons(
+              isLoading: _isLoading,
+              isAdopting: _isAdopting,
+              generateButtonLabel: _generateButtonLabel,
+              canAdopt:
+                  _generatedScheduleId != null && _scheduleResponse != null,
+              onGenerate: _requestGenerateSchedule,
+              onAdopt: _adoptSchedule,
+            ),
           ),
-        ),
+        ],
         const SizedBox(height: 12),
         ScheduleSectionCard(
           title: '対戦表',

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -6,8 +6,13 @@ import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 import '../application/generated_schedule_service.dart';
 import '../domain/saved_event_models.dart';
 import '../infrastructure/generated_schedule_api_client.dart';
-import 'models/event_draft.dart';
 import 'event_list_page.dart';
+import 'models/event_draft.dart';
+import 'widgets/schedule_action_buttons.dart';
+import 'widgets/schedule_event_summary_card.dart';
+import 'widgets/schedule_participants_card.dart';
+import 'widgets/schedule_rounds_view.dart';
+import 'widgets/schedule_section_card.dart';
 
 class SchedulePage extends StatefulWidget {
   const SchedulePage({super.key, required this.draft});
@@ -25,16 +30,82 @@ class _SchedulePageState extends State<SchedulePage> {
 
   bool _isLoading = true;
   bool _isAdopting = false;
-
-  bool get _hasAdoptedSchedule {
-    return _isAdopted || (_savedEvent?.event.hasAdoptedSchedule ?? false);
-  }
-
   String? _errorMessage;
   String? _generatedScheduleId;
   Map<String, dynamic>? _scheduleResponse;
 
   SavedEventAggregate? _savedEvent;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _service = GeneratedScheduleService(
+      GeneratedScheduleApiClient(
+        baseUrl: AppConfig.coreApiBaseUrl,
+      ),
+    );
+
+    _generateSchedule();
+  }
+
+  bool get _isAdopted => _scheduleResponse?['adopted'] == true;
+
+  bool get _hasAdoptedSchedule {
+    return _isAdopted || (_savedEvent?.event.hasAdoptedSchedule ?? false);
+  }
+
+  String get _eventStatusLabel {
+    if (_hasAdoptedSchedule) {
+      return '採用済み';
+    }
+
+    if (_isLoading && _scheduleResponse == null) {
+      return '生成中';
+    }
+
+    if (_errorMessage != null && _scheduleResponse == null) {
+      return '生成失敗';
+    }
+
+    final generatedScheduleId =
+        _savedEvent?.event.displayGeneratedScheduleId ?? _generatedScheduleId;
+
+    if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
+      return '未生成';
+    }
+
+    if (_isLoading) {
+      return '処理中';
+    }
+
+    return '生成済み';
+  }
+
+  String get _generateButtonLabel {
+    final generatedScheduleId =
+        _savedEvent?.event.displayGeneratedScheduleId ?? _generatedScheduleId;
+
+    return generatedScheduleId == null || generatedScheduleId.isEmpty
+        ? '生成'
+        : '再生成';
+  }
+
+  Map<String, String> get _playerNameById {
+    return {
+      for (final participant in widget.draft.participants)
+        participant.id: participant.displayName,
+    };
+  }
+
+  List<ScheduleParticipantViewModel> get _participantViewModels {
+    return widget.draft.participants.asMap().entries.map((entry) {
+      return ScheduleParticipantViewModel(
+        orderNo: entry.key + 1,
+        displayName: entry.value.displayName,
+      );
+    }).toList(growable: false);
+  }
 
   Future<SavedEventAggregate> _ensureSavedEvent() async {
     final existing = _savedEvent;
@@ -80,28 +151,6 @@ class _SchedulePageState extends State<SchedulePage> {
     _showMessage('共有URLをコピーしました');
   }
 
-  @override
-  void initState() {
-    super.initState();
-
-    _service = GeneratedScheduleService(
-      GeneratedScheduleApiClient(
-        baseUrl: AppConfig.coreApiBaseUrl,
-      ),
-    );
-
-    _generateSchedule();
-  }
-
-  bool get _isAdopted => _scheduleResponse?['adopted'] == true;
-
-  Map<String, String> get _playerNameById {
-    return {
-      for (final participant in widget.draft.participants)
-        participant.id: participant.displayName,
-    };
-  }
-
   void _showMessage(String message) {
     final messenger = ScaffoldMessenger.of(context);
     messenger.hideCurrentSnackBar();
@@ -114,6 +163,11 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   Future<void> _generateSchedule() async {
+    if (_hasAdoptedSchedule) {
+      _showMessage('採用済みのため再生成できません');
+      return;
+    }
+
     setState(() {
       _isLoading = true;
       _errorMessage = null;
@@ -148,7 +202,7 @@ class _SchedulePageState extends State<SchedulePage> {
       if (!mounted) return;
 
       setState(() {
-        _errorMessage = e.toString();
+        _errorMessage = '対戦表を生成できませんでした: $e';
       });
     } finally {
       if (mounted) {
@@ -202,7 +256,7 @@ class _SchedulePageState extends State<SchedulePage> {
       return;
     }
 
-    if (_isAdopting) return;
+    if (_isAdopting || _hasAdoptedSchedule) return;
 
     setState(() {
       _isAdopting = true;
@@ -232,7 +286,7 @@ class _SchedulePageState extends State<SchedulePage> {
       if (!mounted) return;
 
       setState(() {
-        _errorMessage = e.toString();
+        _errorMessage = '対戦表を採用できませんでした: $e';
       });
     } finally {
       if (mounted) {
@@ -257,239 +311,68 @@ class _SchedulePageState extends State<SchedulePage> {
     }
   }
 
-  List<Map<String, dynamic>> _asObjectList(Object? value) {
-    if (value is! List) return const [];
-
-    return value
-        .whereType<Map>()
-        .map((e) => e.map((key, value) => MapEntry(key.toString(), value)))
-        .toList(growable: false);
-  }
-
-  List<int> _asIntList(Object? value) {
-    if (value is! List) return const [];
-
-    return value
-        .map((e) {
-          if (e is int) return e;
-          return int.tryParse(e.toString());
-        })
-        .whereType<int>()
-        .toList(growable: false);
-  }
-
-  Map<int, String> _buildSlotToPlayerId() {
-    final assignment = _asObjectList(_scheduleResponse?['assignment']);
-
-    return {
-      for (final row in assignment)
-        if (row['slot_number'] != null && row['player_id'] != null)
-          int.parse(row['slot_number'].toString()): row['player_id'].toString(),
-    };
-  }
-
-  String _playerLabelFromId(String playerId) {
-    return _playerNameById[playerId] ?? playerId;
-  }
-
-  String _playerLabelFromSlot(int slotNumber, Map<int, String> slotToPlayerId) {
-    final playerId = slotToPlayerId[slotNumber];
-    if (playerId == null) return 'slot:$slotNumber';
-    return _playerLabelFromId(playerId);
-  }
-
-  String _formatTeamFromSlots(
-      List<int> slots, Map<int, String> slotToPlayerId) {
-    if (slots.isEmpty) return '-';
-
-    return slots
-        .map((slot) => '$slot: ${_playerLabelFromSlot(slot, slotToPlayerId)}')
-        .join(' / ');
-  }
-
-  String _formatRestPlayersBySlots(
-      List<int> slotNumbers, Map<int, String> slotToPlayerId) {
-    if (slotNumbers.isEmpty) return '-';
-
-    return slotNumbers
-        .map((slot) => '$slot: ${_playerLabelFromSlot(slot, slotToPlayerId)}')
-        .join(' / ');
-  }
-
-  Widget _buildSectionCard({
-    required String title,
-    required Widget child,
-  }) {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              title,
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 16,
-              ),
-            ),
-            const SizedBox(height: 12),
-            child,
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildSummaryCard() {
-    return _buildSectionCard(
-      title: '入力内容',
-      child: Wrap(
-        spacing: 16,
-        runSpacing: 8,
-        children: [
-          Text('イベント名: ${widget.draft.eventName}'),
-          Text('面数: ${widget.draft.courts}'),
-          Text('人数: ${widget.draft.players}'),
-          if (_savedEvent != null) Text('共有ID: ${_savedEvent!.event.publicId}'),
-          if (_savedEvent != null)
-            OutlinedButton.icon(
-              onPressed: _copyShareUrl,
-              icon: const Icon(Icons.copy),
-              label: const Text('共有URLをコピー'),
-            ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildPlayersCard() {
-    return _buildSectionCard(
-      title: '参加者',
-      child: Wrap(
-        spacing: 6,
-        runSpacing: 6,
-        children: widget.draft.participants.asMap().entries.map((entry) {
-          final index = entry.key;
-          final participant = entry.value;
-
-          return Chip(
-            label: Text('${index + 1}: ${participant.displayName}'),
-          );
-        }).toList(),
-      ),
-    );
-  }
-
-  Widget _buildActionButtons() {
-    return Wrap(
-      spacing: 12,
-      runSpacing: 12,
+  Widget _buildScheduleBody() {
+    return ListView(
+      padding: const EdgeInsets.all(16),
       children: [
-        FilledButton.icon(
-          onPressed:
-              (_isLoading || _hasAdoptedSchedule) ? null : _generateSchedule,
-          icon: const Icon(Icons.refresh),
-          label: const Text('再生成'),
+        ScheduleEventSummaryCard(
+          eventName: widget.draft.eventName,
+          courtCount: widget.draft.courts,
+          participantCount: widget.draft.players,
+          publicId: _savedEvent?.event.publicId,
+          statusLabel: _eventStatusLabel,
+          onCopyShareUrl: _savedEvent == null ? null : _copyShareUrl,
         ),
-        FilledButton.tonalIcon(
-          onPressed: (_isLoading || _generatedScheduleId == null)
-              ? null
-              : _reloadSchedule,
-          icon: const Icon(Icons.download),
-          label: const Text('再取得'),
+        const SizedBox(height: 12),
+        ScheduleParticipantsCard(
+          participants: _participantViewModels,
         ),
-        FilledButton(
-          onPressed: (_isLoading ||
-                  _isAdopting ||
-                  _generatedScheduleId == null ||
-                  _hasAdoptedSchedule)
-              ? null
-              : _adoptSchedule,
-          child: _isAdopting
-              ? const SizedBox(
-                  width: 18,
-                  height: 18,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
-              : const Text('採用'),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildScheduleRounds() {
-    final rounds = _asObjectList(_scheduleResponse?['rounds']);
-    final slotToPlayerId = _buildSlotToPlayerId();
-
-    if (rounds.isEmpty) {
-      return const Text('対戦表データがありません');
-    }
-
-    return Column(
-      children: rounds.map((round) {
-        final roundNumber = round['round_number']?.toString() ?? '-';
-        final restSlotNumbers = _asIntList(round['rest_slot_numbers']);
-        final courts = _asObjectList(round['courts']);
-
-        return Card(
-          margin: const EdgeInsets.only(bottom: 12),
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  '第$roundNumber試合',
-                  style: const TextStyle(
-                    fontWeight: FontWeight.bold,
-                    fontSize: 18,
-                  ),
-                ),
-                const SizedBox(height: 12),
-                ...courts.map((court) {
-                  final courtNumber = court['court_number']?.toString() ?? '-';
-                  final team1Slots = _asIntList(court['team1_player_slots']);
-                  final team2Slots = _asIntList(court['team2_player_slots']);
-
-                  return Padding(
-                    padding: const EdgeInsets.only(bottom: 12),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'コート$courtNumber',
-                          style: const TextStyle(
-                            fontWeight: FontWeight.bold,
-                            fontSize: 14,
-                          ),
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          '${_formatTeamFromSlots(team1Slots, slotToPlayerId)}  vs  ${_formatTeamFromSlots(team2Slots, slotToPlayerId)}',
-                        ),
-                        // const SizedBox(height: 2),
-                        // Text(
-                        //   '${team1Slots.join(" / ")}  vs  ${team2Slots.join(" / ")}',
-                        //   style: Theme.of(context).textTheme.bodySmall,
-                        // ),
-                      ],
-                    ),
-                  );
-                }),
-                const Divider(),
-                Text(
-                    '休憩: ${_formatRestPlayersBySlots(restSlotNumbers, slotToPlayerId)}'),
-              ],
-            ),
+        const SizedBox(height: 12),
+        ScheduleSectionCard(
+          title: '操作',
+          child: ScheduleActionButtons(
+            hasAdoptedSchedule: _hasAdoptedSchedule,
+            isLoading: _isLoading,
+            isAdopting: _isAdopting,
+            generateButtonLabel: _generateButtonLabel,
+            canReload: _generatedScheduleId != null,
+            canAdopt: _generatedScheduleId != null && _scheduleResponse != null,
+            onGenerate: _generateSchedule,
+            onReload: _reloadSchedule,
+            onAdopt: _adoptSchedule,
           ),
-        );
-      }).toList(growable: false),
+        ),
+        const SizedBox(height: 12),
+        ScheduleSectionCard(
+          title: '対戦表',
+          child: _isLoading
+              ? const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(16),
+                    child: CircularProgressIndicator(),
+                  ),
+                )
+              : ScheduleRoundsView(
+                  scheduleResponse: _scheduleResponse,
+                  playerNameById: _playerNameById,
+                ),
+        ),
+        if (_errorMessage != null) ...[
+          const SizedBox(height: 12),
+          ScheduleSectionCard(
+            title: 'エラー',
+            child: Text(_errorMessage!),
+          ),
+        ],
+        const SizedBox(height: 80),
+      ],
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    final showInitialLoading = _isLoading && _scheduleResponse == null;
+
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.draft.eventName),
@@ -510,36 +393,11 @@ class _SchedulePageState extends State<SchedulePage> {
         ],
       ),
       body: SafeArea(
-        child: _isLoading && _scheduleResponse == null
+        child: showInitialLoading
             ? const Center(
                 child: CircularProgressIndicator(),
               )
-            : ListView(
-                padding: const EdgeInsets.all(16),
-                children: [
-                  _buildSummaryCard(),
-                  const SizedBox(height: 12),
-                  _buildPlayersCard(),
-                  const SizedBox(height: 12),
-                  _buildSectionCard(
-                    title: '操作',
-                    child: _buildActionButtons(),
-                  ),
-                  const SizedBox(height: 12),
-                  _buildSectionCard(
-                    title: '対戦表',
-                    child: _buildScheduleRounds(),
-                  ),
-                  if (_errorMessage != null) ...[
-                    const SizedBox(height: 12),
-                    _buildSectionCard(
-                      title: 'エラー',
-                      child: Text(_errorMessage!),
-                    ),
-                  ],
-                  const SizedBox(height: 80),
-                ],
-              ),
+            : _buildScheduleBody(),
       ),
     );
   }

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -461,7 +461,6 @@ class _SchedulePageState extends State<SchedulePage> {
         if (!_hasAdoptedSchedule) ...[
           const SizedBox(height: 12),
           ScheduleSectionCard(
-            title: '操作',
             child: ScheduleActionButtons(
               isLoading: _isLoading,
               isAdopting: _isAdopting,

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -214,18 +214,41 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   Future<void> _reloadSchedule() async {
-    final generatedScheduleId = _generatedScheduleId;
-    if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
-      _showMessage('再取得する generated_schedule_id がありません');
-      return;
-    }
-
     setState(() {
       _isLoading = true;
       _errorMessage = null;
     });
 
     try {
+      var generatedScheduleId = _generatedScheduleId;
+
+      final savedEvent = _savedEvent;
+      if (savedEvent != null) {
+        final aggregate =
+            await appEventRepository.findByPublicId(savedEvent.event.publicId);
+        if (!mounted) return;
+
+        if (aggregate != null) {
+          generatedScheduleId = aggregate.event.displayGeneratedScheduleId;
+
+          setState(() {
+            _savedEvent = aggregate;
+            _generatedScheduleId = generatedScheduleId;
+          });
+        }
+      }
+
+      if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
+        if (!mounted) return;
+
+        setState(() {
+          _scheduleResponse = null;
+          _errorMessage = '再取得する generated_schedule_id がありません';
+          _isLoading = false;
+        });
+        return;
+      }
+
       final response = await _service.getById(generatedScheduleId);
       if (!mounted) return;
 
@@ -238,7 +261,7 @@ class _SchedulePageState extends State<SchedulePage> {
       if (!mounted) return;
 
       setState(() {
-        _errorMessage = e.toString();
+        _errorMessage = '対戦表を取得できませんでした: $e';
       });
     } finally {
       if (mounted) {

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -458,7 +458,6 @@ class _SchedulePageState extends State<SchedulePage> {
               '面数: ${widget.draft.courts}　　参加者: ${widget.draft.participants.length}人',
           participants: _participantViewModels,
         ),
-        const SizedBox(height: 12),
         if (!_hasAdoptedSchedule) ...[
           const SizedBox(height: 12),
           ScheduleSectionCard(

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -392,7 +392,7 @@ class _SchedulePageState extends State<SchedulePage> {
           latestEvent.event.currentGeneratedScheduleId;
 
       if (latestCurrentGeneratedScheduleId != displayedGeneratedScheduleId) {
-        _showMessage('対戦表が更新されています。最新の対戦表を再取得します');
+        _showMessage('対戦表が更新されています。最新の情報に更新します');
         await _reloadSchedule();
         return;
       }
@@ -411,7 +411,7 @@ class _SchedulePageState extends State<SchedulePage> {
         _savedEvent = _replaceSavedEvent(latestEvent, updatedEvent);
       });
 
-      _showMessage('採用しました');
+      _showMessage('この対戦表を採用しました');
       await _reloadSchedule();
     } catch (e) {
       if (!mounted) return;

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -115,6 +115,15 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   Future<void> _requestGenerateSchedule() async {
+    final latestEvent = await _refreshSavedEventForAction();
+    if (!mounted) return;
+
+    if (latestEvent?.event.hasAdoptedSchedule == true) {
+      _showMessage('採用済みのため再生成できません');
+      await _reloadSchedule();
+      return;
+    }
+
     if (!_hasGeneratedSchedule) {
       await _generateSchedule();
       return;
@@ -145,7 +154,42 @@ class _SchedulePageState extends State<SchedulePage> {
 
     if (!mounted || confirmed != true) return;
 
+    final latestBeforeGenerate = await _refreshSavedEventForAction();
+    if (!mounted) return;
+
+    if (latestBeforeGenerate?.event.hasAdoptedSchedule == true) {
+      _showMessage('採用済みのため再生成できません');
+      await _reloadSchedule();
+      return;
+    }
+
     await _generateSchedule();
+  }
+
+  Future<SavedEventAggregate?> _refreshSavedEventForAction() async {
+    final savedEvent = _savedEvent;
+    if (savedEvent == null) return null;
+
+    final aggregate =
+        await appEventRepository.findByPublicId(savedEvent.event.publicId);
+    if (!mounted) return null;
+
+    if (aggregate == null) {
+      setState(() {
+        _savedEvent = null;
+        _scheduleResponse = null;
+        _generatedScheduleId = null;
+        _errorMessage = '対戦表が見つかりません';
+      });
+      return null;
+    }
+
+    setState(() {
+      _savedEvent = aggregate;
+      _generatedScheduleId = aggregate.event.displayGeneratedScheduleId;
+    });
+
+    return aggregate;
   }
 
   Future<SavedEventAggregate> _ensureSavedEvent() async {
@@ -314,9 +358,32 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   Future<void> _adoptSchedule() async {
+    final latestEvent = await _refreshSavedEventForAction();
+    if (!mounted) return;
+
+    if (latestEvent == null) {
+      _showMessage('採用するイベント情報がありません');
+      return;
+    }
+
+    if (latestEvent.event.hasAdoptedSchedule) {
+      _showMessage('すでに採用済みです');
+      await _reloadSchedule();
+      return;
+    }
+
+    final latestCurrentGeneratedScheduleId =
+        latestEvent.event.currentGeneratedScheduleId;
+
+    if (latestCurrentGeneratedScheduleId != _generatedScheduleId) {
+      _showMessage('対戦表が更新されています。最新の対戦表を再取得します');
+      await _reloadSchedule();
+      return;
+    }
+
     final generatedScheduleId = _generatedScheduleId;
     if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
-      _showMessage('採用する generated_schedule_id がありません');
+      _showMessage('採用するイベント情報がありません');
       return;
     }
 

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -91,6 +91,13 @@ class _SchedulePageState extends State<SchedulePage> {
         : '再生成';
   }
 
+  bool get _hasGeneratedSchedule {
+    final generatedScheduleId =
+        _savedEvent?.event.displayGeneratedScheduleId ?? _generatedScheduleId;
+
+    return generatedScheduleId != null && generatedScheduleId.isNotEmpty;
+  }
+
   Map<String, String> get _playerNameById {
     return {
       for (final participant in widget.draft.participants)
@@ -105,6 +112,40 @@ class _SchedulePageState extends State<SchedulePage> {
         displayName: entry.value.displayName,
       );
     }).toList(growable: false);
+  }
+
+  Future<void> _requestGenerateSchedule() async {
+    if (!_hasGeneratedSchedule) {
+      await _generateSchedule();
+      return;
+    }
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('再生成しますか？'),
+          content: const Text(
+            '現在表示している対戦表を新しい対戦表に差し替えます。\n'
+            '共有URLから表示される未採用の対戦表も、再生成後の内容に更新されます。',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('キャンセル'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('再生成する'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (!mounted || confirmed != true) return;
+
+    await _generateSchedule();
   }
 
   Future<SavedEventAggregate> _ensureSavedEvent() async {
@@ -360,7 +401,7 @@ class _SchedulePageState extends State<SchedulePage> {
             generateButtonLabel: _generateButtonLabel,
             canReload: _generatedScheduleId != null,
             canAdopt: _generatedScheduleId != null && _scheduleResponse != null,
-            onGenerate: _generateSchedule,
+            onGenerate: _requestGenerateSchedule,
             onReload: _reloadSchedule,
             onAdopt: _adoptSchedule,
           ),

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_action_buttons.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_action_buttons.dart
@@ -3,48 +3,23 @@ import 'package:flutter/material.dart';
 class ScheduleActionButtons extends StatelessWidget {
   const ScheduleActionButtons({
     super.key,
-    required this.hasAdoptedSchedule,
     required this.isLoading,
     required this.isAdopting,
     required this.generateButtonLabel,
-    required this.canReload,
     required this.canAdopt,
     required this.onGenerate,
-    required this.onReload,
     required this.onAdopt,
   });
 
-  final bool hasAdoptedSchedule;
   final bool isLoading;
   final bool isAdopting;
   final String generateButtonLabel;
-  final bool canReload;
   final bool canAdopt;
   final VoidCallback? onGenerate;
-  final VoidCallback? onReload;
   final VoidCallback? onAdopt;
 
   @override
   Widget build(BuildContext context) {
-    if (hasAdoptedSchedule) {
-      return Wrap(
-        spacing: 12,
-        runSpacing: 12,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: [
-          const Chip(
-            avatar: Icon(Icons.check),
-            label: Text('採用済み'),
-          ),
-          FilledButton.tonalIcon(
-            onPressed: isLoading ? null : onReload,
-            icon: const Icon(Icons.sync),
-            label: const Text('最新の情報に更新'),
-          ),
-        ],
-      );
-    }
-
     return Wrap(
       spacing: 12,
       runSpacing: 12,
@@ -53,11 +28,6 @@ class ScheduleActionButtons extends StatelessWidget {
           onPressed: isLoading ? null : onGenerate,
           icon: const Icon(Icons.refresh),
           label: Text(generateButtonLabel),
-        ),
-        FilledButton.tonalIcon(
-          onPressed: (isLoading || !canReload) ? null : onReload,
-          icon: const Icon(Icons.sync),
-          label: const Text('最新の情報に更新'),
         ),
         FilledButton.icon(
           onPressed: (isLoading || isAdopting || !canAdopt) ? null : onAdopt,

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_action_buttons.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_action_buttons.dart
@@ -38,8 +38,8 @@ class ScheduleActionButtons extends StatelessWidget {
           ),
           FilledButton.tonalIcon(
             onPressed: isLoading ? null : onReload,
-            icon: const Icon(Icons.download),
-            label: const Text('再取得'),
+            icon: const Icon(Icons.sync),
+            label: const Text('最新の情報に更新'),
           ),
         ],
       );
@@ -56,18 +56,19 @@ class ScheduleActionButtons extends StatelessWidget {
         ),
         FilledButton.tonalIcon(
           onPressed: (isLoading || !canReload) ? null : onReload,
-          icon: const Icon(Icons.download),
-          label: const Text('再取得'),
+          icon: const Icon(Icons.sync),
+          label: const Text('最新の情報に更新'),
         ),
-        FilledButton(
+        FilledButton.icon(
           onPressed: (isLoading || isAdopting || !canAdopt) ? null : onAdopt,
-          child: isAdopting
+          icon: isAdopting
               ? const SizedBox(
                   width: 18,
                   height: 18,
                   child: CircularProgressIndicator(strokeWidth: 2),
                 )
-              : const Text('採用'),
+              : const Icon(Icons.check),
+          label: Text(isAdopting ? '採用中' : 'この対戦表を採用'),
         ),
       ],
     );

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_action_buttons.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_action_buttons.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+class ScheduleActionButtons extends StatelessWidget {
+  const ScheduleActionButtons({
+    super.key,
+    required this.hasAdoptedSchedule,
+    required this.isLoading,
+    required this.isAdopting,
+    required this.generateButtonLabel,
+    required this.canReload,
+    required this.canAdopt,
+    required this.onGenerate,
+    required this.onReload,
+    required this.onAdopt,
+  });
+
+  final bool hasAdoptedSchedule;
+  final bool isLoading;
+  final bool isAdopting;
+  final String generateButtonLabel;
+  final bool canReload;
+  final bool canAdopt;
+  final VoidCallback? onGenerate;
+  final VoidCallback? onReload;
+  final VoidCallback? onAdopt;
+
+  @override
+  Widget build(BuildContext context) {
+    if (hasAdoptedSchedule) {
+      return Wrap(
+        spacing: 12,
+        runSpacing: 12,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          const Chip(
+            avatar: Icon(Icons.check),
+            label: Text('採用済み'),
+          ),
+          FilledButton.tonalIcon(
+            onPressed: isLoading ? null : onReload,
+            icon: const Icon(Icons.download),
+            label: const Text('再取得'),
+          ),
+        ],
+      );
+    }
+
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      children: [
+        FilledButton.icon(
+          onPressed: isLoading ? null : onGenerate,
+          icon: const Icon(Icons.refresh),
+          label: Text(generateButtonLabel),
+        ),
+        FilledButton.tonalIcon(
+          onPressed: (isLoading || !canReload) ? null : onReload,
+          icon: const Icon(Icons.download),
+          label: const Text('再取得'),
+        ),
+        FilledButton(
+          onPressed: (isLoading || isAdopting || !canAdopt) ? null : onAdopt,
+          child: isAdopting
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('採用'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -24,10 +24,10 @@ class ScheduleEventSummaryCard extends StatelessWidget {
           runSpacing: 4,
           crossAxisAlignment: WrapCrossAlignment.center,
           children: [
-            // Chip(
-            //   label: Text(statusLabel, style: TextStyle(fontSize: 14)),
-            //   visualDensity: VisualDensity.compact,
-            // ),
+            Chip(
+              label: Text(statusLabel, style: TextStyle(fontSize: 14)),
+              visualDensity: VisualDensity.compact,
+            ),
             if (onCopyShareUrl != null)
               OutlinedButton.icon(
                 onPressed: onCopyShareUrl,

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -3,16 +3,12 @@ import 'package:flutter/material.dart';
 class ScheduleEventSummaryCard extends StatelessWidget {
   const ScheduleEventSummaryCard({
     super.key,
-    required this.courtCount,
-    required this.participantCount,
     required this.statusLabel,
     this.onCopyShareUrl,
     this.onRefresh,
     this.canRefresh = true,
   });
 
-  final int courtCount;
-  final int participantCount;
   final String statusLabel;
   final VoidCallback? onCopyShareUrl;
   final VoidCallback? onRefresh;
@@ -22,18 +18,16 @@ class ScheduleEventSummaryCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(4),
         child: Wrap(
-          spacing: 12,
-          runSpacing: 8,
+          spacing: 6,
+          runSpacing: 4,
           crossAxisAlignment: WrapCrossAlignment.center,
           children: [
-            Text('面数: $courtCount'),
-            Text('参加者: $participantCount人'),
-            Chip(
-              label: Text(statusLabel),
-              visualDensity: VisualDensity.compact,
-            ),
+            // Chip(
+            //   label: Text(statusLabel, style: TextStyle(fontSize: 14)),
+            //   visualDensity: VisualDensity.compact,
+            // ),
             if (onCopyShareUrl != null)
               OutlinedButton.icon(
                 onPressed: onCopyShareUrl,

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+import 'schedule_section_card.dart';
+
+class ScheduleEventSummaryCard extends StatelessWidget {
+  const ScheduleEventSummaryCard({
+    super.key,
+    required this.eventName,
+    required this.courtCount,
+    required this.participantCount,
+    required this.statusLabel,
+    this.publicId,
+    this.onCopyShareUrl,
+  });
+
+  final String eventName;
+  final int courtCount;
+  final int participantCount;
+  final String statusLabel;
+  final String? publicId;
+  final VoidCallback? onCopyShareUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final publicId = this.publicId;
+
+    return ScheduleSectionCard(
+      title: 'イベント情報',
+      child: Wrap(
+        spacing: 16,
+        runSpacing: 8,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          Text('イベント名: $eventName'),
+          Text('面数: $courtCount'),
+          Text('人数: $participantCount'),
+          if (publicId != null && publicId.isNotEmpty) Text('共有ID: $publicId'),
+          Text('状態: $statusLabel'),
+          if (onCopyShareUrl != null)
+            OutlinedButton.icon(
+              onPressed: onCopyShareUrl,
+              icon: const Icon(Icons.copy),
+              label: const Text('共有URLをコピー'),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -1,48 +1,53 @@
 import 'package:flutter/material.dart';
 
-import 'schedule_section_card.dart';
-
 class ScheduleEventSummaryCard extends StatelessWidget {
   const ScheduleEventSummaryCard({
     super.key,
-    required this.eventName,
     required this.courtCount,
     required this.participantCount,
     required this.statusLabel,
-    this.publicId,
     this.onCopyShareUrl,
+    this.onRefresh,
+    this.canRefresh = true,
   });
 
-  final String eventName;
   final int courtCount;
   final int participantCount;
   final String statusLabel;
-  final String? publicId;
   final VoidCallback? onCopyShareUrl;
+  final VoidCallback? onRefresh;
+  final bool canRefresh;
 
   @override
   Widget build(BuildContext context) {
-    final publicId = this.publicId;
-
-    return ScheduleSectionCard(
-      title: 'イベント情報',
-      child: Wrap(
-        spacing: 16,
-        runSpacing: 8,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: [
-          Text('イベント名: $eventName'),
-          Text('面数: $courtCount'),
-          Text('人数: $participantCount'),
-          if (publicId != null && publicId.isNotEmpty) Text('共有ID: $publicId'),
-          Text('状態: $statusLabel'),
-          if (onCopyShareUrl != null)
-            OutlinedButton.icon(
-              onPressed: onCopyShareUrl,
-              icon: const Icon(Icons.copy),
-              label: const Text('共有URLをコピー'),
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Wrap(
+          spacing: 12,
+          runSpacing: 8,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            Text('面数: $courtCount'),
+            Text('参加者: $participantCount人'),
+            Chip(
+              label: Text(statusLabel),
+              visualDensity: VisualDensity.compact,
             ),
-        ],
+            if (onCopyShareUrl != null)
+              OutlinedButton.icon(
+                onPressed: onCopyShareUrl,
+                icon: const Icon(Icons.copy),
+                label: const Text('共有URLをコピー'),
+              ),
+            if (onRefresh != null)
+              FilledButton.tonalIcon(
+                onPressed: canRefresh ? onRefresh : null,
+                icon: const Icon(Icons.sync),
+                label: const Text('最新の情報に更新'),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_participants_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_participants_card.dart
@@ -12,7 +12,7 @@ class ScheduleParticipantViewModel {
   final String displayName;
 }
 
-class ScheduleParticipantsCard extends StatelessWidget {
+class ScheduleParticipantsCard extends StatefulWidget {
   const ScheduleParticipantsCard({
     super.key,
     required this.participants,
@@ -21,8 +21,52 @@ class ScheduleParticipantsCard extends StatelessWidget {
   final List<ScheduleParticipantViewModel> participants;
 
   @override
+  State<ScheduleParticipantsCard> createState() =>
+      _ScheduleParticipantsCardState();
+}
+
+class _ScheduleParticipantsCardState extends State<ScheduleParticipantsCard> {
+  final _scrollController = ScrollController();
+  bool _showScrollHint = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _scrollController.addListener(_updateScrollHint);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _updateScrollHint());
+  }
+
+  @override
+  void didUpdateWidget(ScheduleParticipantsCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _updateScrollHint());
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_updateScrollHint);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _updateScrollHint() {
+    if (!_scrollController.hasClients) return;
+
+    final maxScrollExtent = _scrollController.position.maxScrollExtent;
+    final pixels = _scrollController.position.pixels;
+    final nextShowScrollHint = maxScrollExtent - pixels > 8;
+
+    if (_showScrollHint == nextShowScrollHint) return;
+
+    setState(() {
+      _showScrollHint = nextShowScrollHint;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (participants.isEmpty) {
+    if (widget.participants.isEmpty) {
       return const ScheduleSectionCard(
         title: '参加者',
         child: Text('参加者情報がありません'),
@@ -31,14 +75,48 @@ class ScheduleParticipantsCard extends StatelessWidget {
 
     return ScheduleSectionCard(
       title: '参加者',
-      child: Wrap(
-        spacing: 6,
-        runSpacing: 6,
-        children: participants.map((participant) {
-          return Chip(
-            label: Text('${participant.orderNo}: ${participant.displayName}'),
-          );
-        }).toList(growable: false),
+      child: SizedBox(
+        height: 44,
+        child: Stack(
+          children: [
+            SingleChildScrollView(
+              controller: _scrollController,
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: widget.participants.map((participant) {
+                  return Padding(
+                    padding: const EdgeInsets.only(right: 6),
+                    child: Chip(
+                      label: Text(
+                        '${participant.orderNo}: ${participant.displayName}',
+                      ),
+                      visualDensity: VisualDensity.compact,
+                    ),
+                  );
+                }).toList(growable: false),
+              ),
+            ),
+            if (_showScrollHint)
+              Positioned(
+                top: 0,
+                right: 0,
+                bottom: 0,
+                child: IgnorePointer(
+                  child: Container(
+                    alignment: Alignment.center,
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    decoration: BoxDecoration(
+                      color: Theme.of(context)
+                          .colorScheme
+                          .surface
+                          .withValues(alpha: 0.88),
+                    ),
+                    child: const Text('>>'),
+                  ),
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_participants_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_participants_card.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+import 'schedule_section_card.dart';
+
+class ScheduleParticipantViewModel {
+  const ScheduleParticipantViewModel({
+    required this.orderNo,
+    required this.displayName,
+  });
+
+  final int orderNo;
+  final String displayName;
+}
+
+class ScheduleParticipantsCard extends StatelessWidget {
+  const ScheduleParticipantsCard({
+    super.key,
+    required this.participants,
+  });
+
+  final List<ScheduleParticipantViewModel> participants;
+
+  @override
+  Widget build(BuildContext context) {
+    if (participants.isEmpty) {
+      return const ScheduleSectionCard(
+        title: '参加者',
+        child: Text('参加者情報がありません'),
+      );
+    }
+
+    return ScheduleSectionCard(
+      title: '参加者',
+      child: Wrap(
+        spacing: 6,
+        runSpacing: 6,
+        children: participants.map((participant) {
+          return Chip(
+            label: Text('${participant.orderNo}: ${participant.displayName}'),
+          );
+        }).toList(growable: false),
+      ),
+    );
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_participants_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_participants_card.dart
@@ -15,9 +15,11 @@ class ScheduleParticipantViewModel {
 class ScheduleParticipantsCard extends StatefulWidget {
   const ScheduleParticipantsCard({
     super.key,
+    required this.title,
     required this.participants,
   });
 
+  final String title;
   final List<ScheduleParticipantViewModel> participants;
 
   @override
@@ -74,7 +76,7 @@ class _ScheduleParticipantsCardState extends State<ScheduleParticipantsCard> {
     }
 
     return ScheduleSectionCard(
-      title: '参加者',
+      title: widget.title,
       child: SizedBox(
         height: 44,
         child: Stack(
@@ -103,13 +105,24 @@ class _ScheduleParticipantsCardState extends State<ScheduleParticipantsCard> {
                 bottom: 0,
                 child: IgnorePointer(
                   child: Container(
-                    alignment: Alignment.center,
-                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    width: 36,
+                    alignment: Alignment.centerRight,
+                    padding: const EdgeInsets.only(right: 8),
                     decoration: BoxDecoration(
-                      color: Theme.of(context)
-                          .colorScheme
-                          .surface
-                          .withValues(alpha: 0.88),
+                      gradient: LinearGradient(
+                        begin: Alignment.centerLeft,
+                        end: Alignment.centerRight,
+                        colors: [
+                          Theme.of(context)
+                              .colorScheme
+                              .surface
+                              .withValues(alpha: 0.0),
+                          Theme.of(context)
+                              .colorScheme
+                              .surface
+                              .withValues(alpha: 0.92),
+                        ],
+                      ),
                     ),
                     child: const Text('>>'),
                   ),

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class ScheduleRoundsView extends StatelessWidget {
+class ScheduleRoundsView extends StatefulWidget {
   const ScheduleRoundsView({
     super.key,
     required this.scheduleResponse,
@@ -11,13 +11,21 @@ class ScheduleRoundsView extends StatelessWidget {
   final Map<String, String> playerNameById;
 
   @override
+  State<ScheduleRoundsView> createState() => _ScheduleRoundsViewState();
+}
+
+class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
+  final Set<String> _expandedRestRoundNumbers = {};
+
+  @override
   Widget build(BuildContext context) {
+    final scheduleResponse = widget.scheduleResponse;
     if (scheduleResponse == null) {
       return const Text('対戦表を取得できていません');
     }
 
-    final rounds = _asObjectList(scheduleResponse?['rounds']);
-    final slotToPlayerId = _buildSlotToPlayerId();
+    final rounds = _asObjectList(scheduleResponse['rounds']);
+    final slotToPlayerId = _buildSlotToPlayerId(scheduleResponse);
 
     if (rounds.isEmpty) {
       return const Text('対戦表データがありません');
@@ -25,59 +33,154 @@ class ScheduleRoundsView extends StatelessWidget {
 
     return Column(
       children: rounds.map((round) {
-        final roundNumber = round['round_number']?.toString() ?? '-';
-        final restSlotNumbers = _asIntList(round['rest_slot_numbers']);
-        final courts = _asObjectList(round['courts']);
+        return _buildRoundCard(round, slotToPlayerId);
+      }).toList(growable: false),
+    );
+  }
 
-        return Card(
-          margin: const EdgeInsets.only(bottom: 12),
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  '第$roundNumber試合',
+  Widget _buildRoundCard(
+    Map<String, dynamic> round,
+    Map<int, String> slotToPlayerId,
+  ) {
+    final roundNumber = round['round_number']?.toString() ?? '-';
+    final restSlotNumbers = _asIntList(round['rest_slot_numbers']);
+    final courts = _asObjectList(round['courts']);
+    final isRestExpanded = _expandedRestRoundNumbers.contains(roundNumber);
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 34,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text(
+                  roundNumber,
+                  textAlign: TextAlign.center,
                   style: const TextStyle(
                     fontWeight: FontWeight.bold,
-                    fontSize: 18,
+                    fontSize: 20,
                   ),
                 ),
-                const SizedBox(height: 12),
-                ...courts.map((court) {
-                  final courtNumber = court['court_number']?.toString() ?? '-';
-                  final team1Slots = _asIntList(court['team1_player_slots']);
-                  final team2Slots = _asIntList(court['team2_player_slots']);
-
-                  return Padding(
-                    padding: const EdgeInsets.only(bottom: 12),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ...courts.map((court) {
+                    return _buildCourtRow(court, slotToPlayerId);
+                  }),
+                  if (isRestExpanded) ...[
+                    const Divider(),
+                    Wrap(
+                      spacing: 6,
+                      runSpacing: 6,
+                      crossAxisAlignment: WrapCrossAlignment.center,
                       children: [
-                        Text(
-                          'コート$courtNumber',
-                          style: const TextStyle(
-                            fontWeight: FontWeight.bold,
-                            fontSize: 14,
-                          ),
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          '${_formatTeamFromSlots(team1Slots, slotToPlayerId)}  vs  ${_formatTeamFromSlots(team2Slots, slotToPlayerId)}',
-                        ),
+                        const Text('休憩:'),
+                        ...restSlotNumbers.map((slotNumber) {
+                          return _buildPlayerChip(
+                            slotNumber: slotNumber,
+                            slotToPlayerId: slotToPlayerId,
+                          );
+                        }),
                       ],
                     ),
-                  );
-                }),
-                const Divider(),
-                Text(
-                  '休憩: ${_formatRestPlayersBySlots(restSlotNumbers, slotToPlayerId)}',
-                ),
-              ],
+                  ],
+                ],
+              ),
             ),
+            const SizedBox(width: 8),
+            _RestToggleButton(
+              restCount: restSlotNumbers.length,
+              isExpanded: isRestExpanded,
+              onTap: () {
+                setState(() {
+                  if (isRestExpanded) {
+                    _expandedRestRoundNumbers.remove(roundNumber);
+                  } else {
+                    _expandedRestRoundNumbers.add(roundNumber);
+                  }
+                });
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCourtRow(
+    Map<String, dynamic> court,
+    Map<int, String> slotToPlayerId,
+  ) {
+    final courtNumber = court['court_number']?.toString() ?? '-';
+    final team1Slots = _asIntList(court['team1_player_slots']);
+    final team2Slots = _asIntList(court['team2_player_slots']);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Wrap(
+        spacing: 6,
+        runSpacing: 6,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          Text(
+            'コート: $courtNumber',
+            style: const TextStyle(fontWeight: FontWeight.bold),
           ),
-        );
-      }).toList(growable: false),
+          ..._buildTeamChips(team1Slots, slotToPlayerId),
+          const Text('vs'),
+          ..._buildTeamChips(team2Slots, slotToPlayerId),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildTeamChips(
+    List<int> slotNumbers,
+    Map<int, String> slotToPlayerId,
+  ) {
+    if (slotNumbers.isEmpty) {
+      return const [Text('-')];
+    }
+
+    final chips = <Widget>[];
+    for (var i = 0; i < slotNumbers.length; i += 1) {
+      if (i > 0) {
+        chips.add(const Text('/'));
+      }
+
+      chips.add(
+        _buildPlayerChip(
+          slotNumber: slotNumbers[i],
+          slotToPlayerId: slotToPlayerId,
+        ),
+      );
+    }
+
+    return chips;
+  }
+
+  Widget _buildPlayerChip({
+    required int slotNumber,
+    required Map<int, String> slotToPlayerId,
+  }) {
+    final playerId = slotToPlayerId[slotNumber];
+    final displayName = playerId == null
+        ? 'slot:$slotNumber'
+        : widget.playerNameById[playerId] ?? playerId;
+
+    return SchedulePlayerChip(
+      slotNumber: slotNumber,
+      playerId: playerId,
+      displayName: displayName,
     );
   }
 
@@ -102,8 +205,8 @@ class ScheduleRoundsView extends StatelessWidget {
         .toList(growable: false);
   }
 
-  Map<int, String> _buildSlotToPlayerId() {
-    final assignment = _asObjectList(scheduleResponse?['assignment']);
+  Map<int, String> _buildSlotToPlayerId(Map<String, dynamic> scheduleResponse) {
+    final assignment = _asObjectList(scheduleResponse['assignment']);
     final slotToPlayerId = <int, String>{};
 
     for (final row in assignment) {
@@ -119,39 +222,92 @@ class ScheduleRoundsView extends StatelessWidget {
 
     return slotToPlayerId;
   }
+}
 
-  String _playerLabelFromId(String playerId) {
-    return playerNameById[playerId] ?? playerId;
+class SchedulePlayerChip extends StatelessWidget {
+  const SchedulePlayerChip({
+    super.key,
+    required this.slotNumber,
+    required this.displayName,
+    this.playerId,
+    this.isHighlighted = false,
+    this.onTap,
+  });
+
+  final int slotNumber;
+  final String displayName;
+  final String? playerId;
+  final bool isHighlighted;
+  final ValueChanged<String>? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final playerId = this.playerId;
+    final label = Text('$slotNumber: $displayName');
+
+    if (onTap == null || playerId == null) {
+      return Chip(
+        label: label,
+        visualDensity: VisualDensity.compact,
+        backgroundColor: isHighlighted
+            ? Theme.of(context).colorScheme.primaryContainer
+            : null,
+      );
+    }
+
+    return ActionChip(
+      label: label,
+      visualDensity: VisualDensity.compact,
+      backgroundColor:
+          isHighlighted ? Theme.of(context).colorScheme.primaryContainer : null,
+      onPressed: () => onTap!(playerId),
+    );
   }
+}
 
-  String _playerLabelFromSlot(
-    int slotNumber,
-    Map<int, String> slotToPlayerId,
-  ) {
-    final playerId = slotToPlayerId[slotNumber];
-    if (playerId == null) return 'slot:$slotNumber';
-    return _playerLabelFromId(playerId);
-  }
+class _RestToggleButton extends StatelessWidget {
+  const _RestToggleButton({
+    required this.restCount,
+    required this.isExpanded,
+    required this.onTap,
+  });
 
-  String _formatTeamFromSlots(
-    List<int> slots,
-    Map<int, String> slotToPlayerId,
-  ) {
-    if (slots.isEmpty) return '-';
+  final int restCount;
+  final bool isExpanded;
+  final VoidCallback onTap;
 
-    return slots
-        .map((slot) => '$slot: ${_playerLabelFromSlot(slot, slotToPlayerId)}')
-        .join(' / ');
-  }
-
-  String _formatRestPlayersBySlots(
-    List<int> slotNumbers,
-    Map<int, String> slotToPlayerId,
-  ) {
-    if (slotNumbers.isEmpty) return '-';
-
-    return slotNumbers
-        .map((slot) => '$slot: ${_playerLabelFromSlot(slot, slotToPlayerId)}')
-        .join(' / ');
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: onTap,
+      child: Container(
+        width: 52,
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: Theme.of(context).colorScheme.outlineVariant,
+          ),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              '休憩',
+              style: TextStyle(fontSize: 12),
+            ),
+            Text(
+              '$restCount人',
+              style: const TextStyle(fontSize: 12),
+            ),
+            Icon(
+              isExpanded ? Icons.expand_less : Icons.expand_more,
+              size: 18,
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+
+class ScheduleRoundsView extends StatelessWidget {
+  const ScheduleRoundsView({
+    super.key,
+    required this.scheduleResponse,
+    required this.playerNameById,
+  });
+
+  final Map<String, dynamic>? scheduleResponse;
+  final Map<String, String> playerNameById;
+
+  @override
+  Widget build(BuildContext context) {
+    if (scheduleResponse == null) {
+      return const Text('対戦表を取得できていません');
+    }
+
+    final rounds = _asObjectList(scheduleResponse?['rounds']);
+    final slotToPlayerId = _buildSlotToPlayerId();
+
+    if (rounds.isEmpty) {
+      return const Text('対戦表データがありません');
+    }
+
+    return Column(
+      children: rounds.map((round) {
+        final roundNumber = round['round_number']?.toString() ?? '-';
+        final restSlotNumbers = _asIntList(round['rest_slot_numbers']);
+        final courts = _asObjectList(round['courts']);
+
+        return Card(
+          margin: const EdgeInsets.only(bottom: 12),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '第$roundNumber試合',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 18,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                ...courts.map((court) {
+                  final courtNumber = court['court_number']?.toString() ?? '-';
+                  final team1Slots = _asIntList(court['team1_player_slots']);
+                  final team2Slots = _asIntList(court['team2_player_slots']);
+
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'コート$courtNumber',
+                          style: const TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 14,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          '${_formatTeamFromSlots(team1Slots, slotToPlayerId)}  vs  ${_formatTeamFromSlots(team2Slots, slotToPlayerId)}',
+                        ),
+                      ],
+                    ),
+                  );
+                }),
+                const Divider(),
+                Text(
+                  '休憩: ${_formatRestPlayersBySlots(restSlotNumbers, slotToPlayerId)}',
+                ),
+              ],
+            ),
+          ),
+        );
+      }).toList(growable: false),
+    );
+  }
+
+  List<Map<String, dynamic>> _asObjectList(Object? value) {
+    if (value is! List) return const [];
+
+    return value
+        .whereType<Map>()
+        .map((e) => e.map((key, value) => MapEntry(key.toString(), value)))
+        .toList(growable: false);
+  }
+
+  List<int> _asIntList(Object? value) {
+    if (value is! List) return const [];
+
+    return value
+        .map((e) {
+          if (e is int) return e;
+          return int.tryParse(e.toString());
+        })
+        .whereType<int>()
+        .toList(growable: false);
+  }
+
+  Map<int, String> _buildSlotToPlayerId() {
+    final assignment = _asObjectList(scheduleResponse?['assignment']);
+    final slotToPlayerId = <int, String>{};
+
+    for (final row in assignment) {
+      final slotNumberValue = row['slot_number'];
+      final playerIdValue = row['player_id'];
+      if (slotNumberValue == null || playerIdValue == null) continue;
+
+      final slotNumber = int.tryParse(slotNumberValue.toString());
+      if (slotNumber == null) continue;
+
+      slotToPlayerId[slotNumber] = playerIdValue.toString();
+    }
+
+    return slotToPlayerId;
+  }
+
+  String _playerLabelFromId(String playerId) {
+    return playerNameById[playerId] ?? playerId;
+  }
+
+  String _playerLabelFromSlot(
+    int slotNumber,
+    Map<int, String> slotToPlayerId,
+  ) {
+    final playerId = slotToPlayerId[slotNumber];
+    if (playerId == null) return 'slot:$slotNumber';
+    return _playerLabelFromId(playerId);
+  }
+
+  String _formatTeamFromSlots(
+    List<int> slots,
+    Map<int, String> slotToPlayerId,
+  ) {
+    if (slots.isEmpty) return '-';
+
+    return slots
+        .map((slot) => '$slot: ${_playerLabelFromSlot(slot, slotToPlayerId)}')
+        .join(' / ');
+  }
+
+  String _formatRestPlayersBySlots(
+    List<int> slotNumbers,
+    Map<int, String> slotToPlayerId,
+  ) {
+    if (slotNumbers.isEmpty) return '-';
+
+    return slotNumbers
+        .map((slot) => '$slot: ${_playerLabelFromSlot(slot, slotToPlayerId)}')
+        .join(' / ');
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
@@ -5,10 +5,12 @@ class ScheduleRoundsView extends StatefulWidget {
     super.key,
     required this.scheduleResponse,
     required this.playerNameById,
+    required this.courtCount,
   });
 
   final Map<String, dynamic>? scheduleResponse;
   final Map<String, String> playerNameById;
+  final int courtCount;
 
   @override
   State<ScheduleRoundsView> createState() => _ScheduleRoundsViewState();
@@ -26,6 +28,8 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
 
     final rounds = _asObjectList(scheduleResponse['rounds']);
     final slotToPlayerId = _buildSlotToPlayerId(scheduleResponse);
+    // final courtCount = scheduleResponse?['courts']?.length ?? 0;
+    final courtCount = 2;
 
     if (rounds.isEmpty) {
       return const Text('対戦表データがありません');
@@ -33,7 +37,7 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
 
     return Column(
       children: rounds.map((round) {
-        return _buildRoundCard(round, slotToPlayerId);
+        return _buildRoundCard(round, slotToPlayerId, courtCount);
       }).toList(growable: false),
     );
   }
@@ -41,31 +45,56 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
   Widget _buildRoundCard(
     Map<String, dynamic> round,
     Map<int, String> slotToPlayerId,
+    int courtCount,
   ) {
     final roundNumber = round['round_number']?.toString() ?? '-';
+    final roundNumberValue = int.tryParse(roundNumber);
+    final isEvenRound = roundNumberValue != null && roundNumberValue.isEven;
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final roundCardColor = isEvenRound
+        ? colorScheme.surface.withValues(alpha: 0.92)
+        : colorScheme.primaryContainer.withValues(alpha: 0.92);
+
     final restSlotNumbers = _asIntList(round['rest_slot_numbers']);
     final courts = _asObjectList(round['courts']);
     final isRestExpanded = _expandedRestRoundNumbers.contains(roundNumber);
 
     return Card(
-      margin: const EdgeInsets.only(bottom: 12),
+      color: roundCardColor,
+      margin: const EdgeInsets.only(bottom: 4),
       child: Padding(
-        padding: const EdgeInsets.all(12),
+        padding: const EdgeInsets.all(4),
         child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             SizedBox(
-              width: 34,
-              child: Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: Text(
-                  roundNumber,
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    fontWeight: FontWeight.bold,
-                    fontSize: 20,
+              width: 36,
+              child: Column(
+                children: [
+                  Text(
+                    'R $roundNumber',
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 14,
+                    ),
                   ),
-                ),
+                  const SizedBox(height: 8),
+                  _RestToggleButton(
+                    restCount: restSlotNumbers.length,
+                    isExpanded: isRestExpanded,
+                    onTap: () {
+                      setState(() {
+                        if (isRestExpanded) {
+                          _expandedRestRoundNumbers.remove(roundNumber);
+                        } else {
+                          _expandedRestRoundNumbers.add(roundNumber);
+                        }
+                      });
+                    },
+                  ),
+                ],
               ),
             ),
             const SizedBox(width: 8),
@@ -74,7 +103,8 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   ...courts.map((court) {
-                    return _buildCourtRow(court, slotToPlayerId);
+                    return _buildCourtRow(court, slotToPlayerId,
+                        showCourtNumber: widget.courtCount >= 2);
                   }),
                   if (isRestExpanded) ...[
                     const Divider(),
@@ -96,20 +126,6 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
                 ],
               ),
             ),
-            const SizedBox(width: 8),
-            _RestToggleButton(
-              restCount: restSlotNumbers.length,
-              isExpanded: isRestExpanded,
-              onTap: () {
-                setState(() {
-                  if (isRestExpanded) {
-                    _expandedRestRoundNumbers.remove(roundNumber);
-                  } else {
-                    _expandedRestRoundNumbers.add(roundNumber);
-                  }
-                });
-              },
-            ),
           ],
         ),
       ),
@@ -117,30 +133,32 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
   }
 
   Widget _buildCourtRow(
-    Map<String, dynamic> court,
-    Map<int, String> slotToPlayerId,
-  ) {
+      Map<String, dynamic> court, Map<int, String> slotToPlayerId,
+      {required bool showCourtNumber}) {
     final courtNumber = court['court_number']?.toString() ?? '-';
     final team1Slots = _asIntList(court['team1_player_slots']);
     final team2Slots = _asIntList(court['team2_player_slots']);
 
     return Padding(
-      padding: const EdgeInsets.only(bottom: 10),
-      child: Wrap(
-        spacing: 6,
-        runSpacing: 6,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: [
-          Text(
-            'コート: $courtNumber',
-            style: const TextStyle(fontWeight: FontWeight.bold),
-          ),
-          ..._buildTeamChips(team1Slots, slotToPlayerId),
-          const Text('vs'),
-          ..._buildTeamChips(team2Slots, slotToPlayerId),
-        ],
-      ),
-    );
+        padding: const EdgeInsets.only(bottom: 8),
+        child: Wrap(
+          spacing: 4,
+          runSpacing: 4,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            if (showCourtNumber)
+              Text(
+                courtNumber,
+                style: const TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 13,
+                ),
+              ),
+            _buildTeamGroup(team1Slots, slotToPlayerId),
+            const Text('vs'),
+            _buildTeamGroup(team2Slots, slotToPlayerId),
+          ],
+        ));
   }
 
   List<Widget> _buildTeamChips(
@@ -151,21 +169,28 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
       return const [Text('-')];
     }
 
-    final chips = <Widget>[];
-    for (var i = 0; i < slotNumbers.length; i += 1) {
-      if (i > 0) {
-        chips.add(const Text('/'));
-      }
-
-      chips.add(
-        _buildPlayerChip(
-          slotNumber: slotNumbers[i],
-          slotToPlayerId: slotToPlayerId,
-        ),
+    return slotNumbers.map((slotNumber) {
+      return _buildPlayerChip(
+        slotNumber: slotNumber,
+        slotToPlayerId: slotToPlayerId,
       );
+    }).toList(growable: false);
+  }
+
+  Widget _buildTeamGroup(
+    List<int> slotNumbers,
+    Map<int, String> slotToPlayerId,
+  ) {
+    if (slotNumbers.isEmpty) {
+      return const Text('-');
     }
 
-    return chips;
+    return Wrap(
+      spacing: 6,
+      runSpacing: 6,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: _buildTeamChips(slotNumbers, slotToPlayerId),
+    );
   }
 
   Widget _buildPlayerChip({
@@ -243,12 +268,23 @@ class SchedulePlayerChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final playerId = this.playerId;
-    final label = Text('$slotNumber: $displayName');
+
+    final label = SizedBox(
+      width: 64,
+      child: Text(
+        '$slotNumber: $displayName',
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        textAlign: TextAlign.center,
+        style: const TextStyle(fontSize: 12),
+      ),
+    );
 
     if (onTap == null || playerId == null) {
       return Chip(
         label: label,
         visualDensity: VisualDensity.compact,
+        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
         backgroundColor: isHighlighted
             ? Theme.of(context).colorScheme.primaryContainer
             : null,
@@ -258,6 +294,7 @@ class SchedulePlayerChip extends StatelessWidget {
     return ActionChip(
       label: label,
       visualDensity: VisualDensity.compact,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
       backgroundColor:
           isHighlighted ? Theme.of(context).colorScheme.primaryContainer : null,
       onPressed: () => onTap!(playerId),
@@ -282,7 +319,7 @@ class _RestToggleButton extends StatelessWidget {
       borderRadius: BorderRadius.circular(12),
       onTap: onTap,
       child: Container(
-        width: 52,
+        width: 40,
         padding: const EdgeInsets.symmetric(vertical: 6),
         decoration: BoxDecoration(
           border: Border.all(
@@ -293,17 +330,13 @@ class _RestToggleButton extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Text(
-              '休憩',
-              style: TextStyle(fontSize: 12),
-            ),
             Text(
-              '$restCount人',
-              style: const TextStyle(fontSize: 12),
+              '休憩: $restCount',
+              style: TextStyle(fontSize: 10),
             ),
             Icon(
               isExpanded ? Icons.expand_less : Icons.expand_more,
-              size: 18,
+              size: 16,
             ),
           ],
         ),

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
@@ -28,8 +28,6 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
 
     final rounds = _asObjectList(scheduleResponse['rounds']);
     final slotToPlayerId = _buildSlotToPlayerId(scheduleResponse);
-    // final courtCount = scheduleResponse?['courts']?.length ?? 0;
-    final courtCount = 2;
 
     if (rounds.isEmpty) {
       return const Text('対戦表データがありません');
@@ -37,7 +35,7 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
 
     return Column(
       children: rounds.map((round) {
-        return _buildRoundCard(round, slotToPlayerId, courtCount);
+        return _buildRoundCard(round, slotToPlayerId);
       }).toList(growable: false),
     );
   }
@@ -45,7 +43,6 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
   Widget _buildRoundCard(
     Map<String, dynamic> round,
     Map<int, String> slotToPlayerId,
-    int courtCount,
   ) {
     final roundNumber = round['round_number']?.toString() ?? '-';
     final roundNumberValue = int.tryParse(roundNumber);

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_section_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_section_card.dart
@@ -3,29 +3,33 @@ import 'package:flutter/material.dart';
 class ScheduleSectionCard extends StatelessWidget {
   const ScheduleSectionCard({
     super.key,
-    required this.title,
+    this.title,
     required this.child,
   });
 
-  final String title;
+  final String? title;
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
+    final title = this.title;
+
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(4),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              title,
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 16,
+            if (title != null && title.isNotEmpty) ...[
+              Text(
+                title,
+                style: const TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16,
+                ),
               ),
-            ),
-            const SizedBox(height: 12),
+              const SizedBox(height: 12),
+            ],
             child,
           ],
         ),

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_section_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_section_card.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class ScheduleSectionCard extends StatelessWidget {
+  const ScheduleSectionCard({
+    super.key,
+    required this.title,
+    required this.child,
+  });
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: 16,
+              ),
+            ),
+            const SizedBox(height: 12),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_section_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_section_card.dart
@@ -14,7 +14,7 @@ class ScheduleSectionCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(4),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [


### PR DESCRIPTION
## 概要

#19 の対応として、generate / 再生成 / adopt の web 導線を仕上げました。

#18 で追加した `RestoredSchedulePage` の表示を基準に、通常の `SchedulePage` と共有URL復元画面の表示・操作感を揃えています。

また、複数タブ / 複数画面で古い event 状態を持ったまま再生成・採用してしまう問題を防ぐため、再生成・採用前に最新の event aggregate を確認するようにしました。

Closes #19

## 対応内容

### 表示 widget の共通化

- `SchedulePage` / `RestoredSchedulePage` の表示部品を共通 widget に切り出し
  - `ScheduleSectionCard`
  - `ScheduleEventSummaryCard`
  - `ScheduleParticipantsCard`
  - `ScheduleActionButtons`
  - `ScheduleRoundsView`
- ロジックは各 page に残し、データを受け取った後の表示部分を共通化
- `RestoredSchedulePage` の表示を基準に、通常生成画面と共有復元画面の見え方を整理

### generate / 再生成導線

- 再生成前に確認ダイアログを表示
- 採用済み event では再生成できないように制御
- 再生成直前に Firestore から最新 event aggregate を再取得
- 確認ダイアログ表示中に別画面で採用された場合も、再確認して再生成を止める

### adopt 導線

- 採用ボタン文言を `この対戦表を採用` に変更
- 採用成功時の文言を `この対戦表を採用しました` に変更
- 採用前に Firestore から最新 event aggregate を再取得
- すでに採用済みの場合は採用せず、最新情報へ更新
- 表示中の `generated_schedule_id` と最新の `currentGeneratedScheduleId` が違う場合は採用せず、最新情報へ更新
- 採用済み状態では再生成 / 採用操作カードを非表示化

### 最新情報への更新

- `再取得` 文言を `最新の情報に更新` に変更
- 更新時に保存済み event aggregate を再取得し、最新の `displayGeneratedScheduleId` を解決してから core get API を呼ぶように変更
- 別画面で再生成・採用された場合も、共有画面側から最新状態に追随できるように対応

### stale event state 対策

- `JsonEventRepository` / `InMemoryEventRepository` で、採用済み event に対する `currentGeneratedScheduleId` 更新を拒否
- 複数タブで古い event 状態を持っている場合でも、採用済み event の current 参照を後から上書きしないようにした

### スマホ向け UI 整理

- イベント情報カードを薄く整理
- 面数・参加者数を参加者カード見出しへ移動
- 参加者一覧を横スクロール化
- 横スクロール可能な場合に `>>` overlay を表示
- 対戦表内の参加者表示を chip 化
- 将来の参加者ハイライト機能に備えて `SchedulePlayerChip` を分離
- 休憩表示を折りたたみ式に変更
- ラウンドごとに背景色を変え、視認性を改善
- 1面の場合は対戦表内のコート番号を非表示にし、2面以上の場合のみ表示
- 操作カードの見出しを非表示化

## 関連 Issue

- #19
- #40

## 確認内容

- [x] `dart format lib/features/doubles_scheduler`
- [x] `flutter analyze`
- [x] `flutter test`

### 手動確認

- [x] 新規入力から対戦表を生成できること
- [x] 生成後に共有URLをコピーできること
- [x] 共有URLから生成済み対戦表を復元できること
- [x] 再生成前に確認ダイアログが表示されること
- [x] 再生成後に `currentGeneratedScheduleId` が更新されること
- [x] 共有画面で `最新の情報に更新` を押すと、最新の `currentGeneratedScheduleId` に追随すること
- [x] 採用できること
- [x] 採用後に採用済み状態として表示されること
- [x] 採用後は再生成 / 採用操作カードが表示されないこと
- [x] 採用済み event に対して別画面から再生成できないこと
- [x] 表示中の対戦表が古い場合、採用せず最新情報に更新されること
- [x] スマホ幅で参加者一覧・対戦表が表示できること
- [x] 1面 / 2面の対戦表表示を確認
- [x] 休憩表示の開閉を確認

## 今回やらないこと

- extend
- cooldown
- 試合結果入力
- ownership チェック
- Undo / rollback
- 参加者アイコン表示
- 参加者ハイライト機能
  - 後続 Issue #40 で扱う
- 状態 chip の最終配置確定
  - 現時点では表示しつつ、今後の UI 調整で再検討する