### PR TITLE
🧪 fix: Improve share URL MVP smoke flow

### DIFF
--- a/lib/app/theme/app_theme.dart
+++ b/lib/app/theme/app_theme.dart
@@ -6,7 +6,8 @@ final ThemeData _baseTheme = ThemeData(
   useMaterial3: true,
 );
 
-final TextTheme _textTheme = GoogleFonts.notoSansJpTextTheme(_baseTheme.textTheme);
+final TextTheme _textTheme =
+    GoogleFonts.notoSansJpTextTheme(_baseTheme.textTheme);
 
 final ThemeData appTheme = _baseTheme.copyWith(
   textTheme: _textTheme,

--- a/lib/features/doubles_scheduler/data/local_schedule_history_item.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_item.dart
@@ -1,0 +1,43 @@
+class LocalScheduleHistoryItem {
+  const LocalScheduleHistoryItem({
+    required this.publicId,
+    required this.title,
+    required this.courtCount,
+    required this.participantCount,
+    required this.firstSavedAt,
+    required this.lastOpenedAt,
+  });
+
+  final String publicId;
+  final String title;
+  final int courtCount;
+  final int participantCount;
+  final DateTime firstSavedAt;
+  final DateTime lastOpenedAt;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'public_id': publicId,
+      'title': title,
+      'court_count': courtCount,
+      'participant_count': participantCount,
+      'first_saved_at': firstSavedAt.toIso8601String(),
+      'last_opened_at': lastOpenedAt.toIso8601String(),
+    };
+  }
+
+  static LocalScheduleHistoryItem fromJson(Map<String, dynamic> json) {
+    return LocalScheduleHistoryItem(
+      publicId: json['public_id'] as String? ?? '',
+      title: json['title'] as String? ?? '無題の対戦表',
+      courtCount: json['court_count'] as int? ?? 0,
+      participantCount: json['participant_count'] as int? ?? 0,
+      firstSavedAt:
+          DateTime.tryParse(json['first_saved_at'] as String? ?? '') ??
+              DateTime.now(),
+      lastOpenedAt:
+          DateTime.tryParse(json['last_opened_at'] as String? ?? '') ??
+              DateTime.now(),
+    );
+  }
+}

--- a/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'local_schedule_history_item.dart';
+
+class LocalScheduleHistoryStore {
+  static const _key = 'lanske_recent_schedules';
+
+  Future<List<LocalScheduleHistoryItem>> findAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return const [];
+
+    final decoded = jsonDecode(raw);
+    if (decoded is! List) return const [];
+
+    return decoded
+        .whereType<Map<String, dynamic>>()
+        .map(LocalScheduleHistoryItem.fromJson)
+        .where((item) => item.publicId.isNotEmpty)
+        .toList(growable: false)
+      ..sort((a, b) => b.lastOpenedAt.compareTo(a.lastOpenedAt));
+  }
+
+  Future<void> upsert(LocalScheduleHistoryItem item) async {
+    final prefs = await SharedPreferences.getInstance();
+    final current = await findAll();
+
+    final existing = {
+      for (final currentItem in current) currentItem.publicId: currentItem,
+    };
+
+    final previous = existing[item.publicId];
+    existing[item.publicId] = LocalScheduleHistoryItem(
+      publicId: item.publicId,
+      title: item.title,
+      courtCount: item.courtCount,
+      participantCount: item.participantCount,
+      firstSavedAt: previous?.firstSavedAt ?? item.firstSavedAt,
+      lastOpenedAt: item.lastOpenedAt,
+    );
+
+    final next = existing.values.toList(growable: false)
+      ..sort((a, b) => b.lastOpenedAt.compareTo(a.lastOpenedAt));
+
+    final limited = next.take(20).map((item) => item.toJson()).toList();
+
+    await prefs.setString(_key, jsonEncode(limited));
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/event_list_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_list_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:srp_lanske/shared/utils/browser_url.dart';
 
 import '../data/local_schedule_history_item.dart';
 import '../data/local_schedule_history_store.dart';
@@ -36,6 +37,19 @@ class _EventListPageState extends State<EventListPage> {
       MaterialPageRoute(
         builder: (_) => RestoredSchedulePage(publicId: item.publicId),
       ),
+    );
+
+    _replaceBrowserUrlWithPublicId(item.publicId);
+  }
+
+  void _replaceBrowserUrlWithPublicId(String publicId) {
+    replaceUrl(
+      Uri.base.replace(
+        queryParameters: {
+          ...Uri.base.queryParameters,
+          'sid': publicId,
+        },
+      ).toString(),
     );
   }
 

