### PR TITLE
♻️ refactor: Clean up web minor refactor for ver0.1.1

### DIFF
--- a/lib/features/doubles_scheduler/application/local_schedule_history_mapper.dart
+++ b/lib/features/doubles_scheduler/application/local_schedule_history_mapper.dart
@@ -1,0 +1,16 @@
+import '../data/local_schedule_history_item.dart';
+import '../domain/saved_event_models.dart';
+
+LocalScheduleHistoryItem buildLocalScheduleHistoryItem(
+  SavedEventAggregate aggregate, {
+  required DateTime now,
+}) {
+  return LocalScheduleHistoryItem(
+    publicId: aggregate.event.publicId,
+    title: aggregate.event.title,
+    courtCount: aggregate.event.courtCount,
+    participantCount: aggregate.participants.length,
+    firstSavedAt: now,
+    lastOpenedAt: now,
+  );
+}

--- a/lib/features/doubles_scheduler/application/saved_event_aggregate_helpers.dart
+++ b/lib/features/doubles_scheduler/application/saved_event_aggregate_helpers.dart
@@ -1,0 +1,13 @@
+import '../domain/saved_event_models.dart';
+
+SavedEventAggregate replaceSavedEventInAggregate(
+  SavedEventAggregate aggregate,
+  SavedEvent event,
+) {
+  return SavedEventAggregate(
+    event: event,
+    participants: aggregate.participants,
+    share: aggregate.share,
+    importRecord: aggregate.importRecord,
+  );
+}

--- a/lib/features/doubles_scheduler/application/schedule_share_url.dart
+++ b/lib/features/doubles_scheduler/application/schedule_share_url.dart
@@ -1,0 +1,11 @@
+String buildScheduleShareUrl({
+  required Uri baseUri,
+  required String publicId,
+}) {
+  return baseUri.replace(
+    queryParameters: {
+      ...baseUri.queryParameters,
+      'sid': publicId,
+    },
+  ).toString();
+}

--- a/lib/features/doubles_scheduler/application/tennisbear_event_url.dart
+++ b/lib/features/doubles_scheduler/application/tennisbear_event_url.dart
@@ -1,0 +1,47 @@
+class TennisbearEventUrl {
+  const TennisbearEventUrl({
+    required this.original,
+    required this.eventId,
+    required this.canonicalUrl,
+  });
+
+  final String original;
+  final String eventId;
+  final String canonicalUrl;
+}
+
+TennisbearEventUrl? parseTennisbearEventUrl(String value) {
+  final original = value.trim();
+  if (original.isEmpty) return null;
+
+  final uri = Uri.tryParse(original);
+  if (uri == null) return null;
+
+  if (uri.scheme != 'https') return null;
+
+  final host = uri.host.toLowerCase();
+  if (host != 'www.tennisbear.net' && host != 'tennisbear.net') {
+    return null;
+  }
+
+  final segments = uri.pathSegments
+      .map((segment) => segment.trim())
+      .where((segment) => segment.isNotEmpty)
+      .toList(growable: false);
+
+  if (segments.length < 2) return null;
+  if (segments[0] != 'event') return null;
+
+  final eventId = segments[1];
+  if (!RegExp(r'^\d+$').hasMatch(eventId)) return null;
+
+  if (segments.length >= 3 && segments[2] != 'info') {
+    return null;
+  }
+
+  return TennisbearEventUrl(
+    original: original,
+    eventId: eventId,
+    canonicalUrl: 'https://www.tennisbear.net/event/$eventId/info',
+  );
+}

--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -9,7 +9,7 @@ import '../infrastructure/tennisbear_import_preview_api_client.dart';
 import 'event_list_page.dart';
 import 'models/event_draft.dart';
 import 'schedule_page.dart';
-import 'widgets/event_setup_display_name_grid.dart';
+import 'widgets/event_setup_detail_section.dart';
 import 'widgets/event_setup_stepper_field.dart';
 import 'widgets/event_setup_url_section.dart';
 
@@ -515,68 +515,6 @@ class _EventSetupPageState extends State<EventSetupPage> {
     });
   }
 
