### PR TITLE
📋 feat: Add share URL guidance

### DIFF
--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -19,27 +19,37 @@ class ScheduleEventSummaryCard extends StatelessWidget {
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(4),
-        child: Wrap(
-          spacing: 6,
-          runSpacing: 4,
-          crossAxisAlignment: WrapCrossAlignment.center,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Chip(
-              label: Text(statusLabel, style: TextStyle(fontSize: 14)),
-              visualDensity: VisualDensity.compact,
+            Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                Chip(
+                  label: Text(statusLabel, style: const TextStyle(fontSize: 14)),
+                  visualDensity: VisualDensity.compact,
+                ),
+                if (onCopyShareUrl != null)
+                  OutlinedButton.icon(
+                    onPressed: onCopyShareUrl,
+                    icon: const Icon(Icons.copy),
+                    label: const Text('共有URLをコピー'),
+                  ),
+                if (onRefresh != null)
+                  FilledButton.tonalIcon(
+                    onPressed: canRefresh ? onRefresh : null,
+                    icon: const Icon(Icons.sync),
+                    label: const Text('最新の情報に更新'),
+                  ),
+              ],
             ),
-            if (onCopyShareUrl != null)
-              OutlinedButton.icon(
-                onPressed: onCopyShareUrl,
-                icon: const Icon(Icons.copy),
-                label: const Text('共有URLをコピー'),
-              ),
-            if (onRefresh != null)
-              FilledButton.tonalIcon(
-                onPressed: canRefresh ? onRefresh : null,
-                icon: const Icon(Icons.sync),
-                label: const Text('最新の情報に更新'),
-              ),
+            const SizedBox(height: 4),
+            Text(
+              'URLを共有して対戦表をみんなで確認しましょう٩( ᐛ )و',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## 概要

#20 の対応として、共有URLコピー導線に案内文を追加しました。

共有URL自体の生成・コピー操作は #19 までに実装済みだったため、今回は共有URLの扱いが分かるように、コピー導線付近へ最低限の説明を追加しています。

Closes #20

## 対応内容

- 共有URLコピー導線の近くに案内文を追加
- 共有URLから参加者が同じ対戦表を確認できることを示す文言を追加

表示文言:

```text
URLを共有して対戦表をみんなで確認しましょう٩( ᐛ )و
```

Google Drive の共有文言参考:

```text
リンクを知っているインターネット上の誰もが閲覧できます
````

## 確認内容

* [x] `dart format lib/features/doubles_scheduler`
* [x] `flutter analyze`
* [x] `flutter test`

### 手動確認

* [x] 共有URLコピー導線が表示されること
* [x] 共有URLをコピーできること
* [x] コピー成功メッセージが表示されること
* [x] 共有URLの案内文が表示されること
* [x] 通常生成画面で表示崩れがないこと
* [x] 共有URL復元画面で表示崩れがないこと

## 今回やらないこと

* SNS共有ボタン
* QRコード生成
* 権限管理
* パスワード付きURL
* URL短縮
* ownership / ログイン制御