--- a/lib/features/doubles_scheduler/presentation/event_list_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_list_page.dart
@@ -1,56 +1,103 @@
 import 'package:flutter/material.dart';
 
-import '../data/mock_log_store.dart';
-import 'schedule_page.dart';
+import '../data/local_schedule_history_item.dart';
+import '../data/local_schedule_history_store.dart';
+import 'restored_schedule_page.dart';
 
-class EventListPage extends StatelessWidget {
+class EventListPage extends StatefulWidget {
   const EventListPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final items = MockLogStore.items;
+  State<EventListPage> createState() => _EventListPageState();
+}
 
+class _EventListPageState extends State<EventListPage> {
+  late Future<List<LocalScheduleHistoryItem>> _itemsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _itemsFuture = LocalScheduleHistoryStore().findAll();
+  }
+
+  String _formatDateTime(DateTime dateTime) {
+    final y = dateTime.year.toString().padLeft(4, '0');
+    final m = dateTime.month.toString().padLeft(2, '0');
+    final d = dateTime.day.toString().padLeft(2, '0');
+    final hh = dateTime.hour.toString().padLeft(2, '0');
+    final mm = dateTime.minute.toString().padLeft(2, '0');
+
+    return '$y/$m/$d $hh:$mm';
+  }
+
+  void _openSchedule(LocalScheduleHistoryItem item) {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (_) => RestoredSchedulePage(publicId: item.publicId),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('対戦表一覧'),
       ),
-      body: items.isEmpty
-          ? const Center(
-              child: Text('まだ保存された対戦表はありません'),
-            )
-          : ListView.separated(
-              padding: const EdgeInsets.all(4),
-              itemCount: items.length,
-              separatorBuilder: (_, __) => const SizedBox(height: 12),
-              itemBuilder: (context, index) {
-                final item = items[index];
-                final draft = item.draft;
+      body: FutureBuilder<List<LocalScheduleHistoryItem>>(
+        future: _itemsFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(
+              child: CircularProgressIndicator(),
+            );
+          }
 
-                return Card(
-                  child: ListTile(
-                    title: Text(draft.eventName),
-                    subtitle: Text(
-                      '面数: ${draft.courts} / 人数: ${draft.players}\n'
-                      '保存日時: ${item.savedAt.year}/'
-                      '${item.savedAt.month.toString().padLeft(2, '0')}/'
-                      '${item.savedAt.day.toString().padLeft(2, '0')} '
-                      '${item.savedAt.hour.toString().padLeft(2, '0')}:'
-                      '${item.savedAt.minute.toString().padLeft(2, '0')}',
-                    ),
-                    isThreeLine: true,
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => SchedulePage(draft: draft),
-                        ),
-                      );
-                    },
+          if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  '対戦表一覧を取得できませんでした。\n'
+                  '${snapshot.error}',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+
+          final items = snapshot.data ?? const [];
+
+          if (items.isEmpty) {
+            return const Center(
+              child: Text('まだ開いた対戦表はありません'),
+            );
+          }
+
+          return ListView.separated(
+            padding: const EdgeInsets.all(4),
+            itemCount: items.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
+            itemBuilder: (context, index) {
+              final item = items[index];
+
+              return Card(
+                child: ListTile(
+                  title: Text(item.title),
+                  subtitle: Text(
+                    '面数: ${item.courtCount} / 人数: ${item.participantCount}\n'
+                    '最終表示: ${_formatDateTime(item.lastOpenedAt)}',
                   ),
-                );
-              },
-            ),
+                  isThreeLine: true,
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () => _openSchedule(item),
+                ),
+              );
+            },
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -5,6 +5,7 @@ import 'package:srp_lanske/shared/utils/number_label_mapper.dart';
 
 import '../domain/participant_draft.dart';
 import '../infrastructure/tennisbear_import_preview_api_client.dart';