-  Widget _buildDetailSection() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Divider(height: 32),
-        TextFormField(
-          controller: _eventNameController,
-          enabled: !_isLoadingEvent,
-          decoration: const InputDecoration(
-            labelText: 'イベント名',
-            border: OutlineInputBorder(),
-          ),
-        ),
-        const SizedBox(height: 16),
-        const Text(
-          '参加者表示名',
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-        ),
-        const SizedBox(height: 8),
-        EventSetupDisplayNameGrid(
-          controllers: _displayNameControllers,
-          focusNodes: _displayNameFocusNodes,
-          sourceDisplayNames: _sourceDisplayNames,
-          isLoadingEvent: _isLoadingEvent,
-        ),
-        const SizedBox(height: 20),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            FilledButton.tonal(
-              onPressed: _isLoadingEvent ? null : _resetInputs,
-              style: FilledButton.styleFrom(
-                minimumSize: Size.zero,
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              ),
-              child: const Text(
-                '入力項目のリセット',
-                style: TextStyle(fontSize: 16),
-              ),
-            ),
-            const SizedBox(width: 12),
-            FilledButton(
-              onPressed: _isLoadingEvent ? null : _submitForm,
-              style: FilledButton.styleFrom(
-                minimumSize: Size.zero,
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
-                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              ),
-              child: const Text(
-                '対戦表の生成',
-                style: TextStyle(fontSize: 22),
-              ),
-            ),
-          ],
-        ),
-      ],
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final urlText = _urlController.text.trim();
@@ -663,7 +601,15 @@ class _EventSetupPageState extends State<EventSetupPage> {
                         style: Theme.of(context).textTheme.bodySmall,
                       ),
                       const SizedBox(height: 24),
-                      _buildDetailSection(),
+                      EventSetupDetailSection(
+                        eventNameController: _eventNameController,
+                        displayNameControllers: _displayNameControllers,
+                        displayNameFocusNodes: _displayNameFocusNodes,
+                        sourceDisplayNames: _sourceDisplayNames,
+                        isLoadingEvent: _isLoadingEvent,
+                        onReset: _resetInputs,
+                        onSubmit: _submitForm,
+                      ),
                       const SizedBox(height: 80),
                     ],
                   ),

--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:srp_lanske/app/config/app_config.dart';
 import 'package:srp_lanske/shared/utils/number_label_mapper.dart';
 
+import '../application/tennisbear_event_url.dart';
 import '../domain/participant_draft.dart';
 import '../infrastructure/tennisbear_import_preview_api_client.dart';
 import 'event_list_page.dart';
@@ -52,8 +53,12 @@ class _EventSetupPageState extends State<EventSetupPage> {
 
   bool get _hasUrlInput => _urlController.text.trim().isNotEmpty;
 
+  TennisbearEventUrl? get _parsedTennisbearEventUrl {
+    return parseTennisbearEventUrl(_urlController.text);
+  }
+
   bool get _isValidTennisbearEventUrl {
-    return _isTennisbearEventUrl(_urlController.text.trim());
+    return _parsedTennisbearEventUrl != null;
   }
 
   bool get _canPasteEventUrl {
@@ -290,13 +295,14 @@ class _EventSetupPageState extends State<EventSetupPage> {
 
     FocusScope.of(context).unfocus();
 
-    final sourceUrl = _normalizeTennisbearEventUrl(_urlController.text);
-    if (sourceUrl.isEmpty) {
+    final originalUrl = _urlController.text.trim();
+    final parsedUrl = parseTennisbearEventUrl(originalUrl);
+    if (originalUrl.isEmpty) {
       _showMessage('URLを入力してください');
       return;
     }
 
-    if (!_isTennisbearEventUrl(sourceUrl)) {
+    if (parsedUrl == null) {
       _showMessage('テニスベアのイベントURLを入力してください');
       return;
     }
@@ -309,7 +315,7 @@ class _EventSetupPageState extends State<EventSetupPage> {
 
     try {
       final preview = await _tennisbearImportPreviewClient.preview(
-        sourceUrl: sourceUrl,
+        sourceUrl: parsedUrl.canonicalUrl,
       );
 
       final elapsed = DateTime.now().difference(startedAt);
@@ -328,7 +334,7 @@ class _EventSetupPageState extends State<EventSetupPage> {
       setState(() {
         _loadedFromUrl = true;
         _isUrlImportCompleted = true;
-        _importedSourceUrl = sourceUrl;
+        _importedSourceUrl = originalUrl;
 
         if (participantCount > 0) {
           _courts = _inferCourtsForPlayers(participantCount);
@@ -430,23 +436,6 @@ class _EventSetupPageState extends State<EventSetupPage> {
     return _buildEffectiveEventName();
   }
 
-  bool _isTennisbearEventUrl(String value) {
-    final normalized = _normalizeTennisbearEventUrl(value);
-    final uri = Uri.tryParse(normalized);
-    if (uri == null) return false;
-
-    if (uri.scheme != 'https') return false;
-    if (uri.host != 'www.tennisbear.net' && uri.host != 'tennisbear.net') {
-      return false;
-    }
-
-    final segments = uri.pathSegments;
-    if (segments.length != 3) return false;
-    if (segments[0] != 'event' || segments[2] != 'info') return false;
-
-    return RegExp(r'^\d+$').hasMatch(segments[1]);
-  }
-
   void _handleUrlChanged(String value) {
     final current = value.trim();
 
@@ -463,7 +452,7 @@ class _EventSetupPageState extends State<EventSetupPage> {
     if (!_canPasteEventUrl) return;
 
     final data = await Clipboard.getData('text/plain');
-    final text = _normalizeTennisbearEventUrl(data?.text?.trim() ?? '');
+    final text = data?.text?.trim() ?? '';
 
     if (text.isEmpty) {
       _showMessage('クリップボードにURLがありません');
@@ -479,13 +468,9 @@ class _EventSetupPageState extends State<EventSetupPage> {
       _urlController.selection = TextSelection.collapsed(offset: text.length);
     });
 
-    if (!_isTennisbearEventUrl(text)) {
+    if (parseTennisbearEventUrl(text) == null) {
       _showMessage('テニスベアのイベントURLを貼り付けてください');
     }
-  }
-
-  String _normalizeTennisbearEventUrl(String value) {
-    return value.trim().replaceFirst(RegExp(r'/+$'), '');
   }
 
   void _clearEventUrl() {

--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -9,6 +9,9 @@ import '../infrastructure/tennisbear_import_preview_api_client.dart';
 import 'event_list_page.dart';
 import 'models/event_draft.dart';
 import 'schedule_page.dart';
+import 'widgets/event_setup_display_name_grid.dart';
+import 'widgets/event_setup_stepper_field.dart';
+import 'widgets/event_setup_url_section.dart';
 
 class EventSetupPage extends StatefulWidget {
   // TODO: 編集時の initialDraft 対応
@@ -512,127 +515,6 @@ class _EventSetupPageState extends State<EventSetupPage> {
     });
   }
 
-  // TODO: 分離・共通化できそうなUI部品は切り出す
-  Widget _buildStepperField({
-    required String label,
-    required TextEditingController controller,
-    required VoidCallback onDecrement,
-    required VoidCallback onIncrement,
-    required String tooltipDecrement,
-    required String tooltipIncrement,
-  }) {
-    return Expanded(
-      child: Row(
-        children: [
-          IconButton(
-            onPressed: _isLoadingEvent ? null : onDecrement,
-            tooltip: tooltipDecrement,
-            icon: const Icon(Icons.remove_circle_outline),
-          ),
-          Expanded(
-            child: SizedBox(
-              width: 84,
-              child: TextFormField(
-                controller: controller,
-                readOnly: true,
-                enabled: !_isLoadingEvent,
-                textAlign: TextAlign.center,
-                decoration: InputDecoration(
-                  labelText: label,
-                  border: const OutlineInputBorder(),
-                  isDense: true,
-                ),
-              ),
-            ),
-          ),
-          IconButton(
-            onPressed: _isLoadingEvent ? null : onIncrement,
-            tooltip: tooltipIncrement,
-            icon: const Icon(Icons.add_circle_outline),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildUrlSection() {
-    final urlText = _urlController.text.trim();
-    final showUrlError = urlText.isNotEmpty && !_isValidTennisbearEventUrl;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        TextFormField(
-          controller: _urlController,
-          enabled: !_isLoadingEvent,
-          onChanged: _handleUrlChanged,
-          decoration: InputDecoration(
-            labelText: 'テニスベアのイベントURL',
-            helperText: '例: https://www.tennisbear.net/event/1156506/info',
-            errorText: showUrlError ? 'テニスベアのイベントURLを入力してください' : null,
-            border: const OutlineInputBorder(),
-            suffixIcon: _hasUrlInput
-                ? IconButton(
-                    tooltip: 'URLをクリア',
-                    onPressed: _canClearEventUrl ? _clearEventUrl : null,
-                    icon: const Icon(Icons.cancel_outlined),
-                  )
-                : null,
-          ),
-        ),
-        const SizedBox(height: 12),
-        Center(
-          child: Wrap(
-            spacing: 12,
-            runSpacing: 12,
-            alignment: WrapAlignment.center,
-            children: [
-              OutlinedButton.icon(
-                onPressed: _canPasteEventUrl ? _pasteEventUrl : null,
-                icon: const Icon(Icons.content_paste),
-                label: const Text('貼り付け'),
-              ),
-              FilledButton.icon(
-                onPressed: _canImportEventUrl ? _fetchEventInfo : null,
-                icon: const Icon(Icons.download),
-                label: const Text('取り込み'),
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildDisplayNameGrid() {
-    final items = List.generate(_displayNameControllers.length, (index) {
-      final sourceName = _sourceDisplayNames[index] ?? circledNumber(index + 1);
-      final labelSuffix = '：$sourceName';
-
-      return TextFormField(
-        controller: _displayNameControllers[index],
-        focusNode: _displayNameFocusNodes[index],
-        enabled: !_isLoadingEvent,
-        decoration: InputDecoration(
-          labelText: '参加者${participantLabelNumber(index)}$labelSuffix',
-          border: const OutlineInputBorder(),
-          isDense: true,
-        ),
-      );
-    });
-
-    return Wrap(
-      spacing: 12,
-      runSpacing: 12,
-      children: List.generate(items.length, (index) {
-        return SizedBox(
-          width: 140,
-          child: items[index],
-        );
-      }),
-    );
-  }
-
   Widget _buildDetailSection() {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -652,7 +534,12 @@ class _EventSetupPageState extends State<EventSetupPage> {
           style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
         ),
         const SizedBox(height: 8),
-        _buildDisplayNameGrid(),
+        EventSetupDisplayNameGrid(
+          controllers: _displayNameControllers,
+          focusNodes: _displayNameFocusNodes,
+          sourceDisplayNames: _sourceDisplayNames,
+          isLoadingEvent: _isLoadingEvent,
+        ),
         const SizedBox(height: 20),
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -692,6 +579,9 @@ class _EventSetupPageState extends State<EventSetupPage> {
 
   @override
   Widget build(BuildContext context) {
+    final urlText = _urlController.text.trim();
+    final showUrlError = urlText.isNotEmpty && !_isValidTennisbearEventUrl;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('ダブルス乱数表 ver0.1'),
@@ -729,23 +619,37 @@ class _EventSetupPageState extends State<EventSetupPage> {
                         style: TextStyle(fontSize: 12, color: Colors.black54),
                       ),
                       const SizedBox(height: 16),
-                      _buildUrlSection(),
+                      EventSetupUrlSection(
+                        controller: _urlController,
+                        isLoadingEvent: _isLoadingEvent,
+                        hasUrlInput: _hasUrlInput,
+                        showUrlError: showUrlError,
+                        canClearEventUrl: _canClearEventUrl,
+                        canPasteEventUrl: _canPasteEventUrl,
+                        canImportEventUrl: _canImportEventUrl,
+                        onChanged: _handleUrlChanged,
+                        onClear: _clearEventUrl,
+                        onPaste: _pasteEventUrl,
+                        onImport: _fetchEventInfo,
+                      ),
                       const SizedBox(height: 16),
                       Row(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          _buildStepperField(
+                          EventSetupStepperField(
                             label: '面数',
                             controller: _courtsController,
+                            isLoadingEvent: _isLoadingEvent,
                             onDecrement: _decrementCourts,
                             onIncrement: _incrementCourts,
                             tooltipDecrement: '面数を減らす',
                             tooltipIncrement: '面数を増やす',
                           ),
                           const SizedBox(width: 12),
-                          _buildStepperField(
+                          EventSetupStepperField(
                             label: '人数',
                             controller: _playersController,
+                            isLoadingEvent: _isLoadingEvent,
                             onDecrement: _decrementPlayers,
                             onIncrement: _incrementPlayers,
                             tooltipDecrement: '人数を減らす',

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -6,7 +6,9 @@ import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 import 'package:srp_lanske/shared/utils/browser_url.dart';
 
 import '../application/generated_schedule_service.dart';
-import '../data/local_schedule_history_item.dart';
+import '../application/local_schedule_history_mapper.dart';
+import '../application/saved_event_aggregate_helpers.dart';
+import '../application/schedule_share_url.dart';
 import '../data/local_schedule_history_store.dart';
 import '../domain/participant_draft.dart';
 import '../domain/public_id.dart';
@@ -398,7 +400,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           generatedScheduleId: generatedScheduleId,
         );
 
-        nextSavedEvent = _replaceSavedEvent(savedEvent, updatedEvent);
+        nextSavedEvent = replaceSavedEventInAggregate(savedEvent, updatedEvent);
       }
 
       if (!mounted) return;
@@ -471,7 +473,10 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
 
       if (!mounted) return;
 
-      final nextSavedEvent = _replaceSavedEvent(latestEvent, updatedEvent);
+      final nextSavedEvent = replaceSavedEventInAggregate(
+        latestEvent,
+        updatedEvent,
+      );
       setState(() {
         _savedEvent = nextSavedEvent;
       });
@@ -496,13 +501,9 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
 
   Future<void> _saveScheduleHistory(SavedEventAggregate aggregate) async {
     await LocalScheduleHistoryStore().upsert(
-      LocalScheduleHistoryItem(
-        publicId: aggregate.event.publicId,
-        title: aggregate.event.title,
-        courtCount: aggregate.event.courtCount,
-        participantCount: aggregate.participants.length,
-        firstSavedAt: DateTime.now(),
-        lastOpenedAt: DateTime.now(),
+      buildLocalScheduleHistoryItem(
+        aggregate,
+        now: DateTime.now(),
       ),
     );
   }
@@ -547,27 +548,10 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     );
   }
 
-  SavedEventAggregate _replaceSavedEvent(
-    SavedEventAggregate aggregate,
-    SavedEvent event,
-  ) {
-    return SavedEventAggregate(
-      event: event,
-      participants: aggregate.participants,
-      share: aggregate.share,
-      importRecord: aggregate.importRecord,
-    );
-  }
-
   String _buildShareUrl() {
     final publicId = _savedEvent?.event.publicId ?? widget.publicId;
 
-    return Uri.base.replace(
-      queryParameters: {
-        ...Uri.base.queryParameters,
-        'sid': publicId,
-      },
-    ).toString();
+    return buildScheduleShareUrl(baseUri: Uri.base, publicId: publicId);
   }
 
   Future<void> _copyShareUrl() async {

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -5,7 +5,9 @@ import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 import 'package:srp_lanske/shared/utils/browser_url.dart';
 
 import '../application/generated_schedule_service.dart';
-import '../data/local_schedule_history_item.dart';
+import '../application/local_schedule_history_mapper.dart';
+import '../application/saved_event_aggregate_helpers.dart';
+import '../application/schedule_share_url.dart';
 import '../data/local_schedule_history_store.dart';
 import '../domain/saved_event_models.dart';
 import '../infrastructure/generated_schedule_api_client.dart';
@@ -187,39 +189,15 @@ class _SchedulePageState extends State<SchedulePage> {
     return savedEvent;
   }
 
-  SavedEventAggregate _replaceSavedEvent(
-    SavedEventAggregate aggregate,
-    SavedEvent event,
-  ) {
-    return SavedEventAggregate(
-      event: event,
-      participants: aggregate.participants,
-      share: aggregate.share,
-      importRecord: aggregate.importRecord,
-    );
-  }
-
   void _replaceBrowserUrlWithPublicId(String publicId) {
-    replaceUrl(
-      Uri.base.replace(
-        queryParameters: {
-          ...Uri.base.queryParameters,
-          'sid': publicId,
-        },
-      ).toString(),
-    );
+    replaceUrl(buildScheduleShareUrl(baseUri: Uri.base, publicId: publicId));
   }
 
   String? _buildShareUrl() {
     final publicId = _savedEvent?.event.publicId;
     if (publicId == null || publicId.isEmpty) return null;
 
-    return Uri.base.replace(
-      queryParameters: {
-        ...Uri.base.queryParameters,
-        'sid': publicId,
-      },
-    ).toString();
+    return buildScheduleShareUrl(baseUri: Uri.base, publicId: publicId);
   }
 
   Future<void> _copyShareUrl() async {
@@ -270,7 +248,7 @@ class _SchedulePageState extends State<SchedulePage> {
           generatedScheduleId: generatedScheduleId,
         );
 
-        nextSavedEvent = _replaceSavedEvent(savedEvent, updatedEvent);
+        nextSavedEvent = replaceSavedEventInAggregate(savedEvent, updatedEvent);
       }
 
       if (!mounted) return;
@@ -407,7 +385,10 @@ class _SchedulePageState extends State<SchedulePage> {
 
       if (!mounted) return;
 
-      final nextSavedEvent = _replaceSavedEvent(latestEvent, updatedEvent);
+      final nextSavedEvent = replaceSavedEventInAggregate(
+        latestEvent,
+        updatedEvent,
+      );
       setState(() {
         _savedEvent = nextSavedEvent;
       });
@@ -432,13 +413,9 @@ class _SchedulePageState extends State<SchedulePage> {
 
   Future<void> _saveScheduleHistory(SavedEventAggregate aggregate) async {
     await LocalScheduleHistoryStore().upsert(
-      LocalScheduleHistoryItem(
-        publicId: aggregate.event.publicId,
-        title: aggregate.event.title,
-        courtCount: aggregate.event.courtCount,
-        participantCount: aggregate.participants.length,
-        firstSavedAt: DateTime.now(),
-        lastOpenedAt: DateTime.now(),
+      buildLocalScheduleHistoryItem(
+        aggregate,
+        now: DateTime.now(),
       ),
     );
   }

--- a/lib/features/doubles_scheduler/presentation/widgets/event_setup_action_buttons.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/event_setup_action_buttons.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+class EventSetupActionButtons extends StatelessWidget {
+  const EventSetupActionButtons({
+    super.key,
+    required this.isLoadingEvent,
+    required this.onReset,
+    required this.onSubmit,
+  });
+
+  final bool isLoadingEvent;
+  final VoidCallback onReset;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        FilledButton.tonal(
+          onPressed: isLoadingEvent ? null : onReset,
+          style: FilledButton.styleFrom(
+            minimumSize: Size.zero,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+          child: const Text(
+            '入力項目のリセット',
+            style: TextStyle(fontSize: 16),
+          ),
+        ),
+        const SizedBox(width: 12),
+        FilledButton(
+          onPressed: isLoadingEvent ? null : onSubmit,
+          style: FilledButton.styleFrom(
+            minimumSize: Size.zero,
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+          child: const Text(
+            '対戦表の生成',
+            style: TextStyle(fontSize: 22),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/widgets/event_setup_detail_section.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/event_setup_detail_section.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+import 'event_setup_action_buttons.dart';
+import 'event_setup_display_name_grid.dart';
+
+class EventSetupDetailSection extends StatelessWidget {
+  const EventSetupDetailSection({
+    super.key,
+    required this.eventNameController,
+    required this.displayNameControllers,
+    required this.displayNameFocusNodes,
+    required this.sourceDisplayNames,
+    required this.isLoadingEvent,
+    required this.onReset,
+    required this.onSubmit,
+  });
+
+  final TextEditingController eventNameController;
+  final List<TextEditingController> displayNameControllers;
+  final List<FocusNode> displayNameFocusNodes;
+  final List<String?> sourceDisplayNames;
+  final bool isLoadingEvent;
+  final VoidCallback onReset;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Divider(height: 32),
+        TextFormField(
+          controller: eventNameController,
+          enabled: !isLoadingEvent,
+          decoration: const InputDecoration(
+            labelText: 'イベント名',
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 16),
+        const Text(
+          '参加者表示名',
+          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        EventSetupDisplayNameGrid(
+          controllers: displayNameControllers,
+          focusNodes: displayNameFocusNodes,
+          sourceDisplayNames: sourceDisplayNames,
+          isLoadingEvent: isLoadingEvent,
+        ),
+        const SizedBox(height: 20),
+        EventSetupActionButtons(
+          isLoadingEvent: isLoadingEvent,
+          onReset: onReset,
+          onSubmit: onSubmit,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/widgets/event_setup_display_name_grid.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/event_setup_display_name_grid.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:srp_lanske/shared/utils/number_label_mapper.dart';
+
+class EventSetupDisplayNameGrid extends StatelessWidget {
+  const EventSetupDisplayNameGrid({
+    super.key,
+    required this.controllers,
+    required this.focusNodes,
+    required this.sourceDisplayNames,
+    required this.isLoadingEvent,
+  });
+
+  final List<TextEditingController> controllers;
+  final List<FocusNode> focusNodes;
+  final List<String?> sourceDisplayNames;
+  final bool isLoadingEvent;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      children: List.generate(controllers.length, (index) {
+        final sourceName = sourceDisplayNames[index] ?? circledNumber(index + 1);
+        final labelSuffix = '：$sourceName';
+
+        return SizedBox(
+          width: 140,
+          child: TextFormField(
+            controller: controllers[index],
+            focusNode: focusNodes[index],
+            enabled: !isLoadingEvent,
+            decoration: InputDecoration(
+              labelText: '参加者${participantLabelNumber(index)}$labelSuffix',
+              border: const OutlineInputBorder(),
+              isDense: true,
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/widgets/event_setup_display_name_grid.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/event_setup_display_name_grid.dart
@@ -21,7 +21,8 @@ class EventSetupDisplayNameGrid extends StatelessWidget {
       spacing: 12,
       runSpacing: 12,
       children: List.generate(controllers.length, (index) {
-        final sourceName = sourceDisplayNames[index] ?? circledNumber(index + 1);
+        final sourceName =
+            sourceDisplayNames[index] ?? circledNumber(index + 1);
         final labelSuffix = '：$sourceName';
 
         return SizedBox(

--- a/lib/features/doubles_scheduler/presentation/widgets/event_setup_stepper_field.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/event_setup_stepper_field.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+class EventSetupStepperField extends StatelessWidget {
+  const EventSetupStepperField({
+    super.key,
+    required this.label,
+    required this.controller,
+    required this.isLoadingEvent,
+    required this.onDecrement,
+    required this.onIncrement,
+    required this.tooltipDecrement,
+    required this.tooltipIncrement,
+  });
+
+  final String label;
+  final TextEditingController controller;
+  final bool isLoadingEvent;
+  final VoidCallback onDecrement;
+  final VoidCallback onIncrement;
+  final String tooltipDecrement;
+  final String tooltipIncrement;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Row(
+        children: [
+          IconButton(
+            onPressed: isLoadingEvent ? null : onDecrement,
+            tooltip: tooltipDecrement,
+            icon: const Icon(Icons.remove_circle_outline),
+          ),
+          Expanded(
+            child: SizedBox(
+              width: 84,
+              child: TextFormField(
+                controller: controller,
+                readOnly: true,
+                enabled: !isLoadingEvent,
+                textAlign: TextAlign.center,
+                decoration: InputDecoration(
+                  labelText: label,
+                  border: const OutlineInputBorder(),
+                  isDense: true,
+                ),
+              ),
+            ),
+          ),
+          IconButton(
+            onPressed: isLoadingEvent ? null : onIncrement,
+            tooltip: tooltipIncrement,
+            icon: const Icon(Icons.add_circle_outline),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/widgets/event_setup_url_section.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/event_setup_url_section.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+class EventSetupUrlSection extends StatelessWidget {
+  const EventSetupUrlSection({
+    super.key,
+    required this.controller,
+    required this.isLoadingEvent,
+    required this.hasUrlInput,
+    required this.showUrlError,
+    required this.canClearEventUrl,
+    required this.canPasteEventUrl,
+    required this.canImportEventUrl,
+    required this.onChanged,
+    required this.onClear,
+    required this.onPaste,
+    required this.onImport,
+  });
+
+  final TextEditingController controller;
+  final bool isLoadingEvent;
+  final bool hasUrlInput;
+  final bool showUrlError;
+  final bool canClearEventUrl;
+  final bool canPasteEventUrl;
+  final bool canImportEventUrl;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onClear;
+  final VoidCallback onPaste;
+  final VoidCallback onImport;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TextFormField(
+          controller: controller,
+          enabled: !isLoadingEvent,
+          onChanged: onChanged,
+          decoration: InputDecoration(
+            labelText: 'テニスベアのイベントURL',
+            helperText: '例: https://www.tennisbear.net/event/1156506/info',
+            errorText: showUrlError ? 'テニスベアのイベントURLを入力してください' : null,
+            border: const OutlineInputBorder(),
+            suffixIcon: hasUrlInput
+                ? IconButton(
+                    tooltip: 'URLをクリア',
+                    onPressed: canClearEventUrl ? onClear : null,
+                    icon: const Icon(Icons.cancel_outlined),
+                  )
+                : null,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Center(
+          child: Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            alignment: WrapAlignment.center,
+            children: [
+              OutlinedButton.icon(
+                onPressed: canPasteEventUrl ? onPaste : null,
+                icon: const Icon(Icons.content_paste),
+                label: const Text('貼り付け'),
+              ),
+              FilledButton.icon(
+                onPressed: canImportEventUrl ? onImport : null,
+                icon: const Icon(Icons.download),
+                label: const Text('取り込み'),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/doubles_scheduler/application/tennisbear_event_url_test.dart
+++ b/test/features/doubles_scheduler/application/tennisbear_event_url_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:srp_lanske/features/doubles_scheduler/application/tennisbear_event_url.dart';
+
+void main() {
+  group('parseTennisbearEventUrl', () {
+    test('accepts canonical and external share event URLs', () {
+      const cases = [
+        'https://www.tennisbear.net/event/1178229/info',
+        'https://www.tennisbear.net/event/1178229/info/',
+        'https://www.tennisbear.net/event/1178229/info/?openExternalBrowser=1',
+        'https://tennisbear.net/event/1178229/info/?openExternalBrowser=1',
+      ];
+
+      for (final value in cases) {
+        final parsed = parseTennisbearEventUrl(value);
+
+        expect(parsed, isNotNull, reason: value);
+        expect(parsed!.original, value);
+        expect(parsed.eventId, '1178229');
+        expect(
+          parsed.canonicalUrl,
+          'https://www.tennisbear.net/event/1178229/info',
+        );
+      }
+    });
+
+    test('accepts event URL without info path and canonicalizes it', () {
+      final parsed = parseTennisbearEventUrl(
+        'https://www.tennisbear.net/event/1178229',
+      );
+
+      expect(parsed, isNotNull);
+      expect(parsed!.eventId, '1178229');
+      expect(
+        parsed.canonicalUrl,
+        'https://www.tennisbear.net/event/1178229/info',
+      );
+    });
+
+    test('rejects non event URLs', () {
+      const cases = [
+        '',
+        'https://example.com/event/1178229/info',
+        'https://www.tennisbear.net/event/abc/info',
+        'https://www.tennisbear.net/user/1178229',
+        'http://www.tennisbear.net/event/1178229/info',
+      ];
+
+      for (final value in cases) {
+        expect(parseTennisbearEventUrl(value), isNull, reason: value);
+      }
+    });
+  });
+}

--- a/test/features/doubles_scheduler/domain/saved_event_models_test.dart
+++ b/test/features/doubles_scheduler/domain/saved_event_models_test.dart
@@ -187,7 +187,8 @@ void main() {
       expect(restored.importRecord, isNull);
     });
 
-    test('throws FormatException when required aggregate fields are missing', () {
+    test('throws FormatException when required aggregate fields are missing',
+        () {
       expect(
         () => SavedEventAggregate.fromJson({
           'schemaVersion': savedEventAggregateSchemaVersion,


### PR DESCRIPTION
## 概要

ver0.1.1 の web 軽微リファクタとして、主導線を大きく変えずに `EventSetupPage` / `SchedulePage` / `RestoredSchedulePage` 周辺を整理しました。

あわせて、TennisBear アプリの外部共有URLからコピーされる `?openExternalBrowser=1` 付きイベントURLを取り込み可能にしました。

## 対応範囲

### 1. `EventSetupPage` の入力系 UI helper / widget 分割

`EventSetupPage` 内にあった入力系 UI helper を、以下の widget に分割しました。

- `EventSetupStepperField`
- `EventSetupUrlSection`
- `EventSetupDisplayNameGrid`
- `EventSetupDetailSection`
- `EventSetupActionButtons`

対象:

- 面数 / 人数 stepper
- TennisBear URL 入力 section
- 参加者表示名 grid
- イベント名 / 参加者表示名 / reset / submit section

大きな state management 変更や controller 化は行っていません。

### 2. TennisBear 外部共有URL対応

TennisBear event URL の parse / validate / canonicalize helper を追加しました。

追加:

- `tennisbear_event_url.dart`
- `tennisbear_event_url_test.dart`

以下のようなURLを受け付けます。

```txt
https://www.tennisbear.net/event/1178229/info
https://www.tennisbear.net/event/1178229/info/
https://www.tennisbear.net/event/1178229/info/?openExternalBrowser=1
https://tennisbear.net/event/1178229/info/?openExternalBrowser=1
https://www.tennisbear.net/event/1178229
````

画面上はユーザーが貼り付けたURLをそのまま表示し、取り込みAPIへは以下の canonical URL を渡します。

```txt
https://www.tennisbear.net/event/{eventId}/info
```

### 3. `SchedulePage` / `RestoredSchedulePage` の小さな共通処理整理

`SchedulePage` / `RestoredSchedulePage` 間で重複していた小さな処理を helper 化しました。

追加:

* `local_schedule_history_mapper.dart`
* `saved_event_aggregate_helpers.dart`
* `schedule_share_url.dart`

整理対象:

* `SavedEventAggregate` の event 差し替え
* `SavedEventAggregate -> LocalScheduleHistoryItem` 変換
* `sid` 付き共有URL生成

page 統合、router 導入、本格 controller 化は行っていません。

### 4. localization 前提の文言整理

l10n 本格導入は行っていません。

ただし、URL section / detail section / action buttons などに UI 文言のまとまりを作り、今後の localization 方針整理と衝突しにくい形にしました。

## やらないこと

このPRでは以下は扱いません。

* 参加者削除 UI の本実装
* 参加者表示名入力欄のレスポンシブ改善本実装
* QRコード共有の本実装
* コート表示名 / コート位置の本実装
* Firestore 正本化
* repository / data model 再設計
* `SchedulePage` / `RestoredSchedulePage` の page 統合
* `SchedulePage` / `RestoredSchedulePage` の本格 controller 化
* router 導入
* l10n 本格導入
* TennisBear URL 取得失敗時の fallback 処理

## 確認

* [x] `dart format lib/ test/`
* [x] `flutter analyze`
* [x] `flutter test`
* [x] 手入力 1面6人 generate
* [x] TennisBear URL 取り込み → generate
* [x] `?openExternalBrowser=1` 付きURLの貼り付け → 取り込み
* [x] 入力リセット
* [x] 参加者表示名の表示確認
* [x] スマホ幅で大きく崩れていないことを確認
* [x] generate → URLコピー
* [x] sid付きURL表示
* [x] reload / shared URL reopening
* [x] TOP → 対戦表一覧 → 復元
* [x] adopt後の表示確認

## 補足

* Firestore 保存設計の変更なし
* route / navigation の大規模変更なし
* core API 仕様変更なし
* 既存の主要導線は維持

Closes #63