+import 'event_list_page.dart';
 import 'models/event_draft.dart';
 import 'schedule_page.dart';
 
@@ -15,6 +16,8 @@ class EventSetupPage extends StatefulWidget {
   @override
   State<EventSetupPage> createState() => _EventSetupPageState();
 }
+
+enum _EventSetupMenuAction { list }
 
 class _EventSetupPageState extends State<EventSetupPage> {
   final _formKey = GlobalKey<FormState>();
@@ -97,6 +100,17 @@ class _EventSetupPageState extends State<EventSetupPage> {
     }
 
     super.dispose();
+  }
+
+  void _handleMenu(_EventSetupMenuAction action) {
+    switch (action) {
+      case _EventSetupMenuAction.list:
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const EventListPage()),
+        );
+        break;
+    }
   }
 
   void _showMessage(String message) {
@@ -691,6 +705,17 @@ class _EventSetupPageState extends State<EventSetupPage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('ダブルス乱数表 ver0.1'),
+        actions: [
+          PopupMenuButton<_EventSetupMenuAction>(
+            onSelected: _handleMenu,
+            itemBuilder: (context) => const [
+              PopupMenuItem(
+                value: _EventSetupMenuAction.list,
+                child: Text('対戦表一覧'),
+              ),
+            ],
+          ),
+        ],
       ),
       body: SafeArea(
         child: Stack(

--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -577,21 +577,24 @@ class _EventSetupPageState extends State<EventSetupPage> {
           ),
         ),
         const SizedBox(height: 12),
-        Wrap(
-          spacing: 12,
-          runSpacing: 12,
-          children: [
-            OutlinedButton.icon(
-              onPressed: _canPasteEventUrl ? _pasteEventUrl : null,
-              icon: const Icon(Icons.content_paste),
-              label: const Text('貼り付け'),
-            ),
-            FilledButton.icon(
-              onPressed: _canImportEventUrl ? _fetchEventInfo : null,
-              icon: const Icon(Icons.download),
-              label: const Text('取り込み'),
-            ),
-          ],
+        Center(
+          child: Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            alignment: WrapAlignment.center,
+            children: [
+              OutlinedButton.icon(
+                onPressed: _canPasteEventUrl ? _pasteEventUrl : null,
+                icon: const Icon(Icons.content_paste),
+                label: const Text('貼り付け'),
+              ),
+              FilledButton.icon(
+                onPressed: _canImportEventUrl ? _fetchEventInfo : null,
+                icon: const Icon(Icons.download),
+                label: const Text('取り込み'),
+              ),
+            ],
+          ),
         ),
       ],
     );
@@ -688,15 +691,6 @@ class _EventSetupPageState extends State<EventSetupPage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('ダブルス乱数表 ver0.1'),
-        actions: [
-          IconButton(
-            tooltip: '対戦表一覧',
-            onPressed: () {
-              // TODO: 対戦表一覧ページへ遷移
-            },
-            icon: const Icon(Icons.history),
-          ),
-        ],
       ),
       body: SafeArea(
         child: Stack(
@@ -751,6 +745,7 @@ class _EventSetupPageState extends State<EventSetupPage> {
                       ),
                       const SizedBox(height: 24),
                       _buildDetailSection(),
+                      const SizedBox(height: 80),
                     ],
                   ),
                 ),

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:srp_lanske/app/config/app_config.dart';
+import 'package:srp_lanske/features/doubles_scheduler/presentation/event_setup_page.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
+import 'package:srp_lanske/shared/utils/browser_url.dart';
 
 import '../application/generated_schedule_service.dart';
 import '../data/local_schedule_history_item.dart';
@@ -527,7 +529,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   void _handleMenu(_ScheduleMenuAction action) {
     switch (action) {
       case _ScheduleMenuAction.top:
-        Navigator.popUntil(context, (route) => route.isFirst);
+        _goTop();
         break;
       case _ScheduleMenuAction.list:
         Navigator.push(
@@ -536,6 +538,18 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         );
         break;
     }
+  }
+
+  void _goTop() {
+    Navigator.pushAndRemoveUntil(
+      context,
+      MaterialPageRoute(builder: (_) => const EventSetupPage()),
+      (_) => false,
+    );
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      replaceUrl('/');
+    });
   }
 
   EventDraft _buildDraft(SavedEventAggregate aggregate) {

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -4,10 +4,13 @@ import 'package:srp_lanske/app/config/app_config.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 
 import '../application/generated_schedule_service.dart';
+import '../data/local_schedule_history_item.dart';
+import '../data/local_schedule_history_store.dart';
 import '../domain/participant_draft.dart';
 import '../domain/public_id.dart';
 import '../domain/saved_event_models.dart';
 import '../infrastructure/generated_schedule_api_client.dart';
+import 'event_list_page.dart';
 import 'models/event_draft.dart';
 import 'widgets/schedule_action_buttons.dart';
 import 'widgets/schedule_event_summary_card.dart';
@@ -26,6 +29,8 @@ class RestoredSchedulePage extends StatefulWidget {
   @override
   State<RestoredSchedulePage> createState() => _RestoredSchedulePageState();
 }
+
+enum _ScheduleMenuAction { top, list }
 
 class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   late final GeneratedScheduleService _service;
@@ -305,6 +310,11 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
             generatedScheduleId;
         _isLoading = false;
       });
+
+      final aggregate = _savedEvent;
+      if (aggregate != null) {
+        await _saveScheduleHistory(aggregate);
+      }
     } catch (e) {
       if (!mounted) return;
 
@@ -416,6 +426,8 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         _generatedScheduleId = generatedScheduleId;
         _isLoading = false;
       });
+
+      await _saveScheduleHistory(nextSavedEvent);
     } catch (e) {
       if (!mounted) return;
 
@@ -476,9 +488,11 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
 
       if (!mounted) return;
 
+      final nextSavedEvent = _replaceSavedEvent(latestEvent, updatedEvent);
       setState(() {
-        _savedEvent = _replaceSavedEvent(latestEvent, updatedEvent);
+        _savedEvent = nextSavedEvent;
       });
+      await _saveScheduleHistory(nextSavedEvent);
 
       _showMessage('この対戦表を採用しました');
       await _reloadSchedule();
@@ -494,6 +508,33 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           _isAdopting = false;
         });
       }
+    }
+  }
+
+  Future<void> _saveScheduleHistory(SavedEventAggregate aggregate) async {
+    await LocalScheduleHistoryStore().upsert(
+      LocalScheduleHistoryItem(
+        publicId: aggregate.event.publicId,
+        title: aggregate.event.title,
+        courtCount: aggregate.event.courtCount,
+        participantCount: aggregate.participants.length,
+        firstSavedAt: DateTime.now(),
+        lastOpenedAt: DateTime.now(),
+      ),
+    );
+  }
+
+  void _handleMenu(_ScheduleMenuAction action) {
+    switch (action) {
+      case _ScheduleMenuAction.top:
+        Navigator.popUntil(context, (route) => route.isFirst);
+        break;
+      case _ScheduleMenuAction.list:
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const EventListPage()),
+        );
+        break;
     }
   }
 
@@ -627,7 +668,26 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(_pageTitle),
+        automaticallyImplyLeading: false,
+        title: Text(
+          _pageTitle,
+          overflow: TextOverflow.ellipsis,
+        ),
+        actions: [
+          PopupMenuButton<_ScheduleMenuAction>(
+            onSelected: _handleMenu,
+            itemBuilder: (context) => const [
+              PopupMenuItem(
+                value: _ScheduleMenuAction.top,
+                child: Text('TOPへ'),
+              ),
+              PopupMenuItem(
+                value: _ScheduleMenuAction.list,
+                child: Text('対戦表一覧'),
+              ),
+            ],
+          ),
+        ],
       ),
       body: SafeArea(
         child: showInitialLoading

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -63,29 +63,19 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   }
 
   String get _eventStatusLabel {
-    final event = _savedEvent?.event;
-    if (event == null) return '-';
-
-    if (_hasAdoptedSchedule) {
-      return '採用済み';
-    }
-
-    final generatedScheduleId = event.displayGeneratedScheduleId;
-    if (_isLoading &&
-        (generatedScheduleId == null || generatedScheduleId.isEmpty)) {
+    if (_isLoading && _scheduleResponse == null) {
       return '生成中';
     }
 
-    if (_isLoading) {
-      return '処理中';
-    }
+    final generatedScheduleId =
+        _savedEvent?.event.displayGeneratedScheduleId ?? _generatedScheduleId;
 
     if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
       return '未生成';
     }
 
-    if (_scheduleResponse == null && _errorMessage != null) {
-      return '取得失敗';
+    if (_isLoading || _isAdopting) {
+      return '処理中';
     }
 
     return '生成済み';
@@ -281,7 +271,10 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       }
 
       await _fetchSchedule(generatedScheduleId);
-    } catch (e) {
+    } catch (e, stackTrace) {
+      debugPrint('Failed to restore schedule: $e');
+      debugPrintStack(stackTrace: stackTrace);
+
       if (!mounted) return;
 
       setState(() {
@@ -289,7 +282,8 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         _scheduleResponse = null;
         _generatedScheduleId = null;
         _selectedParticipantId = null;
-        _errorMessage = '共有情報を取得できませんでした: $e';
+        _errorMessage = '対戦表を取得できませんでした。\n'
+            '通信状態を確認して、再読み込みしてください。';
         _isLoading = false;
       });
     }
@@ -569,7 +563,6 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           )
         else ...[
           ScheduleEventSummaryCard(
-            statusLabel: _eventStatusLabel,
             onCopyShareUrl: _copyShareUrl,
             onRefresh: _reloadSchedule,
             canRefresh: _generatedScheduleId != null,
@@ -586,6 +579,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
             const SizedBox(height: 12),
             ScheduleSectionCard(
               child: ScheduleActionButtons(
+                statusLabel: _eventStatusLabel,
                 isLoading: _isLoading,
                 isAdopting: _isAdopting,
                 generateButtonLabel: _generateButtonLabel,

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -4,6 +4,8 @@ import 'package:srp_lanske/app/config/app_config.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 
 import '../application/generated_schedule_service.dart';
+import '../data/local_schedule_history_item.dart';
+import '../data/local_schedule_history_store.dart';
 import '../domain/saved_event_models.dart';
 import '../infrastructure/generated_schedule_api_client.dart';
 import 'event_list_page.dart';
@@ -284,6 +286,8 @@ class _SchedulePageState extends State<SchedulePage> {
         _scheduleResponse = response;
         _generatedScheduleId = generatedScheduleId;
       });
+
+      await _saveScheduleHistory(nextSavedEvent);
     } catch (e) {
       if (!mounted) return;
 
@@ -408,9 +412,11 @@ class _SchedulePageState extends State<SchedulePage> {
 
       if (!mounted) return;
 
+      final nextSavedEvent = _replaceSavedEvent(latestEvent, updatedEvent);
       setState(() {
-        _savedEvent = _replaceSavedEvent(latestEvent, updatedEvent);
+        _savedEvent = nextSavedEvent;
       });
+      await _saveScheduleHistory(nextSavedEvent);
 
       _showMessage('この対戦表を採用しました');
       await _reloadSchedule();
@@ -427,6 +433,19 @@ class _SchedulePageState extends State<SchedulePage> {
         });
       }
     }
+  }
+
+  Future<void> _saveScheduleHistory(SavedEventAggregate aggregate) async {
+    await LocalScheduleHistoryStore().upsert(
+      LocalScheduleHistoryItem(
+        publicId: aggregate.event.publicId,
+        title: aggregate.event.title,
+        courtCount: aggregate.event.courtCount,
+        participantCount: aggregate.participants.length,
+        firstSavedAt: DateTime.now(),
+        lastOpenedAt: DateTime.now(),
+      ),
+    );
   }
 
   void _handleMenu(_ScheduleMenuAction action) {

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -23,7 +23,7 @@ class SchedulePage extends StatefulWidget {
   State<SchedulePage> createState() => _SchedulePageState();
 }
 
-enum _ScheduleMenuAction { edit, list }
+enum _ScheduleMenuAction { top, list }
 
 class _SchedulePageState extends State<SchedulePage> {
   late final GeneratedScheduleService _service;
@@ -57,16 +57,8 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   String get _eventStatusLabel {
-    if (_hasAdoptedSchedule) {
-      return '採用済み';
-    }
-
     if (_isLoading && _scheduleResponse == null) {
       return '生成中';
-    }
-
-    if (_errorMessage != null && _scheduleResponse == null) {
-      return '生成失敗';
     }
 
     final generatedScheduleId =
@@ -76,7 +68,7 @@ class _SchedulePageState extends State<SchedulePage> {
       return '未生成';
     }
 
-    if (_isLoading) {
+    if (_isLoading || _isAdopting) {
       return '処理中';
     }
 
@@ -439,8 +431,8 @@ class _SchedulePageState extends State<SchedulePage> {
 
   void _handleMenu(_ScheduleMenuAction action) {
     switch (action) {
-      case _ScheduleMenuAction.edit:
-        Navigator.pop(context);
+      case _ScheduleMenuAction.top:
+        Navigator.popUntil(context, (route) => route.isFirst);
         break;
       case _ScheduleMenuAction.list:
         Navigator.push(
@@ -456,7 +448,6 @@ class _SchedulePageState extends State<SchedulePage> {
       padding: const EdgeInsets.all(4),
       children: [
         ScheduleEventSummaryCard(
-          statusLabel: _eventStatusLabel,
           onCopyShareUrl: _savedEvent == null ? null : _copyShareUrl,
           onRefresh: _reloadSchedule,
           canRefresh: _generatedScheduleId != null,
@@ -473,6 +464,7 @@ class _SchedulePageState extends State<SchedulePage> {
           const SizedBox(height: 12),
           ScheduleSectionCard(
             child: ScheduleActionButtons(
+              statusLabel: _eventStatusLabel,
               isLoading: _isLoading,
               isAdopting: _isAdopting,
               generateButtonLabel: _generateButtonLabel,
@@ -519,14 +511,15 @@ class _SchedulePageState extends State<SchedulePage> {
 
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         title: Text(widget.draft.eventName),
         actions: [
           PopupMenuButton<_ScheduleMenuAction>(
             onSelected: _handleMenu,
             itemBuilder: (context) => const [
               PopupMenuItem(
-                value: _ScheduleMenuAction.edit,
-                child: Text('このイベントを編集'),
+                value: _ScheduleMenuAction.top,
+                child: Text('TOPへ'),
               ),
               PopupMenuItem(
                 value: _ScheduleMenuAction.list,

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:srp_lanske/app/config/app_config.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
+import 'package:srp_lanske/shared/utils/browser_url.dart';
 
 import '../application/generated_schedule_service.dart';
 import '../data/local_schedule_history_item.dart';
@@ -9,6 +10,7 @@ import '../data/local_schedule_history_store.dart';
 import '../domain/saved_event_models.dart';
 import '../infrastructure/generated_schedule_api_client.dart';
 import 'event_list_page.dart';
+import 'event_setup_page.dart';
 import 'models/event_draft.dart';
 import 'widgets/schedule_action_buttons.dart';
 import 'widgets/schedule_event_summary_card.dart';
@@ -216,6 +218,17 @@ class _SchedulePageState extends State<SchedulePage> {
     );
   }
 
+  void _replaceBrowserUrlWithPublicId(String publicId) {
+    replaceUrl(
+      Uri.base.replace(
+        queryParameters: {
+          ...Uri.base.queryParameters,
+          'sid': publicId,
+        },
+      ).toString(),
+    );
+  }
+
   String? _buildShareUrl() {
     final publicId = _savedEvent?.event.publicId;
     if (publicId == null || publicId.isEmpty) return null;
@@ -287,6 +300,7 @@ class _SchedulePageState extends State<SchedulePage> {
         _generatedScheduleId = generatedScheduleId;
       });
 
+      _replaceBrowserUrlWithPublicId(nextSavedEvent.event.publicId);
       await _saveScheduleHistory(nextSavedEvent);
     } catch (e) {
       if (!mounted) return;
@@ -451,7 +465,7 @@ class _SchedulePageState extends State<SchedulePage> {
   void _handleMenu(_ScheduleMenuAction action) {
     switch (action) {
       case _ScheduleMenuAction.top:
-        Navigator.popUntil(context, (route) => route.isFirst);
+        _goTop();
         break;
       case _ScheduleMenuAction.list:
         Navigator.push(
@@ -460,6 +474,18 @@ class _SchedulePageState extends State<SchedulePage> {
         );
         break;
     }
+  }
+
+  void _goTop() {
+    Navigator.pushAndRemoveUntil(
+      context,
+      MaterialPageRoute(builder: (_) => const EventSetupPage()),
+      (_) => false,
+    );
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      replaceUrl('/');
+    });
   }
 
   Widget _buildScheduleBody() {

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_action_buttons.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_action_buttons.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 class ScheduleActionButtons extends StatelessWidget {
   const ScheduleActionButtons({
     super.key,
+    required this.statusLabel,
     required this.isLoading,
     required this.isAdopting,
     required this.generateButtonLabel,
@@ -11,6 +12,7 @@ class ScheduleActionButtons extends StatelessWidget {
     required this.onAdopt,
   });
 
+  final String statusLabel;
   final bool isLoading;
   final bool isAdopting;
   final String generateButtonLabel;
@@ -20,15 +22,15 @@ class ScheduleActionButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Wrap(
-      spacing: 12,
-      runSpacing: 12,
+    final buttons = Row(
+      mainAxisSize: MainAxisSize.min,
       children: [
         FilledButton.icon(
           onPressed: isLoading ? null : onGenerate,
           icon: const Icon(Icons.refresh),
           label: Text(generateButtonLabel),
         ),
+        const SizedBox(width: 12),
         FilledButton.icon(
           onPressed: (isLoading || isAdopting || !canAdopt) ? null : onAdopt,
           icon: isAdopting
@@ -39,6 +41,19 @@ class ScheduleActionButtons extends StatelessWidget {
                 )
               : const Icon(Icons.check),
           label: Text(isAdopting ? '採用中' : 'この対戦表を採用'),
+        ),
+      ],
+    );
+
+    return Wrap(
+      spacing: 12,
+      runSpacing: 8,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        buttons,
+        Chip(
+          label: Text(statusLabel, style: const TextStyle(fontSize: 14)),
+          visualDensity: VisualDensity.compact,
         ),
       ],
     );

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -3,13 +3,11 @@ import 'package:flutter/material.dart';
 class ScheduleEventSummaryCard extends StatelessWidget {
   const ScheduleEventSummaryCard({
     super.key,
-    required this.statusLabel,
     this.onCopyShareUrl,
     this.onRefresh,
     this.canRefresh = true,
   });
 
-  final String statusLabel;
   final VoidCallback? onCopyShareUrl;
   final VoidCallback? onRefresh;
   final bool canRefresh;
@@ -27,11 +25,6 @@ class ScheduleEventSummaryCard extends StatelessWidget {
               runSpacing: 4,
               crossAxisAlignment: WrapCrossAlignment.center,
               children: [
-                Chip(
-                  label:
-                      Text(statusLabel, style: const TextStyle(fontSize: 14)),
-                  visualDensity: VisualDensity.compact,
-                ),
                 if (onCopyShareUrl != null)
                   OutlinedButton.icon(
                     onPressed: onCopyShareUrl,

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_player_chip.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_player_chip.dart
@@ -55,9 +55,9 @@ class SchedulePlayerChip extends StatelessWidget {
   double get _nameFontSize {
     switch (size) {
       case SchedulePlayerChipSize.normal:
-        return 9;
-      case SchedulePlayerChipSize.compact:
         return 8;
+      case SchedulePlayerChipSize.compact:
+        return 7;
     }
   }
 

--- a/lib/shared/utils/browser_url.dart
+++ b/lib/shared/utils/browser_url.dart
@@ -1,0 +1,1 @@
+export 'browser_url_stub.dart' if (dart.library.html) 'browser_url_web.dart';

--- a/lib/shared/utils/browser_url_stub.dart
+++ b/lib/shared/utils/browser_url_stub.dart
@@ -1,0 +1,1 @@
+void replaceUrl(String url) {}

--- a/lib/shared/utils/browser_url_web.dart
+++ b/lib/shared/utils/browser_url_web.dart
@@ -1,0 +1,5 @@
+import 'package:web/web.dart' as web;
+
+void replaceUrl(String url) {
+  web.window.history.replaceState(null, '', url);
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,8 +7,10 @@ import Foundation
 
 import cloud_firestore
 import firebase_core
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -558,7 +558,7 @@ packages:
     source: hosted
     version: "15.0.2"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -416,6 +416,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.23"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   firebase_core: ^4.9.0
   google_fonts: ^8.1.0
   shared_preferences: ^2.5.5
+  web: ^1.1.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   cloud_firestore: ^6.4.1
   firebase_core: ^4.9.0
   google_fonts: ^8.1.0
+  shared_preferences: ^2.5.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 概要

- #21 の共有URL MVP 手動スモークテスト中に見つかった導線・表示の問題を修正
- #45 として、ブラウザ保存の対戦表一覧を最小実装
- generate 後 / 対戦表一覧遷移時に URL の `sid` を更新し、リロード復元しやすくした
- TOP / 対戦表一覧 / 共有対戦表復元まわりの AppBar 導線を整理

## 変更内容

### #21 スモークテスト中の修正

- TOPへ遷移時に `route.isFirst` 依存をやめ、TOP画面へ戻るように修正
- generate 後にブラウザURLを `?sid={publicId}` へ更新
- 対戦表一覧から対戦表を開いたときも、ブラウザURLの `sid` を選択対象へ更新
- `RestoredSchedulePage` でも通常の対戦表画面と同様に AppBar メニューを表示
- プレイヤーチップの表示名が枠にかぶりにくいように調整
- 共有URL / 対戦表取得失敗時の表示文言を調整し、詳細は debug log に出す形へ整理

### #45 ブラウザ保存の対戦表一覧

- ブラウザローカルに最近扱った対戦表履歴を保存
- generate / adopt / 共有URL復元時に履歴を upsert
- TOP / 対戦表画面から「対戦表一覧」を開けるようにした
- 一覧から共有対戦表を開き直せるようにした
- 共有URLコピー前にブラウザリロードしても、TOP → 対戦表一覧から戻れる導線を追加

## スコープ外

- Firestore 全件一覧
- 他ユーザーの対戦表検索
- 参加者名検索
- 履歴の削除・並び替え・詳細管理
- 右側ドロワー表示

右側ドロワー表示は ver0.2 の #46 に分離。

## 手動確認

- [x] テニスベアURL保存
- [x] 貼り付けテキストから event / participant 候補作成
- [x] event / participant 確認・編集
- [x] generate
- [x] 再生成
- [x] adopt
- [x] URLコピー
- [x] 共有URLを別タブで開く
- [x] リロード復元
- [x] generate 後、URL が `?sid={publicId}` に更新される
- [x] TOPへ で `/` に戻る
- [x] 対戦表一覧から開いた対戦表の `sid` が URL に反映される
- [x] TOP → 対戦表一覧から最近の対戦表へ戻れる
- [x] 1面4人 / 1面6人 / 1面7人
- [x] 2面8人 / 2面11人 / 2面12人 / 2面13人 / 2面15人
- [x] `flutter analyze`

## 関連

Refs #21
Closes #45