### PR TITLE
🌐 feat: add ja/en localization foundation refs #56

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -37,14 +37,14 @@ docs 全体の入口は [Docs index](README.md) です。
 例:
 
 ```text
-feature/1-project-structure
-feature/2-page-skeleton
-feature/3-mock-generation-flow
+feat/1-project-structure
+feat/2-page-skeleton
+feat/3-mock-generation-flow
 docs/5-reorganize-docs
 refactor/63-split-event-setup-ui
 ```
 
-実装作業は `feature/`、docs 整理は `docs/`、リファクタリングは `refactor/` など、作業内容に合わせて選ぶ。
+実装作業は `feat/`、docs 整理は `docs/`、リファクタリングは `refactor/` など、作業内容に合わせて選ぶ。
 
 ---
 
@@ -200,7 +200,7 @@ docs のみの変更では、実装に影響しないことを確認したうえ
 - knockout
 - score
 
-feature単位で拡張していく
+機能単位で拡張していく
 
 ---
 

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,4 @@
+arb-dir: lib/l10n
+template-arb-file: app_ja.arb
+output-localization-file: app_localizations.dart
+nullable-getter: false

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
 
 import '../features/doubles_scheduler/presentation/event_setup_page.dart';
 import '../features/doubles_scheduler/presentation/restored_schedule_page.dart';
@@ -18,6 +19,9 @@ class App extends StatelessWidget {
     return MaterialApp(
       title: 'Lanske',
       debugShowCheckedModeBanner: true,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('ja'),
       theme: appTheme,
       home: home,
     );

--- a/lib/features/doubles_scheduler/data/local_schedule_history_item.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_item.dart
@@ -32,7 +32,7 @@ class LocalScheduleHistoryItem {
 
     return LocalScheduleHistoryItem(
       publicId: json['public_id'] as String? ?? '',
-      title: json['title'] as String? ?? '無題の対戦表',
+      title: json['title'] as String? ?? 'Untitled match table',
       courtCount: json['court_count'] as int? ?? 0,
       playerCount: rawPlayerCount as int? ?? 0,
       firstSavedAt:

--- a/lib/features/doubles_scheduler/infrastructure/tennisbear_import_preview_api_client.dart
+++ b/lib/features/doubles_scheduler/infrastructure/tennisbear_import_preview_api_client.dart
@@ -47,7 +47,8 @@ class TennisbearImportPreviewApiClient {
     if (response.statusCode < 200 || response.statusCode >= 300) {
       throw TennisbearImportPreviewApiException(
         statusCode: response.statusCode,
-        message: decoded['message']?.toString() ?? 'イベント情報の取得に失敗しました',
+        message: decoded['message']?.toString() ??
+            'Failed to load event information.',
         body: decoded,
       );
     }

--- a/lib/features/doubles_scheduler/presentation/event_list_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_list_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
 import 'package:srp_lanske/shared/utils/browser_url.dart';
 
 import '../data/local_schedule_history_item.dart';
@@ -55,9 +56,11 @@ class _EventListPageState extends State<EventListPage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('対戦表一覧'),
+        title: Text(l10n.matchTableList),
       ),
       body: FutureBuilder<List<LocalScheduleHistoryItem>>(
         future: _itemsFuture,
@@ -73,8 +76,7 @@ class _EventListPageState extends State<EventListPage> {
               child: Padding(
                 padding: const EdgeInsets.all(16),
                 child: Text(
-                  '対戦表一覧を取得できませんでした。\n'
-                  '${snapshot.error}',
+                  l10n.reloadScheduleFailedMessage(snapshot.error.toString()),
                   textAlign: TextAlign.center,
                 ),
               ),
@@ -84,8 +86,8 @@ class _EventListPageState extends State<EventListPage> {
           final items = snapshot.data ?? const [];
 
           if (items.isEmpty) {
-            return const Center(
-              child: Text('まだ開いた対戦表はありません'),
+            return Center(
+              child: Text(l10n.scheduleNotFoundMessage),
             );
           }
 
@@ -100,8 +102,8 @@ class _EventListPageState extends State<EventListPage> {
                 child: ListTile(
                   title: Text(item.title),
                   subtitle: Text(
-                    '面数: ${item.courtCount} / 人数: ${item.playerCount}\n'
-                    '最終表示: ${_formatDateTime(item.lastOpenedAt)}',
+                    '${l10n.schedulePlayersTitle(item.courtCount, item.playerCount)}\n'
+                    '${_formatDateTime(item.lastOpenedAt)}',
                   ),
                   isThreeLine: true,
                   trailing: const Icon(Icons.chevron_right),

--- a/lib/features/doubles_scheduler/presentation/event_list_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_list_page.dart
@@ -103,7 +103,7 @@ class _EventListPageState extends State<EventListPage> {
                   title: Text(item.title),
                   subtitle: Text(
                     '${l10n.schedulePlayersTitle(item.courtCount, item.playerCount)}\n'
-                    '${_formatDateTime(item.lastOpenedAt)}',
+                    '${l10n.lastOpenedAtLabel(_formatDateTime(item.lastOpenedAt))}',
                   ),
                   isThreeLine: true,
                   trailing: const Icon(Icons.chevron_right),

--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:srp_lanske/app/config/app_config.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
 import 'package:srp_lanske/shared/utils/number_label_mapper.dart';
 
 import '../application/tennisbear_event_url.dart';
@@ -300,17 +301,19 @@ class _EventSetupPageState extends State<EventSetupPage> {
   Future<void> _fetchEventInfo() async {
     if (_isLoadingEvent) return;
 
+    final l10n = AppLocalizations.of(context);
+
     FocusScope.of(context).unfocus();
 
     final originalUrl = _urlController.text.trim();
     final parsedUrl = parseTennisbearEventUrl(originalUrl);
     if (originalUrl.isEmpty) {
-      _showMessage('URLを入力してください');
+      _showMessage(l10n.enterUrlMessage);
       return;
     }
 
     if (parsedUrl == null) {
-      _showMessage('テニスベアのイベントURLを入力してください');
+      _showMessage(l10n.enterTennisbearEventUrlMessage);
       return;
     }
 
@@ -376,9 +379,9 @@ class _EventSetupPageState extends State<EventSetupPage> {
 
       final warnings = preview.warnings;
       if (warnings.isEmpty) {
-        _showMessage('イベント情報を取得しました');
+        _showMessage(l10n.eventInfoLoadedMessage);
       } else {
-        _showMessage('イベント情報を取得しました（一部情報は取得できませんでした）');
+        _showMessage(l10n.eventInfoPartiallyLoadedMessage);
       }
     } on TennisbearImportPreviewApiException catch (e) {
       final elapsed = DateTime.now().difference(startedAt);
@@ -398,7 +401,7 @@ class _EventSetupPageState extends State<EventSetupPage> {
 
       if (!mounted) return;
       // TODO: イベント情報取得失敗時のエラーログを送る仕組みができたら、ここで例外内容も送る。adminにメール送信するのもあり。
-      _showMessage('取得できませんでした。URLを確認して再度お試しください');
+      _showMessage(l10n.eventInfoLoadFailedMessage);
     } finally {
       if (mounted) {
         setState(() {
@@ -458,11 +461,13 @@ class _EventSetupPageState extends State<EventSetupPage> {
   Future<void> _pasteEventUrl() async {
     if (!_canPasteEventUrl) return;
 
+    final l10n = AppLocalizations.of(context);
+
     final data = await Clipboard.getData('text/plain');
     final text = data?.text?.trim() ?? '';
 
     if (text.isEmpty) {
-      _showMessage('クリップボードにURLがありません');
+      _showMessage(l10n.clipboardUrlNotFoundMessage);
       return;
     }
 
@@ -476,7 +481,7 @@ class _EventSetupPageState extends State<EventSetupPage> {
     });
 
     if (parseTennisbearEventUrl(text) == null) {
-      _showMessage('テニスベアのイベントURLを貼り付けてください');
+      _showMessage(l10n.pasteTennisbearEventUrlMessage);
     }
   }
 
@@ -521,19 +526,20 @@ class _EventSetupPageState extends State<EventSetupPage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final urlText = _urlController.text.trim();
     final showUrlError = urlText.isNotEmpty && !_isValidTennisbearEventUrl;
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('ダブルス乱数表 ver0.1'),
+        title: Text(l10n.eventSetupTitle),
         actions: [
           PopupMenuButton<_EventSetupMenuAction>(
             onSelected: _handleMenu,
-            itemBuilder: (context) => const [
+            itemBuilder: (context) => [
               PopupMenuItem(
                 value: _EventSetupMenuAction.list,
-                child: Text('対戦表一覧'),
+                child: Text(l10n.matchTableList),
               ),
             ],
           ),
@@ -551,14 +557,17 @@ class _EventSetupPageState extends State<EventSetupPage> {
                   child: ListView(
                     padding: const EdgeInsets.all(4),
                     children: [
-                      const Text(
-                        'URLを貼るか、手動で面数・人数を入力してください。',
-                        style: TextStyle(fontSize: 16),
+                      Text(
+                        l10n.eventSetupInstruction,
+                        style: const TextStyle(fontSize: 16),
                       ),
                       const SizedBox(height: 8),
-                      const Text(
-                        'ver0.1では、1面4〜7人 / 2面8〜15人に対応しています。',
-                        style: TextStyle(fontSize: 12, color: Colors.black54),
+                      Text(
+                        l10n.eventSetupSupportedConditions,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: Colors.black54,
+                        ),
                       ),
                       const SizedBox(height: 16),
                       EventSetupUrlSection(
@@ -579,29 +588,32 @@ class _EventSetupPageState extends State<EventSetupPage> {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           EventSetupStepperField(
-                            label: '面数',
+                            label: l10n.courtCountLabel,
                             controller: _courtsController,
                             isLoadingEvent: _isLoadingEvent,
                             onDecrement: _decrementCourts,
                             onIncrement: _incrementCourts,
-                            tooltipDecrement: '面数を減らす',
-                            tooltipIncrement: '面数を増やす',
+                            tooltipDecrement: l10n.decrementCourtCountTooltip,
+                            tooltipIncrement: l10n.incrementCourtCountTooltip,
                           ),
                           const SizedBox(width: 12),
                           EventSetupStepperField(
-                            label: '人数',
+                            label: l10n.playerCountLabel,
                             controller: _playerCountController,
                             isLoadingEvent: _isLoadingEvent,
                             onDecrement: _decrementPlayerCount,
                             onIncrement: _incrementPlayerCount,
-                            tooltipDecrement: '人数を減らす',
-                            tooltipIncrement: '人数を増やす',
+                            tooltipDecrement: l10n.decrementPlayerCountTooltip,
+                            tooltipIncrement: l10n.incrementPlayerCountTooltip,
                           ),
                         ],
                       ),
                       const SizedBox(height: 8),
                       Text(
-                        '人数は $_minPlayerCount 人以上、$_maxPlayerCount 人以下で入力してください。',
+                        l10n.playerCountRangeHelp(
+                          _minPlayerCount,
+                          _maxPlayerCount,
+                        ),
                         style: Theme.of(context).textTheme.bodySmall,
                       ),
                       const SizedBox(height: 24),
@@ -621,14 +633,14 @@ class _EventSetupPageState extends State<EventSetupPage> {
               ),
             ),
             if (_isLoadingEvent)
-              const Positioned.fill(
+              Positioned.fill(
                 child: Center(
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      CircularProgressIndicator(),
-                      SizedBox(height: 12),
-                      Text('イベント情報を取得中...'),
+                      const CircularProgressIndicator(),
+                      const SizedBox(height: 12),
+                      Text(l10n.loadingEventInfo),
                     ],
                   ),
                 ),

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:srp_lanske/app/config/app_config.dart';
 import 'package:srp_lanske/features/doubles_scheduler/presentation/event_setup_page.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 import 'package:srp_lanske/shared/utils/browser_url.dart';
 
@@ -58,7 +59,11 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       ),
     );
 
-    _restore();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _restore();
+      }
+    });
   }
 
   bool get _isAdopted => _scheduleResponse?['adopted'] == true;
@@ -67,15 +72,15 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     return _isAdopted || (_savedEvent?.event.hasAdoptedSchedule ?? false);
   }
 
-  String get _pageTitle {
-    return _savedEvent?.event.title ?? '共有対戦表';
+  String _pageTitle(AppLocalizations l10n) {
+    return _savedEvent?.event.title ?? l10n.matchTableTitle;
   }
 
-  String get _generateButtonLabel {
+  String _generateButtonLabel(AppLocalizations l10n) {
     final generatedScheduleId = _savedEvent?.event.displayGeneratedScheduleId;
     return generatedScheduleId == null || generatedScheduleId.isEmpty
-        ? '生成'
-        : '再生成';
+        ? l10n.generateButton
+        : l10n.regenerateButton;
   }
 
   bool get _hasGeneratedSchedule {
@@ -115,11 +120,12 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   }
 
   Future<void> _requestGenerateSchedule() async {
+    final l10n = AppLocalizations.of(context);
     final latestEvent = await _refreshSavedEventForAction();
     if (!mounted) return;
 
     if (latestEvent?.event.hasAdoptedSchedule == true) {
-      _showMessage('採用済みのため再生成できません');
+      _showMessage(l10n.cannotRegenerateAdoptedScheduleMessage);
       await _reloadSchedule();
       return;
     }
@@ -133,19 +139,16 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: const Text('再生成しますか？'),
-          content: const Text(
-            '現在表示している対戦表を新しい対戦表に差し替えます。\n'
-            '共有URLから表示される未採用の対戦表も、再生成後の内容に更新されます。',
-          ),
+          title: Text(l10n.regenerateConfirmTitle),
+          content: Text(l10n.regenerateConfirmBody),
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(context, false),
-              child: const Text('キャンセル'),
+              child: Text(l10n.cancelButton),
             ),
             FilledButton(
               onPressed: () => Navigator.pop(context, true),
-              child: const Text('再生成する'),
+              child: Text(l10n.regenerateActionButton),
             ),
           ],
         );
@@ -158,7 +161,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     if (!mounted) return;
 
     if (latestBeforeGenerate?.event.hasAdoptedSchedule == true) {
-      _showMessage('採用済みのため再生成できません');
+      _showMessage(l10n.cannotRegenerateAdoptedScheduleMessage);
       await _reloadSchedule();
       return;
     }
@@ -167,12 +170,13 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   }
 
   Future<SavedEventAggregate?> _refreshSavedEventForAction() async {
+    final l10n = AppLocalizations.of(context);
     final publicId =
         (_savedEvent?.event.publicId ?? widget.publicId).trim().toUpperCase();
 
     if (!isValidPublicId(publicId)) {
       setState(() {
-        _errorMessage = '共有IDが正しくありません';
+        _errorMessage = l10n.scheduleNotFoundMessage;
       });
       return null;
     }
@@ -186,7 +190,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         _scheduleResponse = null;
         _generatedScheduleId = null;
         _selectedPlayerId = null;
-        _errorMessage = '対戦表が見つかりません';
+        _errorMessage = l10n.scheduleNotFoundMessage;
       });
       return null;
     }
@@ -200,6 +204,8 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   }
 
   Future<void> _restore() async {
+    final l10n = AppLocalizations.of(context);
+
     setState(() {
       _isLoading = true;
       _errorMessage = null;
@@ -212,7 +218,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
 
       setState(() {
         _isLoading = false;
-        _errorMessage = '共有IDが正しくありません';
+        _errorMessage = l10n.scheduleNotFoundMessage;
       });
       return;
     }
@@ -227,7 +233,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           _scheduleResponse = null;
           _generatedScheduleId = null;
           _selectedPlayerId = null;
-          _errorMessage = '対戦表が見つかりません';
+          _errorMessage = l10n.scheduleNotFoundMessage;
           _isLoading = false;
         });
         return;
@@ -243,7 +249,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       if (aggregate.players.isEmpty) {
         setState(() {
           _selectedPlayerId = null;
-          _errorMessage = '参加者情報がありません';
+          _errorMessage = l10n.noPlayersMessage;
           _isLoading = false;
         });
         return;
@@ -251,7 +257,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
 
       if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
         setState(() {
-          _errorMessage = 'まだ対戦表が生成されていません';
+          _errorMessage = l10n.scheduleNotLoadedMessage;
           _isLoading = false;
         });
         return;
@@ -269,14 +275,15 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         _scheduleResponse = null;
         _generatedScheduleId = null;
         _selectedPlayerId = null;
-        _errorMessage = '対戦表を取得できませんでした。\n'
-            '通信状態を確認して、再読み込みしてください。';
+        _errorMessage = l10n.reloadScheduleFailedMessage(e.toString());
         _isLoading = false;
       });
     }
   }
 
   Future<void> _fetchSchedule(String generatedScheduleId) async {
+    final l10n = AppLocalizations.of(context);
+
     setState(() {
       _isLoading = true;
       _errorMessage = null;
@@ -302,18 +309,19 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
 
       setState(() {
         _scheduleResponse = null;
-        _errorMessage = '対戦表を取得できませんでした: $e';
+        _errorMessage = l10n.reloadScheduleFailedMessage(e.toString());
         _isLoading = false;
       });
     }
   }
 
   Future<void> _reloadSchedule() async {
+    final l10n = AppLocalizations.of(context);
     final publicId =
         (_savedEvent?.event.publicId ?? widget.publicId).trim().toUpperCase();
 
     if (!isValidPublicId(publicId)) {
-      _showMessage('共有IDが正しくありません');
+      _showMessage(l10n.scheduleNotFoundMessage);
       return;
     }
 
@@ -332,7 +340,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           _scheduleResponse = null;
           _generatedScheduleId = null;
           _selectedPlayerId = null;
-          _errorMessage = '対戦表が見つかりません';
+          _errorMessage = l10n.scheduleNotFoundMessage;
           _isLoading = false;
         });
         return;
@@ -348,7 +356,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
         setState(() {
           _scheduleResponse = null;
-          _errorMessage = 'まだ対戦表が生成されていません';
+          _errorMessage = l10n.scheduleNotLoadedMessage;
           _isLoading = false;
         });
         return;
@@ -359,21 +367,22 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       if (!mounted) return;
 
       setState(() {
-        _errorMessage = '共有情報を再取得できませんでした: $e';
+        _errorMessage = l10n.reloadScheduleFailedMessage(e.toString());
         _isLoading = false;
       });
     }
   }
 
   Future<void> _generateSchedule() async {
+    final l10n = AppLocalizations.of(context);
     final savedEvent = _savedEvent;
     if (savedEvent == null) {
-      _showMessage('再生成するイベント情報がありません');
+      _showMessage(l10n.adoptEventMissingMessage);
       return;
     }
 
     if (_hasAdoptedSchedule) {
-      _showMessage('採用済みのため再生成できません');
+      _showMessage(l10n.cannotRegenerateAdoptedScheduleMessage);
       return;
     }
 
@@ -414,18 +423,19 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       if (!mounted) return;
 
       setState(() {
-        _errorMessage = '対戦表を生成できませんでした: $e';
+        _errorMessage = l10n.generateScheduleFailedMessage(e.toString());
         _isLoading = false;
       });
     }
   }
 
   Future<void> _adoptSchedule() async {
+    final l10n = AppLocalizations.of(context);
     final displayedGeneratedScheduleId = _generatedScheduleId;
 
     if (displayedGeneratedScheduleId == null ||
         displayedGeneratedScheduleId.isEmpty) {
-      _showMessage('採用する generated_schedule_id がありません');
+      _showMessage(l10n.adoptScheduleMissingIdMessage);
       return;
     }
 
@@ -441,12 +451,12 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       if (!mounted) return;
 
       if (latestEvent == null) {
-        _showMessage('採用するイベント情報がありません');
+        _showMessage(l10n.adoptEventMissingMessage);
         return;
       }
 
       if (latestEvent.event.hasAdoptedSchedule) {
-        _showMessage('すでに採用済みです');
+        _showMessage(l10n.alreadyAdoptedScheduleMessage);
         await _reloadSchedule();
         return;
       }
@@ -455,7 +465,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           latestEvent.event.currentGeneratedScheduleId;
 
       if (latestCurrentGeneratedScheduleId != displayedGeneratedScheduleId) {
-        _showMessage('対戦表が更新されています。最新の情報に更新します');
+        _showMessage(l10n.scheduleUpdatedReloadMessage);
         await _reloadSchedule();
         return;
       }
@@ -479,13 +489,13 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       });
       await _saveScheduleHistory(nextSavedEvent);
 
-      _showMessage('この対戦表を採用しました');
+      _showMessage(l10n.adoptScheduleCompletedMessage);
       await _reloadSchedule();
     } catch (e) {
       if (!mounted) return;
 
       setState(() {
-        _errorMessage = '対戦表を採用できませんでした: $e';
+        _errorMessage = l10n.adoptScheduleFailedMessage(e.toString());
       });
     } finally {
       if (mounted) {
@@ -552,8 +562,9 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   }
 
   Future<void> _copyShareUrl() async {
+    final l10n = AppLocalizations.of(context);
     await Clipboard.setData(ClipboardData(text: _buildShareUrl()));
-    _showMessage('URLをコピーしました');
+    _showMessage(l10n.shareUrlCopiedMessage);
   }
 
   void _showMessage(String message) {
@@ -568,6 +579,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   }
 
   Widget _buildScheduleBody() {
+    final l10n = AppLocalizations.of(context);
     final savedEvent = _savedEvent;
 
     return ListView(
@@ -575,8 +587,8 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       children: [
         if (savedEvent == null)
           ScheduleSectionCard(
-            title: '共有URL',
-            child: Text('共有ID: ${widget.publicId}'),
+            title: 'URL',
+            child: Text('ID: ${widget.publicId}'),
           )
         else ...[
           ScheduleEventSummaryCard(
@@ -586,8 +598,10 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           ),
           const SizedBox(height: 12),
           SchedulePlayersCard(
-            title:
-                '面数: ${savedEvent.event.courtCount}　　参加者: ${savedEvent.players.length}人',
+            title: l10n.schedulePlayersTitle(
+              savedEvent.event.courtCount,
+              savedEvent.players.length,
+            ),
             players: _playerViewModels,
             selectedPlayerId: _selectedPlayerId,
             onPlayerSelected: _toggleSelectedPlayer,
@@ -598,7 +612,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
               child: ScheduleActionButtons(
                 isLoading: _isLoading,
                 isAdopting: _isAdopting,
-                generateButtonLabel: _generateButtonLabel,
+                generateButtonLabel: _generateButtonLabel(l10n),
                 canAdopt:
                     _generatedScheduleId != null && _scheduleResponse != null,
                 onGenerate: _requestGenerateSchedule,
@@ -608,7 +622,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           ],
           const SizedBox(height: 12),
           ScheduleSectionCard(
-            title: '対戦表',
+            title: l10n.matchTableTitle,
             child: _isLoading
                 ? const Center(
                     child: Padding(
@@ -628,7 +642,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         if (_errorMessage != null) ...[
           const SizedBox(height: 12),
           ScheduleSectionCard(
-            title: 'エラー',
+            title: l10n.errorTitle,
             child: Text(_errorMessage!),
           ),
         ],
@@ -639,26 +653,27 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final showInitialLoading = _isLoading && _savedEvent == null;
 
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false,
         title: Text(
-          _pageTitle,
+          _pageTitle(l10n),
           overflow: TextOverflow.ellipsis,
         ),
         actions: [
           PopupMenuButton<_ScheduleMenuAction>(
             onSelected: _handleMenu,
-            itemBuilder: (context) => const [
+            itemBuilder: (context) => [
               PopupMenuItem(
                 value: _ScheduleMenuAction.top,
-                child: Text('TOPへ'),
+                child: Text(l10n.topPageMenu),
               ),
               PopupMenuItem(
                 value: _ScheduleMenuAction.list,
-                child: Text('対戦表一覧'),
+                child: Text(l10n.matchTableList),
               ),
             ],
           ),

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -54,7 +54,11 @@ class _SchedulePageState extends State<SchedulePage> {
       ),
     );
 
-    _generateSchedule();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _generateSchedule();
+      }
+    });
   }
 
   bool get _isAdopted => _scheduleResponse?['adopted'] == true;

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:srp_lanske/app/config/app_config.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 import 'package:srp_lanske/shared/utils/browser_url.dart';
 
@@ -62,13 +63,13 @@ class _SchedulePageState extends State<SchedulePage> {
     return _isAdopted || (_savedEvent?.event.hasAdoptedSchedule ?? false);
   }
 
-  String get _generateButtonLabel {
+  String _generateButtonLabel(AppLocalizations l10n) {
     final generatedScheduleId =
         _savedEvent?.event.displayGeneratedScheduleId ?? _generatedScheduleId;
 
     return generatedScheduleId == null || generatedScheduleId.isEmpty
-        ? '生成'
-        : '再生成';
+        ? l10n.generateButton
+        : l10n.regenerateButton;
   }
 
   bool get _hasGeneratedSchedule {
@@ -101,11 +102,12 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   Future<void> _requestGenerateSchedule() async {
+    final l10n = AppLocalizations.of(context);
     final latestEvent = await _refreshSavedEventForAction();
     if (!mounted) return;
 
     if (latestEvent?.event.hasAdoptedSchedule == true) {
-      _showMessage('採用済みのため再生成できません');
+      _showMessage(l10n.cannotRegenerateAdoptedScheduleMessage);
       await _reloadSchedule();
       return;
     }
@@ -119,19 +121,16 @@ class _SchedulePageState extends State<SchedulePage> {
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: const Text('再生成しますか？'),
-          content: const Text(
-            '現在表示している対戦表を新しい対戦表に差し替えます。\n'
-            '共有URLから表示される未採用の対戦表も、再生成後の内容に更新されます。',
-          ),
+          title: Text(l10n.regenerateConfirmTitle),
+          content: Text(l10n.regenerateConfirmBody),
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(context, false),
-              child: const Text('キャンセル'),
+              child: Text(l10n.cancelButton),
             ),
             FilledButton(
               onPressed: () => Navigator.pop(context, true),
-              child: const Text('再生成する'),
+              child: Text(l10n.regenerateActionButton),
             ),
           ],
         );
@@ -144,7 +143,7 @@ class _SchedulePageState extends State<SchedulePage> {
     if (!mounted) return;
 
     if (latestBeforeGenerate?.event.hasAdoptedSchedule == true) {
-      _showMessage('採用済みのため再生成できません');
+      _showMessage(l10n.cannotRegenerateAdoptedScheduleMessage);
       await _reloadSchedule();
       return;
     }
@@ -153,6 +152,7 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   Future<SavedEventAggregate?> _refreshSavedEventForAction() async {
+    final l10n = AppLocalizations.of(context);
     final savedEvent = _savedEvent;
     if (savedEvent == null) return null;
 
@@ -165,7 +165,7 @@ class _SchedulePageState extends State<SchedulePage> {
         _savedEvent = null;
         _scheduleResponse = null;
         _generatedScheduleId = null;
-        _errorMessage = '対戦表が見つかりません';
+        _errorMessage = l10n.scheduleNotFoundMessage;
       });
       return null;
     }
@@ -199,14 +199,15 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   Future<void> _copyShareUrl() async {
+    final l10n = AppLocalizations.of(context);
     final shareUrl = _buildShareUrl();
     if (shareUrl == null) {
-      _showMessage('URLを作成できませんでした');
+      _showMessage(l10n.shareUrlCreateFailedMessage);
       return;
     }
 
     await Clipboard.setData(ClipboardData(text: shareUrl));
-    _showMessage('URLをコピーしました');
+    _showMessage(l10n.shareUrlCopiedMessage);
   }
 
   void _showMessage(String message) {
@@ -221,8 +222,9 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   Future<void> _generateSchedule() async {
+    final l10n = AppLocalizations.of(context);
     if (_hasAdoptedSchedule) {
-      _showMessage('採用済みのため再生成できません');
+      _showMessage(l10n.cannotRegenerateAdoptedScheduleMessage);
       return;
     }
 
@@ -263,7 +265,7 @@ class _SchedulePageState extends State<SchedulePage> {
       if (!mounted) return;
 
       setState(() {
-        _errorMessage = '対戦表を生成できませんでした: $e';
+        _errorMessage = l10n.generateScheduleFailedMessage(e.toString());
       });
     } finally {
       if (mounted) {
@@ -275,6 +277,7 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   Future<void> _reloadSchedule() async {
+    final l10n = AppLocalizations.of(context);
     setState(() {
       _isLoading = true;
       _errorMessage = null;
@@ -304,7 +307,7 @@ class _SchedulePageState extends State<SchedulePage> {
 
         setState(() {
           _scheduleResponse = null;
-          _errorMessage = '再取得する generated_schedule_id がありません';
+          _errorMessage = l10n.reloadScheduleMissingIdMessage;
           _isLoading = false;
         });
         return;
@@ -322,7 +325,7 @@ class _SchedulePageState extends State<SchedulePage> {
       if (!mounted) return;
 
       setState(() {
-        _errorMessage = '対戦表を取得できませんでした: $e';
+        _errorMessage = l10n.reloadScheduleFailedMessage(e.toString());
       });
     } finally {
       if (mounted) {
@@ -334,11 +337,12 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   Future<void> _adoptSchedule() async {
+    final l10n = AppLocalizations.of(context);
     final displayedGeneratedScheduleId = _generatedScheduleId;
 
     if (displayedGeneratedScheduleId == null ||
         displayedGeneratedScheduleId.isEmpty) {
-      _showMessage('採用する generated_schedule_id がありません');
+      _showMessage(l10n.adoptScheduleMissingIdMessage);
       return;
     }
 
@@ -354,12 +358,12 @@ class _SchedulePageState extends State<SchedulePage> {
       if (!mounted) return;
 
       if (latestEvent == null) {
-        _showMessage('採用するイベント情報がありません');
+        _showMessage(l10n.adoptEventMissingMessage);
         return;
       }
 
       if (latestEvent.event.hasAdoptedSchedule) {
-        _showMessage('すでに採用済みです');
+        _showMessage(l10n.alreadyAdoptedScheduleMessage);
         await _reloadSchedule();
         return;
       }
@@ -368,7 +372,7 @@ class _SchedulePageState extends State<SchedulePage> {
           latestEvent.event.currentGeneratedScheduleId;
 
       if (latestCurrentGeneratedScheduleId != displayedGeneratedScheduleId) {
-        _showMessage('対戦表が更新されています。最新の情報に更新します');
+        _showMessage(l10n.scheduleUpdatedReloadMessage);
         await _reloadSchedule();
         return;
       }
@@ -392,13 +396,13 @@ class _SchedulePageState extends State<SchedulePage> {
       });
       await _saveScheduleHistory(nextSavedEvent);
 
-      _showMessage('この対戦表を採用しました');
+      _showMessage(l10n.adoptScheduleCompletedMessage);
       await _reloadSchedule();
     } catch (e) {
       if (!mounted) return;
 
       setState(() {
-        _errorMessage = '対戦表を採用できませんでした: $e';
+        _errorMessage = l10n.adoptScheduleFailedMessage(e.toString());
       });
     } finally {
       if (mounted) {
@@ -445,6 +449,8 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   Widget _buildScheduleBody() {
+    final l10n = AppLocalizations.of(context);
+
     return ListView(
       padding: const EdgeInsets.all(4),
       children: [
@@ -455,8 +461,10 @@ class _SchedulePageState extends State<SchedulePage> {
         ),
         const SizedBox(height: 12),
         SchedulePlayersCard(
-          title:
-              '面数: ${widget.draft.courts}　　参加者: ${widget.draft.playerCount}人',
+          title: l10n.schedulePlayersTitle(
+            widget.draft.courts,
+            widget.draft.playerCount,
+          ),
           players: _playerViewModels,
           selectedPlayerId: _selectedPlayerId,
           onPlayerSelected: _toggleSelectedPlayer,
@@ -467,7 +475,7 @@ class _SchedulePageState extends State<SchedulePage> {
             child: ScheduleActionButtons(
               isLoading: _isLoading,
               isAdopting: _isAdopting,
-              generateButtonLabel: _generateButtonLabel,
+              generateButtonLabel: _generateButtonLabel(l10n),
               canAdopt:
                   _generatedScheduleId != null && _scheduleResponse != null,
               onGenerate: _requestGenerateSchedule,
@@ -477,7 +485,7 @@ class _SchedulePageState extends State<SchedulePage> {
         ],
         const SizedBox(height: 12),
         ScheduleSectionCard(
-          title: '対戦表',
+          title: l10n.matchTableTitle,
           child: _isLoading
               ? const Center(
                   child: Padding(
@@ -496,7 +504,7 @@ class _SchedulePageState extends State<SchedulePage> {
         if (_errorMessage != null) ...[
           const SizedBox(height: 12),
           ScheduleSectionCard(
-            title: 'エラー',
+            title: l10n.errorTitle,
             child: Text(_errorMessage!),
           ),
         ],
@@ -507,6 +515,7 @@ class _SchedulePageState extends State<SchedulePage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final showInitialLoading = _isLoading && _scheduleResponse == null;
 
     return Scaffold(
@@ -516,14 +525,14 @@ class _SchedulePageState extends State<SchedulePage> {
         actions: [
           PopupMenuButton<_ScheduleMenuAction>(
             onSelected: _handleMenu,
-            itemBuilder: (context) => const [
+            itemBuilder: (context) => [
               PopupMenuItem(
                 value: _ScheduleMenuAction.top,
-                child: Text('TOPへ'),
+                child: Text(l10n.topPageMenu),
               ),
               PopupMenuItem(
                 value: _ScheduleMenuAction.list,
-                child: Text('対戦表一覧'),
+                child: Text(l10n.matchTableList),
               ),
             ],
           ),

--- a/lib/features/doubles_scheduler/presentation/widgets/event_setup_action_buttons.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/event_setup_action_buttons.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
 
 class EventSetupActionButtons extends StatelessWidget {
   const EventSetupActionButtons({
@@ -14,6 +15,8 @@ class EventSetupActionButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
@@ -24,9 +27,9 @@ class EventSetupActionButtons extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             tapTargetSize: MaterialTapTargetSize.shrinkWrap,
           ),
-          child: const Text(
-            '入力項目のリセット',
-            style: TextStyle(fontSize: 16),
+          child: Text(
+            l10n.resetInputsButton,
+            style: const TextStyle(fontSize: 16),
           ),
         ),
         const SizedBox(width: 12),
@@ -37,9 +40,9 @@ class EventSetupActionButtons extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
             tapTargetSize: MaterialTapTargetSize.shrinkWrap,
           ),
-          child: const Text(
-            '対戦表の生成',
-            style: TextStyle(fontSize: 22),
+          child: Text(
+            l10n.generateScheduleButton,
+            style: const TextStyle(fontSize: 22),
           ),
         ),
       ],

--- a/lib/features/doubles_scheduler/presentation/widgets/event_setup_detail_section.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/event_setup_detail_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
 
 import 'event_setup_action_buttons.dart';
 import 'event_setup_display_name_grid.dart';
@@ -25,6 +26,8 @@ class EventSetupDetailSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -32,15 +35,15 @@ class EventSetupDetailSection extends StatelessWidget {
         TextFormField(
           controller: eventNameController,
           enabled: !isLoadingEvent,
-          decoration: const InputDecoration(
-            labelText: 'イベント名',
-            border: OutlineInputBorder(),
+          decoration: InputDecoration(
+            labelText: l10n.eventNameLabel,
+            border: const OutlineInputBorder(),
           ),
         ),
         const SizedBox(height: 16),
-        const Text(
-          '参加者表示名',
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        Text(
+          l10n.playerDisplayNameSectionTitle,
+          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
         ),
         const SizedBox(height: 8),
         EventSetupDisplayNameGrid(

--- a/lib/features/doubles_scheduler/presentation/widgets/event_setup_display_name_grid.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/event_setup_display_name_grid.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
 import 'package:srp_lanske/shared/utils/number_label_mapper.dart';
 
 class EventSetupDisplayNameGrid extends StatelessWidget {
@@ -17,13 +18,14 @@ class EventSetupDisplayNameGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return Wrap(
       spacing: 12,
       runSpacing: 12,
       children: List.generate(controllers.length, (index) {
         final sourceName =
             sourceDisplayNames[index] ?? circledNumber(index + 1);
-        final labelSuffix = '：$sourceName';
 
         return SizedBox(
           width: 140,
@@ -32,7 +34,10 @@ class EventSetupDisplayNameGrid extends StatelessWidget {
             focusNode: focusNodes[index],
             enabled: !isLoadingEvent,
             decoration: InputDecoration(
-              labelText: '参加者${participantLabelNumber(index)}$labelSuffix',
+              labelText: l10n.playerDisplayNameInputLabel(
+                index + 1,
+                sourceName,
+              ),
               border: const OutlineInputBorder(),
               isDense: true,
             ),

--- a/lib/features/doubles_scheduler/presentation/widgets/event_setup_url_section.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/event_setup_url_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
 
 class EventSetupUrlSection extends StatelessWidget {
   const EventSetupUrlSection({
@@ -30,6 +31,8 @@ class EventSetupUrlSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -38,13 +41,13 @@ class EventSetupUrlSection extends StatelessWidget {
           enabled: !isLoadingEvent,
           onChanged: onChanged,
           decoration: InputDecoration(
-            labelText: 'テニスベアのイベントURL',
-            helperText: '例: https://www.tennisbear.net/event/1156506/info',
-            errorText: showUrlError ? 'テニスベアのイベントURLを入力してください' : null,
+            labelText: l10n.tennisbearEventUrlLabel,
+            helperText: l10n.tennisbearEventUrlHelper,
+            errorText: showUrlError ? l10n.tennisbearEventUrlError : null,
             border: const OutlineInputBorder(),
             suffixIcon: hasUrlInput
                 ? IconButton(
-                    tooltip: 'URLをクリア',
+                    tooltip: l10n.clearUrlTooltip,
                     onPressed: canClearEventUrl ? onClear : null,
                     icon: const Icon(Icons.cancel_outlined),
                   )
@@ -61,12 +64,12 @@ class EventSetupUrlSection extends StatelessWidget {
               OutlinedButton.icon(
                 onPressed: canPasteEventUrl ? onPaste : null,
                 icon: const Icon(Icons.content_paste),
-                label: const Text('貼り付け'),
+                label: Text(l10n.pasteButton),
               ),
               FilledButton.icon(
                 onPressed: canImportEventUrl ? onImport : null,
                 icon: const Icon(Icons.download),
-                label: const Text('取り込み'),
+                label: Text(l10n.importButton),
               ),
             ],
           ),

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_action_buttons.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_action_buttons.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
 
 class ScheduleActionButtons extends StatelessWidget {
   const ScheduleActionButtons({
@@ -20,6 +21,8 @@ class ScheduleActionButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     final buttons = Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -38,7 +41,11 @@ class ScheduleActionButtons extends StatelessWidget {
                   child: CircularProgressIndicator(strokeWidth: 2),
                 )
               : const Icon(Icons.check),
-          label: Text(isAdopting ? '採用中' : 'この対戦表を採用'),
+          label: Text(
+            isAdopting
+                ? l10n.adoptingScheduleButton
+                : l10n.adoptScheduleButton,
+          ),
         ),
       ],
     );

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_action_buttons.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_action_buttons.dart
@@ -42,9 +42,7 @@ class ScheduleActionButtons extends StatelessWidget {
                 )
               : const Icon(Icons.check),
           label: Text(
-            isAdopting
-                ? l10n.adoptingScheduleButton
-                : l10n.adoptScheduleButton,
+            isAdopting ? l10n.adoptingScheduleButton : l10n.adoptScheduleButton,
           ),
         ),
       ],

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
 
 class ScheduleEventSummaryCard extends StatelessWidget {
   const ScheduleEventSummaryCard({
@@ -14,6 +15,8 @@ class ScheduleEventSummaryCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(4),
@@ -29,19 +32,19 @@ class ScheduleEventSummaryCard extends StatelessWidget {
                   OutlinedButton.icon(
                     onPressed: onCopyShareUrl,
                     icon: const Icon(Icons.copy),
-                    label: const Text('URLをコピー'),
+                    label: Text(l10n.copyUrlButton),
                   ),
                 if (onRefresh != null)
                   FilledButton.tonalIcon(
                     onPressed: canRefresh ? onRefresh : null,
                     icon: const Icon(Icons.sync),
-                    label: const Text('最新の情報に更新'),
+                    label: Text(l10n.refreshLatestButton),
                   ),
               ],
             ),
             const SizedBox(height: 4),
             Text(
-              'URLを共有して対戦表をみんなで確認しましょう٩( ᐛ )و',
+              l10n.shareUrlDescription,
               style: Theme.of(context).textTheme.bodySmall,
             ),
           ],

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_players_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_players_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
 
 import 'schedule_player_chip.dart';
 import 'schedule_section_card.dart';
@@ -74,10 +75,12 @@ class _SchedulePlayersCardState extends State<SchedulePlayersCard> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     if (widget.players.isEmpty) {
-      return const ScheduleSectionCard(
-        title: '参加者',
-        child: Text('参加者情報がありません'),
+      return ScheduleSectionCard(
+        title: l10n.playersTitle,
+        child: Text(l10n.noPlayersMessage),
       );
     }
 

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
 
 import 'schedule_player_chip.dart';
 
@@ -27,16 +28,17 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final scheduleResponse = widget.scheduleResponse;
     if (scheduleResponse == null) {
-      return const Text('対戦表を取得できていません');
+      return Text(l10n.scheduleNotLoadedMessage);
     }
 
     final rounds = _asObjectList(scheduleResponse['rounds']);
     final slotToPlayerId = _buildSlotToPlayerId(scheduleResponse);
 
     if (rounds.isEmpty) {
-      return const Text('対戦表データがありません');
+      return Text(l10n.scheduleDataEmptyMessage);
     }
 
     return Column(
@@ -50,6 +52,7 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
     Map<String, dynamic> round,
     Map<int, String> slotToPlayerId,
   ) {
+    final l10n = AppLocalizations.of(context);
     final roundNumber = round['round_number']?.toString() ?? '-';
     final roundNumberValue = int.tryParse(roundNumber);
     final isEvenRound = roundNumberValue != null && roundNumberValue.isEven;
@@ -113,8 +116,11 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   ...courts.map((court) {
-                    return _buildCourtRow(court, slotToPlayerId,
-                        showCourtNumber: widget.courtCount >= 2);
+                    return _buildCourtRow(
+                      court,
+                      slotToPlayerId,
+                      showCourtNumber: widget.courtCount >= 2,
+                    );
                   }),
                   if (isRestExpanded) ...[
                     const Divider(),
@@ -123,7 +129,7 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
                       runSpacing: 6,
                       crossAxisAlignment: WrapCrossAlignment.center,
                       children: [
-                        const Text('休憩:'),
+                        Text('${l10n.restLabel}:'),
                         ...restSlotNumbers.map((slotNumber) {
                           return _buildPlayerChip(
                             slotNumber: slotNumber,
@@ -145,32 +151,35 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
   }
 
   Widget _buildCourtRow(
-      Map<String, dynamic> court, Map<int, String> slotToPlayerId,
-      {required bool showCourtNumber}) {
+    Map<String, dynamic> court,
+    Map<int, String> slotToPlayerId, {
+    required bool showCourtNumber,
+  }) {
     final courtNumber = court['court_number']?.toString() ?? '-';
     final team1Slots = _asIntList(court['team1_player_slots']);
     final team2Slots = _asIntList(court['team2_player_slots']);
 
     return Padding(
-        padding: const EdgeInsets.only(bottom: 8),
-        child: Wrap(
-          spacing: 4,
-          runSpacing: 4,
-          crossAxisAlignment: WrapCrossAlignment.center,
-          children: [
-            if (showCourtNumber)
-              Text(
-                courtNumber,
-                style: const TextStyle(
-                  fontWeight: FontWeight.bold,
-                  fontSize: 13,
-                ),
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Wrap(
+        spacing: 4,
+        runSpacing: 4,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          if (showCourtNumber)
+            Text(
+              courtNumber,
+              style: const TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: 13,
               ),
-            _buildTeamGroup(team1Slots, slotToPlayerId),
-            const Text('vs'),
-            _buildTeamGroup(team2Slots, slotToPlayerId),
-          ],
-        ));
+            ),
+          _buildTeamGroup(team1Slots, slotToPlayerId),
+          const Text('vs'),
+          _buildTeamGroup(team2Slots, slotToPlayerId),
+        ],
+      ),
+    );
   }
 
   List<Widget> _buildTeamChips(
@@ -293,6 +302,7 @@ class _RestToggleButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final colorScheme = Theme.of(context).colorScheme;
     final backgroundColor =
         isHighlighted ? colorScheme.tertiaryContainer : Colors.transparent;
@@ -321,7 +331,7 @@ class _RestToggleButton extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               Text(
-                '休憩',
+                l10n.restLabel,
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 10,
@@ -332,7 +342,7 @@ class _RestToggleButton extends StatelessWidget {
                 ),
               ),
               Text(
-                '$restCount人',
+                l10n.restCountLabel(restCount),
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 10,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3,5 +3,131 @@
   "appTitle": "Lanske",
   "@appTitle": {
     "description": "Application title."
+  },
+  "eventSetupTitle": "Doubles Match Table ver0.1",
+  "@eventSetupTitle": {
+    "description": "Title shown on the event setup page."
+  },
+  "matchTableList": "Match table list",
+  "@matchTableList": {
+    "description": "Menu item label for the saved/generated match table list."
+  },
+  "eventSetupInstruction": "Paste a URL or enter the court and player counts manually.",
+  "@eventSetupInstruction": {
+    "description": "Instruction text on the event setup page."
+  },
+  "eventSetupSupportedConditions": "ver0.1 supports 1 court with 4 to 7 players and 2 courts with 8 to 15 players.",
+  "@eventSetupSupportedConditions": {
+    "description": "Short note about supported court and player count conditions."
+  },
+  "courtCountLabel": "Courts",
+  "@courtCountLabel": {
+    "description": "Label for court count input."
+  },
+  "playerCountLabel": "Players",
+  "@playerCountLabel": {
+    "description": "Label for player count input."
+  },
+  "decrementCourtCountTooltip": "Decrease court count",
+  "@decrementCourtCountTooltip": {
+    "description": "Tooltip for decreasing court count."
+  },
+  "incrementCourtCountTooltip": "Increase court count",
+  "@incrementCourtCountTooltip": {
+    "description": "Tooltip for increasing court count."
+  },
+  "decrementPlayerCountTooltip": "Decrease player count",
+  "@decrementPlayerCountTooltip": {
+    "description": "Tooltip for decreasing player count."
+  },
+  "incrementPlayerCountTooltip": "Increase player count",
+  "@incrementPlayerCountTooltip": {
+    "description": "Tooltip for increasing player count."
+  },
+  "playerCountRangeHelp": "Enter between {minPlayerCount} and {maxPlayerCount} players.",
+  "@playerCountRangeHelp": {
+    "description": "Help text that shows the valid player count range.",
+    "placeholders": {
+      "minPlayerCount": {
+        "type": "int",
+        "example": "4"
+      },
+      "maxPlayerCount": {
+        "type": "int",
+        "example": "7"
+      }
+    }
+  },
+  "loadingEventInfo": "Loading event info...",
+  "@loadingEventInfo": {
+    "description": "Loading message shown while importing event information."
+  },
+  "enterUrlMessage": "Enter a URL.",
+  "@enterUrlMessage": {
+    "description": "Snack bar message shown when URL input is empty."
+  },
+  "enterTennisbearEventUrlMessage": "Enter a TennisBear event URL.",
+  "@enterTennisbearEventUrlMessage": {
+    "description": "Snack bar message shown when the URL is not a TennisBear event URL."
+  },
+  "eventInfoLoadedMessage": "Event info loaded.",
+  "@eventInfoLoadedMessage": {
+    "description": "Snack bar message shown when event information was imported successfully."
+  },
+  "eventInfoPartiallyLoadedMessage": "Event info loaded. Some details could not be imported.",
+  "@eventInfoPartiallyLoadedMessage": {
+    "description": "Snack bar message shown when event information was imported with warnings."
+  },
+  "eventInfoLoadFailedMessage": "Could not load event info. Check the URL and try again.",
+  "@eventInfoLoadFailedMessage": {
+    "description": "Snack bar message shown when event information import failed."
+  },
+  "clipboardUrlNotFoundMessage": "No URL found in the clipboard.",
+  "@clipboardUrlNotFoundMessage": {
+    "description": "Snack bar message shown when clipboard has no URL."
+  },
+  "pasteTennisbearEventUrlMessage": "Paste a TennisBear event URL.",
+  "@pasteTennisbearEventUrlMessage": {
+    "description": "Snack bar message shown when pasted text is not a TennisBear event URL."
+  },
+  "tennisbearEventUrlLabel": "TennisBear event URL",
+  "@tennisbearEventUrlLabel": {
+    "description": "Input label for TennisBear event URL."
+  },
+  "tennisbearEventUrlHelper": "Example: TennisBear event detail URL",
+  "@tennisbearEventUrlHelper": {
+    "description": "Helper text example for TennisBear event URL input."
+  },
+  "tennisbearEventUrlError": "Enter a TennisBear event URL.",
+  "@tennisbearEventUrlError": {
+    "description": "Validation error for TennisBear event URL input."
+  },
+  "clearUrlTooltip": "Clear URL",
+  "@clearUrlTooltip": {
+    "description": "Tooltip for clearing the URL input."
+  },
+  "pasteButton": "Paste",
+  "@pasteButton": {
+    "description": "Button label for pasting text from clipboard."
+  },
+  "importButton": "Import",
+  "@importButton": {
+    "description": "Button label for importing event information."
+  },
+  "eventNameLabel": "Event name",
+  "@eventNameLabel": {
+    "description": "Input label for event name."
+  },
+  "playerDisplayNameSectionTitle": "Player display names",
+  "@playerDisplayNameSectionTitle": {
+    "description": "Section title for player display name inputs."
+  },
+  "resetInputsButton": "Reset inputs",
+  "@resetInputsButton": {
+    "description": "Button label for resetting input fields."
+  },
+  "generateScheduleButton": "Generate match table",
+  "@generateScheduleButton": {
+    "description": "Button label for generating a match table."
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -120,6 +120,14 @@
   "@playerDisplayNameSectionTitle": {
     "description": "Section title for player display name inputs."
   },
+  "playerDisplayNameInputLabel": "Player {playerNumber}: {sourceName}",
+  "@playerDisplayNameInputLabel": {
+    "description": "Input label for each player display name field.",
+    "placeholders": {
+      "playerNumber": {"type": "int", "example": "1"},
+      "sourceName": {"type": "String", "example": "1"}
+    }
+  },
   "resetInputsButton": "Reset inputs",
   "@resetInputsButton": {
     "description": "Button label for resetting input fields."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -8,6 +8,10 @@
   "@eventSetupTitle": {
     "description": "Title shown on the event setup page."
   },
+  "topPageMenu": "Top",
+  "@topPageMenu": {
+    "description": "Menu item label for returning to the top page."
+  },
   "matchTableList": "Match table list",
   "@matchTableList": {
     "description": "Menu item label for the saved/generated match table list."
@@ -48,14 +52,8 @@
   "@playerCountRangeHelp": {
     "description": "Help text that shows the valid player count range.",
     "placeholders": {
-      "minPlayerCount": {
-        "type": "int",
-        "example": "4"
-      },
-      "maxPlayerCount": {
-        "type": "int",
-        "example": "7"
-      }
+      "minPlayerCount": {"type": "int", "example": "4"},
+      "maxPlayerCount": {"type": "int", "example": "7"}
     }
   },
   "loadingEventInfo": "Loading event info...",
@@ -129,5 +127,145 @@
   "generateScheduleButton": "Generate match table",
   "@generateScheduleButton": {
     "description": "Button label for generating a match table."
+  },
+  "generateButton": "Generate",
+  "@generateButton": {
+    "description": "Short button label for generating a schedule."
+  },
+  "regenerateButton": "Regenerate",
+  "@regenerateButton": {
+    "description": "Short button label for regenerating a schedule."
+  },
+  "adoptingScheduleButton": "Adopting",
+  "@adoptingScheduleButton": {
+    "description": "Button label shown while adopting a schedule."
+  },
+  "adoptScheduleButton": "Use this table",
+  "@adoptScheduleButton": {
+    "description": "Button label for adopting the currently displayed schedule."
+  },
+  "cannotRegenerateAdoptedScheduleMessage": "This table has already been adopted and cannot be regenerated.",
+  "@cannotRegenerateAdoptedScheduleMessage": {
+    "description": "Message shown when regeneration is blocked because the schedule was adopted."
+  },
+  "regenerateConfirmTitle": "Regenerate?",
+  "@regenerateConfirmTitle": {
+    "description": "Dialog title for confirming schedule regeneration."
+  },
+  "regenerateConfirmBody": "The currently displayed match table will be replaced.\nUnadopted tables shown from the share URL will also be updated.",
+  "@regenerateConfirmBody": {
+    "description": "Dialog body for confirming schedule regeneration."
+  },
+  "cancelButton": "Cancel",
+  "@cancelButton": {
+    "description": "Generic cancel button label."
+  },
+  "regenerateActionButton": "Regenerate",
+  "@regenerateActionButton": {
+    "description": "Dialog action button label for regenerating a schedule."
+  },
+  "scheduleNotFoundMessage": "Match table not found.",
+  "@scheduleNotFoundMessage": {
+    "description": "Message shown when the saved schedule cannot be found."
+  },
+  "shareUrlCreateFailedMessage": "Could not create the URL.",
+  "@shareUrlCreateFailedMessage": {
+    "description": "Message shown when a share URL cannot be created."
+  },
+  "shareUrlCopiedMessage": "URL copied.",
+  "@shareUrlCopiedMessage": {
+    "description": "Message shown when the share URL was copied."
+  },
+  "generateScheduleFailedMessage": "Could not generate the match table: {error}",
+  "@generateScheduleFailedMessage": {
+    "description": "Error message shown when schedule generation failed.",
+    "placeholders": {"error": {"type": "String", "example": "network error"}}
+  },
+  "reloadScheduleMissingIdMessage": "No generated_schedule_id is available for reload.",
+  "@reloadScheduleMissingIdMessage": {
+    "description": "Error message shown when no generated schedule id is available for reload."
+  },
+  "reloadScheduleFailedMessage": "Could not load the match table: {error}",
+  "@reloadScheduleFailedMessage": {
+    "description": "Error message shown when reloading a schedule failed.",
+    "placeholders": {"error": {"type": "String", "example": "network error"}}
+  },
+  "adoptScheduleMissingIdMessage": "No generated_schedule_id is available for adoption.",
+  "@adoptScheduleMissingIdMessage": {
+    "description": "Message shown when no generated schedule id is available for adoption."
+  },
+  "adoptEventMissingMessage": "No event information is available for adoption.",
+  "@adoptEventMissingMessage": {
+    "description": "Message shown when event information for adoption is missing."
+  },
+  "alreadyAdoptedScheduleMessage": "This table has already been adopted.",
+  "@alreadyAdoptedScheduleMessage": {
+    "description": "Message shown when the schedule has already been adopted."
+  },
+  "scheduleUpdatedReloadMessage": "The match table has been updated. Loading the latest information.",
+  "@scheduleUpdatedReloadMessage": {
+    "description": "Message shown when the displayed schedule is outdated."
+  },
+  "adoptScheduleCompletedMessage": "This match table was adopted.",
+  "@adoptScheduleCompletedMessage": {
+    "description": "Message shown when schedule adoption completed."
+  },
+  "adoptScheduleFailedMessage": "Could not adopt the match table: {error}",
+  "@adoptScheduleFailedMessage": {
+    "description": "Error message shown when schedule adoption failed.",
+    "placeholders": {"error": {"type": "String", "example": "network error"}}
+  },
+  "schedulePlayersTitle": "Courts: {courtCount}    Players: {playerCount}",
+  "@schedulePlayersTitle": {
+    "description": "Title for player list showing court count and player count.",
+    "placeholders": {
+      "courtCount": {"type": "int", "example": "1"},
+      "playerCount": {"type": "int", "example": "6"}
+    }
+  },
+  "matchTableTitle": "Match table",
+  "@matchTableTitle": {
+    "description": "Section title for the match table."
+  },
+  "errorTitle": "Error",
+  "@errorTitle": {
+    "description": "Generic error section title."
+  },
+  "copyUrlButton": "Copy URL",
+  "@copyUrlButton": {
+    "description": "Button label for copying a share URL."
+  },
+  "refreshLatestButton": "Refresh",
+  "@refreshLatestButton": {
+    "description": "Button label for refreshing the latest schedule information."
+  },
+  "shareUrlDescription": "Share the URL so everyone can check the match table.",
+  "@shareUrlDescription": {
+    "description": "Short description encouraging users to share the schedule URL."
+  },
+  "playersTitle": "Players",
+  "@playersTitle": {
+    "description": "Section title for player information."
+  },
+  "noPlayersMessage": "No player information is available.",
+  "@noPlayersMessage": {
+    "description": "Message shown when no player information is available."
+  },
+  "scheduleNotLoadedMessage": "The match table has not been loaded.",
+  "@scheduleNotLoadedMessage": {
+    "description": "Message shown when no schedule response is loaded."
+  },
+  "scheduleDataEmptyMessage": "No match table data is available.",
+  "@scheduleDataEmptyMessage": {
+    "description": "Message shown when the schedule response contains no rounds."
+  },
+  "restLabel": "Rest",
+  "@restLabel": {
+    "description": "Label for resting players."
+  },
+  "restCountLabel": "{restCount} rest",
+  "@restCountLabel": {
+    "description": "Short label showing the number of resting players.",
+    "placeholders": {"restCount": {"type": "int", "example": "2"}}
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -52,8 +52,14 @@
   "@playerCountRangeHelp": {
     "description": "Help text that shows the valid player count range.",
     "placeholders": {
-      "minPlayerCount": {"type": "int", "example": "4"},
-      "maxPlayerCount": {"type": "int", "example": "7"}
+      "minPlayerCount": {
+        "type": "int",
+        "example": "4"
+      },
+      "maxPlayerCount": {
+        "type": "int",
+        "example": "7"
+      }
     }
   },
   "loadingEventInfo": "Loading event info...",
@@ -124,8 +130,14 @@
   "@playerDisplayNameInputLabel": {
     "description": "Input label for each player display name field.",
     "placeholders": {
-      "playerNumber": {"type": "int", "example": "1"},
-      "sourceName": {"type": "String", "example": "1"}
+      "playerNumber": {
+        "type": "int",
+        "example": "1"
+      },
+      "sourceName": {
+        "type": "String",
+        "example": "1"
+      }
     }
   },
   "resetInputsButton": "Reset inputs",
@@ -187,7 +199,12 @@
   "generateScheduleFailedMessage": "Could not generate the match table: {error}",
   "@generateScheduleFailedMessage": {
     "description": "Error message shown when schedule generation failed.",
-    "placeholders": {"error": {"type": "String", "example": "network error"}}
+    "placeholders": {
+      "error": {
+        "type": "String",
+        "example": "network error"
+      }
+    }
   },
   "reloadScheduleMissingIdMessage": "No generated_schedule_id is available for reload.",
   "@reloadScheduleMissingIdMessage": {
@@ -196,7 +213,12 @@
   "reloadScheduleFailedMessage": "Could not load the match table: {error}",
   "@reloadScheduleFailedMessage": {
     "description": "Error message shown when reloading a schedule failed.",
-    "placeholders": {"error": {"type": "String", "example": "network error"}}
+    "placeholders": {
+      "error": {
+        "type": "String",
+        "example": "network error"
+      }
+    }
   },
   "adoptScheduleMissingIdMessage": "No generated_schedule_id is available for adoption.",
   "@adoptScheduleMissingIdMessage": {
@@ -221,14 +243,25 @@
   "adoptScheduleFailedMessage": "Could not adopt the match table: {error}",
   "@adoptScheduleFailedMessage": {
     "description": "Error message shown when schedule adoption failed.",
-    "placeholders": {"error": {"type": "String", "example": "network error"}}
+    "placeholders": {
+      "error": {
+        "type": "String",
+        "example": "network error"
+      }
+    }
   },
   "schedulePlayersTitle": "Courts: {courtCount}    Players: {playerCount}",
   "@schedulePlayersTitle": {
     "description": "Title for player list showing court count and player count.",
     "placeholders": {
-      "courtCount": {"type": "int", "example": "1"},
-      "playerCount": {"type": "int", "example": "6"}
+      "courtCount": {
+        "type": "int",
+        "example": "1"
+      },
+      "playerCount": {
+        "type": "int",
+        "example": "6"
+      }
     }
   },
   "matchTableTitle": "Match table",
@@ -274,6 +307,21 @@
   "restCountLabel": "{restCount} rest",
   "@restCountLabel": {
     "description": "Short label showing the number of resting players.",
-    "placeholders": {"restCount": {"type": "int", "example": "2"}}
+    "placeholders": {
+      "restCount": {
+        "type": "int",
+        "example": "2"
+      }
+    }
+  },
+  "lastOpenedAtLabel": "Last opened: {lastOpenedAt}",
+  "@lastOpenedAtLabel": {
+    "description": "Label showing when a saved schedule was last opened.",
+    "placeholders": {
+      "lastOpenedAt": {
+        "type": "String",
+        "example": "2026/05/22 23:10"
+      }
+    }
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,7 @@
+{
+  "@@locale": "en",
+  "appTitle": "Lanske",
+  "@appTitle": {
+    "description": "Application title."
+  }
+}

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -8,6 +8,10 @@
   "@eventSetupTitle": {
     "description": "Title shown on the event setup page."
   },
+  "topPageMenu": "TOPへ",
+  "@topPageMenu": {
+    "description": "Menu item label for returning to the top page."
+  },
   "matchTableList": "対戦表一覧",
   "@matchTableList": {
     "description": "Menu item label for the saved/generated match table list."
@@ -48,14 +52,8 @@
   "@playerCountRangeHelp": {
     "description": "Help text that shows the valid player count range.",
     "placeholders": {
-      "minPlayerCount": {
-        "type": "int",
-        "example": "4"
-      },
-      "maxPlayerCount": {
-        "type": "int",
-        "example": "7"
-      }
+      "minPlayerCount": {"type": "int", "example": "4"},
+      "maxPlayerCount": {"type": "int", "example": "7"}
     }
   },
   "loadingEventInfo": "イベント情報を取得中...",
@@ -129,5 +127,145 @@
   "generateScheduleButton": "対戦表の生成",
   "@generateScheduleButton": {
     "description": "Button label for generating a match table."
+  },
+  "generateButton": "生成",
+  "@generateButton": {
+    "description": "Short button label for generating a schedule."
+  },
+  "regenerateButton": "再生成",
+  "@regenerateButton": {
+    "description": "Short button label for regenerating a schedule."
+  },
+  "adoptingScheduleButton": "採用中",
+  "@adoptingScheduleButton": {
+    "description": "Button label shown while adopting a schedule."
+  },
+  "adoptScheduleButton": "この対戦表を採用",
+  "@adoptScheduleButton": {
+    "description": "Button label for adopting the currently displayed schedule."
+  },
+  "cannotRegenerateAdoptedScheduleMessage": "採用済みのため再生成できません",
+  "@cannotRegenerateAdoptedScheduleMessage": {
+    "description": "Message shown when regeneration is blocked because the schedule was adopted."
+  },
+  "regenerateConfirmTitle": "再生成しますか？",
+  "@regenerateConfirmTitle": {
+    "description": "Dialog title for confirming schedule regeneration."
+  },
+  "regenerateConfirmBody": "現在表示している対戦表を新しい対戦表に差し替えます。\n共有URLから表示される未採用の対戦表も、再生成後の内容に更新されます。",
+  "@regenerateConfirmBody": {
+    "description": "Dialog body for confirming schedule regeneration."
+  },
+  "cancelButton": "キャンセル",
+  "@cancelButton": {
+    "description": "Generic cancel button label."
+  },
+  "regenerateActionButton": "再生成する",
+  "@regenerateActionButton": {
+    "description": "Dialog action button label for regenerating a schedule."
+  },
+  "scheduleNotFoundMessage": "対戦表が見つかりません",
+  "@scheduleNotFoundMessage": {
+    "description": "Message shown when the saved schedule cannot be found."
+  },
+  "shareUrlCreateFailedMessage": "URLを作成できませんでした",
+  "@shareUrlCreateFailedMessage": {
+    "description": "Message shown when a share URL cannot be created."
+  },
+  "shareUrlCopiedMessage": "URLをコピーしました",
+  "@shareUrlCopiedMessage": {
+    "description": "Message shown when the share URL was copied."
+  },
+  "generateScheduleFailedMessage": "対戦表を生成できませんでした: {error}",
+  "@generateScheduleFailedMessage": {
+    "description": "Error message shown when schedule generation failed.",
+    "placeholders": {"error": {"type": "String", "example": "network error"}}
+  },
+  "reloadScheduleMissingIdMessage": "再取得する generated_schedule_id がありません",
+  "@reloadScheduleMissingIdMessage": {
+    "description": "Error message shown when no generated schedule id is available for reload."
+  },
+  "reloadScheduleFailedMessage": "対戦表を取得できませんでした: {error}",
+  "@reloadScheduleFailedMessage": {
+    "description": "Error message shown when reloading a schedule failed.",
+    "placeholders": {"error": {"type": "String", "example": "network error"}}
+  },
+  "adoptScheduleMissingIdMessage": "採用する generated_schedule_id がありません",
+  "@adoptScheduleMissingIdMessage": {
+    "description": "Message shown when no generated schedule id is available for adoption."
+  },
+  "adoptEventMissingMessage": "採用するイベント情報がありません",
+  "@adoptEventMissingMessage": {
+    "description": "Message shown when event information for adoption is missing."
+  },
+  "alreadyAdoptedScheduleMessage": "すでに採用済みです",
+  "@alreadyAdoptedScheduleMessage": {
+    "description": "Message shown when the schedule has already been adopted."
+  },
+  "scheduleUpdatedReloadMessage": "対戦表が更新されています。最新の情報に更新します",
+  "@scheduleUpdatedReloadMessage": {
+    "description": "Message shown when the displayed schedule is outdated."
+  },
+  "adoptScheduleCompletedMessage": "この対戦表を採用しました",
+  "@adoptScheduleCompletedMessage": {
+    "description": "Message shown when schedule adoption completed."
+  },
+  "adoptScheduleFailedMessage": "対戦表を採用できませんでした: {error}",
+  "@adoptScheduleFailedMessage": {
+    "description": "Error message shown when schedule adoption failed.",
+    "placeholders": {"error": {"type": "String", "example": "network error"}}
+  },
+  "schedulePlayersTitle": "面数: {courtCount}　　参加者: {playerCount}人",
+  "@schedulePlayersTitle": {
+    "description": "Title for player list showing court count and player count.",
+    "placeholders": {
+      "courtCount": {"type": "int", "example": "1"},
+      "playerCount": {"type": "int", "example": "6"}
+    }
+  },
+  "matchTableTitle": "対戦表",
+  "@matchTableTitle": {
+    "description": "Section title for the match table."
+  },
+  "errorTitle": "エラー",
+  "@errorTitle": {
+    "description": "Generic error section title."
+  },
+  "copyUrlButton": "URLをコピー",
+  "@copyUrlButton": {
+    "description": "Button label for copying a share URL."
+  },
+  "refreshLatestButton": "最新の情報に更新",
+  "@refreshLatestButton": {
+    "description": "Button label for refreshing the latest schedule information."
+  },
+  "shareUrlDescription": "URLを共有して対戦表をみんなで確認しましょう٩( ᐛ )و",
+  "@shareUrlDescription": {
+    "description": "Short description encouraging users to share the schedule URL."
+  },
+  "playersTitle": "参加者",
+  "@playersTitle": {
+    "description": "Section title for player information."
+  },
+  "noPlayersMessage": "参加者情報がありません",
+  "@noPlayersMessage": {
+    "description": "Message shown when no player information is available."
+  },
+  "scheduleNotLoadedMessage": "対戦表を取得できていません",
+  "@scheduleNotLoadedMessage": {
+    "description": "Message shown when no schedule response is loaded."
+  },
+  "scheduleDataEmptyMessage": "対戦表データがありません",
+  "@scheduleDataEmptyMessage": {
+    "description": "Message shown when the schedule response contains no rounds."
+  },
+  "restLabel": "休憩",
+  "@restLabel": {
+    "description": "Label for resting players."
+  },
+  "restCountLabel": "{restCount}人",
+  "@restCountLabel": {
+    "description": "Short label showing the number of resting players.",
+    "placeholders": {"restCount": {"type": "int", "example": "2"}}
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -52,8 +52,14 @@
   "@playerCountRangeHelp": {
     "description": "Help text that shows the valid player count range.",
     "placeholders": {
-      "minPlayerCount": {"type": "int", "example": "4"},
-      "maxPlayerCount": {"type": "int", "example": "7"}
+      "minPlayerCount": {
+        "type": "int",
+        "example": "4"
+      },
+      "maxPlayerCount": {
+        "type": "int",
+        "example": "7"
+      }
     }
   },
   "loadingEventInfo": "イベント情報を取得中...",
@@ -124,8 +130,14 @@
   "@playerDisplayNameInputLabel": {
     "description": "Input label for each player display name field.",
     "placeholders": {
-      "playerNumber": {"type": "int", "example": "1"},
-      "sourceName": {"type": "String", "example": "①"}
+      "playerNumber": {
+        "type": "int",
+        "example": "1"
+      },
+      "sourceName": {
+        "type": "String",
+        "example": "①"
+      }
     }
   },
   "resetInputsButton": "入力項目のリセット",
@@ -187,7 +199,12 @@
   "generateScheduleFailedMessage": "対戦表を生成できませんでした: {error}",
   "@generateScheduleFailedMessage": {
     "description": "Error message shown when schedule generation failed.",
-    "placeholders": {"error": {"type": "String", "example": "network error"}}
+    "placeholders": {
+      "error": {
+        "type": "String",
+        "example": "network error"
+      }
+    }
   },
   "reloadScheduleMissingIdMessage": "再取得する generated_schedule_id がありません",
   "@reloadScheduleMissingIdMessage": {
@@ -196,7 +213,12 @@
   "reloadScheduleFailedMessage": "対戦表を取得できませんでした: {error}",
   "@reloadScheduleFailedMessage": {
     "description": "Error message shown when reloading a schedule failed.",
-    "placeholders": {"error": {"type": "String", "example": "network error"}}
+    "placeholders": {
+      "error": {
+        "type": "String",
+        "example": "network error"
+      }
+    }
   },
   "adoptScheduleMissingIdMessage": "採用する generated_schedule_id がありません",
   "@adoptScheduleMissingIdMessage": {
@@ -221,14 +243,25 @@
   "adoptScheduleFailedMessage": "対戦表を採用できませんでした: {error}",
   "@adoptScheduleFailedMessage": {
     "description": "Error message shown when schedule adoption failed.",
-    "placeholders": {"error": {"type": "String", "example": "network error"}}
+    "placeholders": {
+      "error": {
+        "type": "String",
+        "example": "network error"
+      }
+    }
   },
   "schedulePlayersTitle": "面数: {courtCount}　　参加者: {playerCount}人",
   "@schedulePlayersTitle": {
     "description": "Title for player list showing court count and player count.",
     "placeholders": {
-      "courtCount": {"type": "int", "example": "1"},
-      "playerCount": {"type": "int", "example": "6"}
+      "courtCount": {
+        "type": "int",
+        "example": "1"
+      },
+      "playerCount": {
+        "type": "int",
+        "example": "6"
+      }
     }
   },
   "matchTableTitle": "対戦表",
@@ -274,6 +307,21 @@
   "restCountLabel": "{restCount}人",
   "@restCountLabel": {
     "description": "Short label showing the number of resting players.",
-    "placeholders": {"restCount": {"type": "int", "example": "2"}}
+    "placeholders": {
+      "restCount": {
+        "type": "int",
+        "example": "2"
+      }
+    }
+  },
+  "lastOpenedAtLabel": "最終表示: {lastOpenedAt}",
+  "@lastOpenedAtLabel": {
+    "description": "Label showing when a saved schedule was last opened.",
+    "placeholders": {
+      "lastOpenedAt": {
+        "type": "String",
+        "example": "2026/05/22 23:10"
+      }
+    }
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -120,6 +120,14 @@
   "@playerDisplayNameSectionTitle": {
     "description": "Section title for player display name inputs."
   },
+  "playerDisplayNameInputLabel": "参加者{playerNumber}：{sourceName}",
+  "@playerDisplayNameInputLabel": {
+    "description": "Input label for each player display name field.",
+    "placeholders": {
+      "playerNumber": {"type": "int", "example": "1"},
+      "sourceName": {"type": "String", "example": "①"}
+    }
+  },
   "resetInputsButton": "入力項目のリセット",
   "@resetInputsButton": {
     "description": "Button label for resetting input fields."

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,0 +1,133 @@
+{
+  "@@locale": "ja",
+  "appTitle": "Lanske",
+  "@appTitle": {
+    "description": "Application title."
+  },
+  "eventSetupTitle": "ダブルス乱数表 ver0.1",
+  "@eventSetupTitle": {
+    "description": "Title shown on the event setup page."
+  },
+  "matchTableList": "対戦表一覧",
+  "@matchTableList": {
+    "description": "Menu item label for the saved/generated match table list."
+  },
+  "eventSetupInstruction": "URLを貼るか、手動で面数・人数を入力してください。",
+  "@eventSetupInstruction": {
+    "description": "Instruction text on the event setup page."
+  },
+  "eventSetupSupportedConditions": "ver0.1では、1面4〜7人 / 2面8〜15人に対応しています。",
+  "@eventSetupSupportedConditions": {
+    "description": "Short note about supported court and player count conditions."
+  },
+  "courtCountLabel": "面数",
+  "@courtCountLabel": {
+    "description": "Label for court count input."
+  },
+  "playerCountLabel": "人数",
+  "@playerCountLabel": {
+    "description": "Label for player count input."
+  },
+  "decrementCourtCountTooltip": "面数を減らす",
+  "@decrementCourtCountTooltip": {
+    "description": "Tooltip for decreasing court count."
+  },
+  "incrementCourtCountTooltip": "面数を増やす",
+  "@incrementCourtCountTooltip": {
+    "description": "Tooltip for increasing court count."
+  },
+  "decrementPlayerCountTooltip": "人数を減らす",
+  "@decrementPlayerCountTooltip": {
+    "description": "Tooltip for decreasing player count."
+  },
+  "incrementPlayerCountTooltip": "人数を増やす",
+  "@incrementPlayerCountTooltip": {
+    "description": "Tooltip for increasing player count."
+  },
+  "playerCountRangeHelp": "人数は {minPlayerCount} 人以上、{maxPlayerCount} 人以下で入力してください。",
+  "@playerCountRangeHelp": {
+    "description": "Help text that shows the valid player count range.",
+    "placeholders": {
+      "minPlayerCount": {
+        "type": "int",
+        "example": "4"
+      },
+      "maxPlayerCount": {
+        "type": "int",
+        "example": "7"
+      }
+    }
+  },
+  "loadingEventInfo": "イベント情報を取得中...",
+  "@loadingEventInfo": {
+    "description": "Loading message shown while importing event information."
+  },
+  "enterUrlMessage": "URLを入力してください",
+  "@enterUrlMessage": {
+    "description": "Snack bar message shown when URL input is empty."
+  },
+  "enterTennisbearEventUrlMessage": "テニスベアのイベントURLを入力してください",
+  "@enterTennisbearEventUrlMessage": {
+    "description": "Snack bar message shown when the URL is not a TennisBear event URL."
+  },
+  "eventInfoLoadedMessage": "イベント情報を取得しました",
+  "@eventInfoLoadedMessage": {
+    "description": "Snack bar message shown when event information was imported successfully."
+  },
+  "eventInfoPartiallyLoadedMessage": "イベント情報を取得しました（一部情報は取得できませんでした）",
+  "@eventInfoPartiallyLoadedMessage": {
+    "description": "Snack bar message shown when event information was imported with warnings."
+  },
+  "eventInfoLoadFailedMessage": "取得できませんでした。URLを確認して再度お試しください",
+  "@eventInfoLoadFailedMessage": {
+    "description": "Snack bar message shown when event information import failed."
+  },
+  "clipboardUrlNotFoundMessage": "クリップボードにURLがありません",
+  "@clipboardUrlNotFoundMessage": {
+    "description": "Snack bar message shown when clipboard has no URL."
+  },
+  "pasteTennisbearEventUrlMessage": "テニスベアのイベントURLを貼り付けてください",
+  "@pasteTennisbearEventUrlMessage": {
+    "description": "Snack bar message shown when pasted text is not a TennisBear event URL."
+  },
+  "tennisbearEventUrlLabel": "テニスベアのイベントURL",
+  "@tennisbearEventUrlLabel": {
+    "description": "Input label for TennisBear event URL."
+  },
+  "tennisbearEventUrlHelper": "例: テニスベアのイベント詳細URL",
+  "@tennisbearEventUrlHelper": {
+    "description": "Helper text example for TennisBear event URL input."
+  },
+  "tennisbearEventUrlError": "テニスベアのイベントURLを入力してください",
+  "@tennisbearEventUrlError": {
+    "description": "Validation error for TennisBear event URL input."
+  },
+  "clearUrlTooltip": "URLをクリア",
+  "@clearUrlTooltip": {
+    "description": "Tooltip for clearing the URL input."
+  },
+  "pasteButton": "貼り付け",
+  "@pasteButton": {
+    "description": "Button label for pasting text from clipboard."
+  },
+  "importButton": "取り込み",
+  "@importButton": {
+    "description": "Button label for importing event information."
+  },
+  "eventNameLabel": "イベント名",
+  "@eventNameLabel": {
+    "description": "Input label for event name."
+  },
+  "playerDisplayNameSectionTitle": "参加者表示名",
+  "@playerDisplayNameSectionTitle": {
+    "description": "Section title for player display name inputs."
+  },
+  "resetInputsButton": "入力項目のリセット",
+  "@resetInputsButton": {
+    "description": "Button label for resetting input fields."
+  },
+  "generateScheduleButton": "対戦表の生成",
+  "@generateScheduleButton": {
+    "description": "Button label for generating a match table."
+  }
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -110,6 +110,12 @@ abstract class AppLocalizations {
   /// **'ダブルス乱数表 ver0.1'**
   String get eventSetupTitle;
 
+  /// Menu item label for returning to the top page.
+  ///
+  /// In ja, this message translates to:
+  /// **'TOPへ'**
+  String get topPageMenu;
+
   /// Menu item label for the saved/generated match table list.
   ///
   /// In ja, this message translates to:
@@ -277,6 +283,204 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'対戦表の生成'**
   String get generateScheduleButton;
+
+  /// Short button label for generating a schedule.
+  ///
+  /// In ja, this message translates to:
+  /// **'生成'**
+  String get generateButton;
+
+  /// Short button label for regenerating a schedule.
+  ///
+  /// In ja, this message translates to:
+  /// **'再生成'**
+  String get regenerateButton;
+
+  /// Button label shown while adopting a schedule.
+  ///
+  /// In ja, this message translates to:
+  /// **'採用中'**
+  String get adoptingScheduleButton;
+
+  /// Button label for adopting the currently displayed schedule.
+  ///
+  /// In ja, this message translates to:
+  /// **'この対戦表を採用'**
+  String get adoptScheduleButton;
+
+  /// Message shown when regeneration is blocked because the schedule was adopted.
+  ///
+  /// In ja, this message translates to:
+  /// **'採用済みのため再生成できません'**
+  String get cannotRegenerateAdoptedScheduleMessage;
+
+  /// Dialog title for confirming schedule regeneration.
+  ///
+  /// In ja, this message translates to:
+  /// **'再生成しますか？'**
+  String get regenerateConfirmTitle;
+
+  /// Dialog body for confirming schedule regeneration.
+  ///
+  /// In ja, this message translates to:
+  /// **'現在表示している対戦表を新しい対戦表に差し替えます。\n共有URLから表示される未採用の対戦表も、再生成後の内容に更新されます。'**
+  String get regenerateConfirmBody;
+
+  /// Generic cancel button label.
+  ///
+  /// In ja, this message translates to:
+  /// **'キャンセル'**
+  String get cancelButton;
+
+  /// Dialog action button label for regenerating a schedule.
+  ///
+  /// In ja, this message translates to:
+  /// **'再生成する'**
+  String get regenerateActionButton;
+
+  /// Message shown when the saved schedule cannot be found.
+  ///
+  /// In ja, this message translates to:
+  /// **'対戦表が見つかりません'**
+  String get scheduleNotFoundMessage;
+
+  /// Message shown when a share URL cannot be created.
+  ///
+  /// In ja, this message translates to:
+  /// **'URLを作成できませんでした'**
+  String get shareUrlCreateFailedMessage;
+
+  /// Message shown when the share URL was copied.
+  ///
+  /// In ja, this message translates to:
+  /// **'URLをコピーしました'**
+  String get shareUrlCopiedMessage;
+
+  /// Error message shown when schedule generation failed.
+  ///
+  /// In ja, this message translates to:
+  /// **'対戦表を生成できませんでした: {error}'**
+  String generateScheduleFailedMessage(String error);
+
+  /// Error message shown when no generated schedule id is available for reload.
+  ///
+  /// In ja, this message translates to:
+  /// **'再取得する generated_schedule_id がありません'**
+  String get reloadScheduleMissingIdMessage;
+
+  /// Error message shown when reloading a schedule failed.
+  ///
+  /// In ja, this message translates to:
+  /// **'対戦表を取得できませんでした: {error}'**
+  String reloadScheduleFailedMessage(String error);
+
+  /// Message shown when no generated schedule id is available for adoption.
+  ///
+  /// In ja, this message translates to:
+  /// **'採用する generated_schedule_id がありません'**
+  String get adoptScheduleMissingIdMessage;
+
+  /// Message shown when event information for adoption is missing.
+  ///
+  /// In ja, this message translates to:
+  /// **'採用するイベント情報がありません'**
+  String get adoptEventMissingMessage;
+
+  /// Message shown when the schedule has already been adopted.
+  ///
+  /// In ja, this message translates to:
+  /// **'すでに採用済みです'**
+  String get alreadyAdoptedScheduleMessage;
+
+  /// Message shown when the displayed schedule is outdated.
+  ///
+  /// In ja, this message translates to:
+  /// **'対戦表が更新されています。最新の情報に更新します'**
+  String get scheduleUpdatedReloadMessage;
+
+  /// Message shown when schedule adoption completed.
+  ///
+  /// In ja, this message translates to:
+  /// **'この対戦表を採用しました'**
+  String get adoptScheduleCompletedMessage;
+
+  /// Error message shown when schedule adoption failed.
+  ///
+  /// In ja, this message translates to:
+  /// **'対戦表を採用できませんでした: {error}'**
+  String adoptScheduleFailedMessage(String error);
+
+  /// Title for player list showing court count and player count.
+  ///
+  /// In ja, this message translates to:
+  /// **'面数: {courtCount}　　参加者: {playerCount}人'**
+  String schedulePlayersTitle(int courtCount, int playerCount);
+
+  /// Section title for the match table.
+  ///
+  /// In ja, this message translates to:
+  /// **'対戦表'**
+  String get matchTableTitle;
+
+  /// Generic error section title.
+  ///
+  /// In ja, this message translates to:
+  /// **'エラー'**
+  String get errorTitle;
+
+  /// Button label for copying a share URL.
+  ///
+  /// In ja, this message translates to:
+  /// **'URLをコピー'**
+  String get copyUrlButton;
+
+  /// Button label for refreshing the latest schedule information.
+  ///
+  /// In ja, this message translates to:
+  /// **'最新の情報に更新'**
+  String get refreshLatestButton;
+
+  /// Short description encouraging users to share the schedule URL.
+  ///
+  /// In ja, this message translates to:
+  /// **'URLを共有して対戦表をみんなで確認しましょう٩( ᐛ )و'**
+  String get shareUrlDescription;
+
+  /// Section title for player information.
+  ///
+  /// In ja, this message translates to:
+  /// **'参加者'**
+  String get playersTitle;
+
+  /// Message shown when no player information is available.
+  ///
+  /// In ja, this message translates to:
+  /// **'参加者情報がありません'**
+  String get noPlayersMessage;
+
+  /// Message shown when no schedule response is loaded.
+  ///
+  /// In ja, this message translates to:
+  /// **'対戦表を取得できていません'**
+  String get scheduleNotLoadedMessage;
+
+  /// Message shown when the schedule response contains no rounds.
+  ///
+  /// In ja, this message translates to:
+  /// **'対戦表データがありません'**
+  String get scheduleDataEmptyMessage;
+
+  /// Label for resting players.
+  ///
+  /// In ja, this message translates to:
+  /// **'休憩'**
+  String get restLabel;
+
+  /// Short label showing the number of resting players.
+  ///
+  /// In ja, this message translates to:
+  /// **'{restCount}人'**
+  String restCountLabel(int restCount);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -272,6 +272,12 @@ abstract class AppLocalizations {
   /// **'参加者表示名'**
   String get playerDisplayNameSectionTitle;
 
+  /// Input label for each player display name field.
+  ///
+  /// In ja, this message translates to:
+  /// **'参加者{playerNumber}：{sourceName}'**
+  String playerDisplayNameInputLabel(int playerNumber, String sourceName);
+
   /// Button label for resetting input fields.
   ///
   /// In ja, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,313 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations_en.dart';
+import 'app_localizations_ja.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of AppLocalizations
+/// returned by `AppLocalizations.of(context)`.
+///
+/// Applications need to include `AppLocalizations.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'l10n/app_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: AppLocalizations.localizationsDelegates,
+///   supportedLocales: AppLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the AppLocalizations.supportedLocales
+/// property.
+abstract class AppLocalizations {
+  AppLocalizations(String locale)
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en'),
+    Locale('ja')
+  ];
+
+  /// Application title.
+  ///
+  /// In ja, this message translates to:
+  /// **'Lanske'**
+  String get appTitle;
+
+  /// Title shown on the event setup page.
+  ///
+  /// In ja, this message translates to:
+  /// **'ダブルス乱数表 ver0.1'**
+  String get eventSetupTitle;
+
+  /// Menu item label for the saved/generated match table list.
+  ///
+  /// In ja, this message translates to:
+  /// **'対戦表一覧'**
+  String get matchTableList;
+
+  /// Instruction text on the event setup page.
+  ///
+  /// In ja, this message translates to:
+  /// **'URLを貼るか、手動で面数・人数を入力してください。'**
+  String get eventSetupInstruction;
+
+  /// Short note about supported court and player count conditions.
+  ///
+  /// In ja, this message translates to:
+  /// **'ver0.1では、1面4〜7人 / 2面8〜15人に対応しています。'**
+  String get eventSetupSupportedConditions;
+
+  /// Label for court count input.
+  ///
+  /// In ja, this message translates to:
+  /// **'面数'**
+  String get courtCountLabel;
+
+  /// Label for player count input.
+  ///
+  /// In ja, this message translates to:
+  /// **'人数'**
+  String get playerCountLabel;
+
+  /// Tooltip for decreasing court count.
+  ///
+  /// In ja, this message translates to:
+  /// **'面数を減らす'**
+  String get decrementCourtCountTooltip;
+
+  /// Tooltip for increasing court count.
+  ///
+  /// In ja, this message translates to:
+  /// **'面数を増やす'**
+  String get incrementCourtCountTooltip;
+
+  /// Tooltip for decreasing player count.
+  ///
+  /// In ja, this message translates to:
+  /// **'人数を減らす'**
+  String get decrementPlayerCountTooltip;
+
+  /// Tooltip for increasing player count.
+  ///
+  /// In ja, this message translates to:
+  /// **'人数を増やす'**
+  String get incrementPlayerCountTooltip;
+
+  /// Help text that shows the valid player count range.
+  ///
+  /// In ja, this message translates to:
+  /// **'人数は {minPlayerCount} 人以上、{maxPlayerCount} 人以下で入力してください。'**
+  String playerCountRangeHelp(int minPlayerCount, int maxPlayerCount);
+
+  /// Loading message shown while importing event information.
+  ///
+  /// In ja, this message translates to:
+  /// **'イベント情報を取得中...'**
+  String get loadingEventInfo;
+
+  /// Snack bar message shown when URL input is empty.
+  ///
+  /// In ja, this message translates to:
+  /// **'URLを入力してください'**
+  String get enterUrlMessage;
+
+  /// Snack bar message shown when the URL is not a TennisBear event URL.
+  ///
+  /// In ja, this message translates to:
+  /// **'テニスベアのイベントURLを入力してください'**
+  String get enterTennisbearEventUrlMessage;
+
+  /// Snack bar message shown when event information was imported successfully.
+  ///
+  /// In ja, this message translates to:
+  /// **'イベント情報を取得しました'**
+  String get eventInfoLoadedMessage;
+
+  /// Snack bar message shown when event information was imported with warnings.
+  ///
+  /// In ja, this message translates to:
+  /// **'イベント情報を取得しました（一部情報は取得できませんでした）'**
+  String get eventInfoPartiallyLoadedMessage;
+
+  /// Snack bar message shown when event information import failed.
+  ///
+  /// In ja, this message translates to:
+  /// **'取得できませんでした。URLを確認して再度お試しください'**
+  String get eventInfoLoadFailedMessage;
+
+  /// Snack bar message shown when clipboard has no URL.
+  ///
+  /// In ja, this message translates to:
+  /// **'クリップボードにURLがありません'**
+  String get clipboardUrlNotFoundMessage;
+
+  /// Snack bar message shown when pasted text is not a TennisBear event URL.
+  ///
+  /// In ja, this message translates to:
+  /// **'テニスベアのイベントURLを貼り付けてください'**
+  String get pasteTennisbearEventUrlMessage;
+
+  /// Input label for TennisBear event URL.
+  ///
+  /// In ja, this message translates to:
+  /// **'テニスベアのイベントURL'**
+  String get tennisbearEventUrlLabel;
+
+  /// Helper text example for TennisBear event URL input.
+  ///
+  /// In ja, this message translates to:
+  /// **'例: テニスベアのイベント詳細URL'**
+  String get tennisbearEventUrlHelper;
+
+  /// Validation error for TennisBear event URL input.
+  ///
+  /// In ja, this message translates to:
+  /// **'テニスベアのイベントURLを入力してください'**
+  String get tennisbearEventUrlError;
+
+  /// Tooltip for clearing the URL input.
+  ///
+  /// In ja, this message translates to:
+  /// **'URLをクリア'**
+  String get clearUrlTooltip;
+
+  /// Button label for pasting text from clipboard.
+  ///
+  /// In ja, this message translates to:
+  /// **'貼り付け'**
+  String get pasteButton;
+
+  /// Button label for importing event information.
+  ///
+  /// In ja, this message translates to:
+  /// **'取り込み'**
+  String get importButton;
+
+  /// Input label for event name.
+  ///
+  /// In ja, this message translates to:
+  /// **'イベント名'**
+  String get eventNameLabel;
+
+  /// Section title for player display name inputs.
+  ///
+  /// In ja, this message translates to:
+  /// **'参加者表示名'**
+  String get playerDisplayNameSectionTitle;
+
+  /// Button label for resetting input fields.
+  ///
+  /// In ja, this message translates to:
+  /// **'入力項目のリセット'**
+  String get resetInputsButton;
+
+  /// Button label for generating a match table.
+  ///
+  /// In ja, this message translates to:
+  /// **'対戦表の生成'**
+  String get generateScheduleButton;
+}
+
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) =>
+      <String>['en', 'ja'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}
+
+AppLocalizations lookupAppLocalizations(Locale locale) {
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'en':
+      return AppLocalizationsEn();
+    case 'ja':
+      return AppLocalizationsJa();
+  }
+
+  throw FlutterError(
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -487,6 +487,12 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'{restCount}人'**
   String restCountLabel(int restCount);
+
+  /// Label showing when a saved schedule was last opened.
+  ///
+  /// In ja, this message translates to:
+  /// **'最終表示: {lastOpenedAt}'**
+  String lastOpenedAtLabel(String lastOpenedAt);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -15,6 +15,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get eventSetupTitle => 'Doubles Match Table ver0.1';
 
   @override
+  String get topPageMenu => 'Top';
+
+  @override
   String get matchTableList => 'Match table list';
 
   @override
@@ -103,4 +106,121 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get generateScheduleButton => 'Generate match table';
+
+  @override
+  String get generateButton => 'Generate';
+
+  @override
+  String get regenerateButton => 'Regenerate';
+
+  @override
+  String get adoptingScheduleButton => 'Adopting';
+
+  @override
+  String get adoptScheduleButton => 'Use this table';
+
+  @override
+  String get cannotRegenerateAdoptedScheduleMessage =>
+      'This table has already been adopted and cannot be regenerated.';
+
+  @override
+  String get regenerateConfirmTitle => 'Regenerate?';
+
+  @override
+  String get regenerateConfirmBody =>
+      'The currently displayed match table will be replaced.\nUnadopted tables shown from the share URL will also be updated.';
+
+  @override
+  String get cancelButton => 'Cancel';
+
+  @override
+  String get regenerateActionButton => 'Regenerate';
+
+  @override
+  String get scheduleNotFoundMessage => 'Match table not found.';
+
+  @override
+  String get shareUrlCreateFailedMessage => 'Could not create the URL.';
+
+  @override
+  String get shareUrlCopiedMessage => 'URL copied.';
+
+  @override
+  String generateScheduleFailedMessage(String error) {
+    return 'Could not generate the match table: $error';
+  }
+
+  @override
+  String get reloadScheduleMissingIdMessage =>
+      'No generated_schedule_id is available for reload.';
+
+  @override
+  String reloadScheduleFailedMessage(String error) {
+    return 'Could not load the match table: $error';
+  }
+
+  @override
+  String get adoptScheduleMissingIdMessage =>
+      'No generated_schedule_id is available for adoption.';
+
+  @override
+  String get adoptEventMissingMessage =>
+      'No event information is available for adoption.';
+
+  @override
+  String get alreadyAdoptedScheduleMessage =>
+      'This table has already been adopted.';
+
+  @override
+  String get scheduleUpdatedReloadMessage =>
+      'The match table has been updated. Loading the latest information.';
+
+  @override
+  String get adoptScheduleCompletedMessage => 'This match table was adopted.';
+
+  @override
+  String adoptScheduleFailedMessage(String error) {
+    return 'Could not adopt the match table: $error';
+  }
+
+  @override
+  String schedulePlayersTitle(int courtCount, int playerCount) {
+    return 'Courts: $courtCount    Players: $playerCount';
+  }
+
+  @override
+  String get matchTableTitle => 'Match table';
+
+  @override
+  String get errorTitle => 'Error';
+
+  @override
+  String get copyUrlButton => 'Copy URL';
+
+  @override
+  String get refreshLatestButton => 'Refresh';
+
+  @override
+  String get shareUrlDescription =>
+      'Share the URL so everyone can check the match table.';
+
+  @override
+  String get playersTitle => 'Players';
+
+  @override
+  String get noPlayersMessage => 'No player information is available.';
+
+  @override
+  String get scheduleNotLoadedMessage => 'The match table has not been loaded.';
+
+  @override
+  String get scheduleDataEmptyMessage => 'No match table data is available.';
+
+  @override
+  String get restLabel => 'Rest';
+
+  @override
+  String restCountLabel(int restCount) {
+    return '$restCount rest';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1,0 +1,106 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class AppLocalizationsEn extends AppLocalizations {
+  AppLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get appTitle => 'Lanske';
+
+  @override
+  String get eventSetupTitle => 'Doubles Match Table ver0.1';
+
+  @override
+  String get matchTableList => 'Match table list';
+
+  @override
+  String get eventSetupInstruction =>
+      'Paste a URL or enter the court and player counts manually.';
+
+  @override
+  String get eventSetupSupportedConditions =>
+      'ver0.1 supports 1 court with 4 to 7 players and 2 courts with 8 to 15 players.';
+
+  @override
+  String get courtCountLabel => 'Courts';
+
+  @override
+  String get playerCountLabel => 'Players';
+
+  @override
+  String get decrementCourtCountTooltip => 'Decrease court count';
+
+  @override
+  String get incrementCourtCountTooltip => 'Increase court count';
+
+  @override
+  String get decrementPlayerCountTooltip => 'Decrease player count';
+
+  @override
+  String get incrementPlayerCountTooltip => 'Increase player count';
+
+  @override
+  String playerCountRangeHelp(int minPlayerCount, int maxPlayerCount) {
+    return 'Enter between $minPlayerCount and $maxPlayerCount players.';
+  }
+
+  @override
+  String get loadingEventInfo => 'Loading event info...';
+
+  @override
+  String get enterUrlMessage => 'Enter a URL.';
+
+  @override
+  String get enterTennisbearEventUrlMessage => 'Enter a TennisBear event URL.';
+
+  @override
+  String get eventInfoLoadedMessage => 'Event info loaded.';
+
+  @override
+  String get eventInfoPartiallyLoadedMessage =>
+      'Event info loaded. Some details could not be imported.';
+
+  @override
+  String get eventInfoLoadFailedMessage =>
+      'Could not load event info. Check the URL and try again.';
+
+  @override
+  String get clipboardUrlNotFoundMessage => 'No URL found in the clipboard.';
+
+  @override
+  String get pasteTennisbearEventUrlMessage => 'Paste a TennisBear event URL.';
+
+  @override
+  String get tennisbearEventUrlLabel => 'TennisBear event URL';
+
+  @override
+  String get tennisbearEventUrlHelper => 'Example: TennisBear event detail URL';
+
+  @override
+  String get tennisbearEventUrlError => 'Enter a TennisBear event URL.';
+
+  @override
+  String get clearUrlTooltip => 'Clear URL';
+
+  @override
+  String get pasteButton => 'Paste';
+
+  @override
+  String get importButton => 'Import';
+
+  @override
+  String get eventNameLabel => 'Event name';
+
+  @override
+  String get playerDisplayNameSectionTitle => 'Player display names';
+
+  @override
+  String get resetInputsButton => 'Reset inputs';
+
+  @override
+  String get generateScheduleButton => 'Generate match table';
+}

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -228,4 +228,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String restCountLabel(int restCount) {
     return '$restCount rest';
   }
+
+  @override
+  String lastOpenedAtLabel(String lastOpenedAt) {
+    return 'Last opened: $lastOpenedAt';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -102,6 +102,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get playerDisplayNameSectionTitle => 'Player display names';
 
   @override
+  String playerDisplayNameInputLabel(int playerNumber, String sourceName) {
+    return 'Player $playerNumber: $sourceName';
+  }
+
+  @override
   String get resetInputsButton => 'Reset inputs';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1,0 +1,104 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Japanese (`ja`).
+class AppLocalizationsJa extends AppLocalizations {
+  AppLocalizationsJa([String locale = 'ja']) : super(locale);
+
+  @override
+  String get appTitle => 'Lanske';
+
+  @override
+  String get eventSetupTitle => 'ダブルス乱数表 ver0.1';
+
+  @override
+  String get matchTableList => '対戦表一覧';
+
+  @override
+  String get eventSetupInstruction => 'URLを貼るか、手動で面数・人数を入力してください。';
+
+  @override
+  String get eventSetupSupportedConditions =>
+      'ver0.1では、1面4〜7人 / 2面8〜15人に対応しています。';
+
+  @override
+  String get courtCountLabel => '面数';
+
+  @override
+  String get playerCountLabel => '人数';
+
+  @override
+  String get decrementCourtCountTooltip => '面数を減らす';
+
+  @override
+  String get incrementCourtCountTooltip => '面数を増やす';
+
+  @override
+  String get decrementPlayerCountTooltip => '人数を減らす';
+
+  @override
+  String get incrementPlayerCountTooltip => '人数を増やす';
+
+  @override
+  String playerCountRangeHelp(int minPlayerCount, int maxPlayerCount) {
+    return '人数は $minPlayerCount 人以上、$maxPlayerCount 人以下で入力してください。';
+  }
+
+  @override
+  String get loadingEventInfo => 'イベント情報を取得中...';
+
+  @override
+  String get enterUrlMessage => 'URLを入力してください';
+
+  @override
+  String get enterTennisbearEventUrlMessage => 'テニスベアのイベントURLを入力してください';
+
+  @override
+  String get eventInfoLoadedMessage => 'イベント情報を取得しました';
+
+  @override
+  String get eventInfoPartiallyLoadedMessage =>
+      'イベント情報を取得しました（一部情報は取得できませんでした）';
+
+  @override
+  String get eventInfoLoadFailedMessage => '取得できませんでした。URLを確認して再度お試しください';
+
+  @override
+  String get clipboardUrlNotFoundMessage => 'クリップボードにURLがありません';
+
+  @override
+  String get pasteTennisbearEventUrlMessage => 'テニスベアのイベントURLを貼り付けてください';
+
+  @override
+  String get tennisbearEventUrlLabel => 'テニスベアのイベントURL';
+
+  @override
+  String get tennisbearEventUrlHelper => '例: テニスベアのイベント詳細URL';
+
+  @override
+  String get tennisbearEventUrlError => 'テニスベアのイベントURLを入力してください';
+
+  @override
+  String get clearUrlTooltip => 'URLをクリア';
+
+  @override
+  String get pasteButton => '貼り付け';
+
+  @override
+  String get importButton => '取り込み';
+
+  @override
+  String get eventNameLabel => 'イベント名';
+
+  @override
+  String get playerDisplayNameSectionTitle => '参加者表示名';
+
+  @override
+  String get resetInputsButton => '入力項目のリセット';
+
+  @override
+  String get generateScheduleButton => '対戦表の生成';
+}

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -15,6 +15,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get eventSetupTitle => 'ダブルス乱数表 ver0.1';
 
   @override
+  String get topPageMenu => 'TOPへ';
+
+  @override
   String get matchTableList => '対戦表一覧';
 
   @override
@@ -101,4 +104,116 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get generateScheduleButton => '対戦表の生成';
+
+  @override
+  String get generateButton => '生成';
+
+  @override
+  String get regenerateButton => '再生成';
+
+  @override
+  String get adoptingScheduleButton => '採用中';
+
+  @override
+  String get adoptScheduleButton => 'この対戦表を採用';
+
+  @override
+  String get cannotRegenerateAdoptedScheduleMessage => '採用済みのため再生成できません';
+
+  @override
+  String get regenerateConfirmTitle => '再生成しますか？';
+
+  @override
+  String get regenerateConfirmBody =>
+      '現在表示している対戦表を新しい対戦表に差し替えます。\n共有URLから表示される未採用の対戦表も、再生成後の内容に更新されます。';
+
+  @override
+  String get cancelButton => 'キャンセル';
+
+  @override
+  String get regenerateActionButton => '再生成する';
+
+  @override
+  String get scheduleNotFoundMessage => '対戦表が見つかりません';
+
+  @override
+  String get shareUrlCreateFailedMessage => 'URLを作成できませんでした';
+
+  @override
+  String get shareUrlCopiedMessage => 'URLをコピーしました';
+
+  @override
+  String generateScheduleFailedMessage(String error) {
+    return '対戦表を生成できませんでした: $error';
+  }
+
+  @override
+  String get reloadScheduleMissingIdMessage =>
+      '再取得する generated_schedule_id がありません';
+
+  @override
+  String reloadScheduleFailedMessage(String error) {
+    return '対戦表を取得できませんでした: $error';
+  }
+
+  @override
+  String get adoptScheduleMissingIdMessage =>
+      '採用する generated_schedule_id がありません';
+
+  @override
+  String get adoptEventMissingMessage => '採用するイベント情報がありません';
+
+  @override
+  String get alreadyAdoptedScheduleMessage => 'すでに採用済みです';
+
+  @override
+  String get scheduleUpdatedReloadMessage => '対戦表が更新されています。最新の情報に更新します';
+
+  @override
+  String get adoptScheduleCompletedMessage => 'この対戦表を採用しました';
+
+  @override
+  String adoptScheduleFailedMessage(String error) {
+    return '対戦表を採用できませんでした: $error';
+  }
+
+  @override
+  String schedulePlayersTitle(int courtCount, int playerCount) {
+    return '面数: $courtCount　　参加者: $playerCount人';
+  }
+
+  @override
+  String get matchTableTitle => '対戦表';
+
+  @override
+  String get errorTitle => 'エラー';
+
+  @override
+  String get copyUrlButton => 'URLをコピー';
+
+  @override
+  String get refreshLatestButton => '最新の情報に更新';
+
+  @override
+  String get shareUrlDescription => 'URLを共有して対戦表をみんなで確認しましょう٩( ᐛ )و';
+
+  @override
+  String get playersTitle => '参加者';
+
+  @override
+  String get noPlayersMessage => '参加者情報がありません';
+
+  @override
+  String get scheduleNotLoadedMessage => '対戦表を取得できていません';
+
+  @override
+  String get scheduleDataEmptyMessage => '対戦表データがありません';
+
+  @override
+  String get restLabel => '休憩';
+
+  @override
+  String restCountLabel(int restCount) {
+    return '$restCount人';
+  }
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -221,4 +221,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String restCountLabel(int restCount) {
     return '$restCount人';
   }
+
+  @override
+  String lastOpenedAtLabel(String lastOpenedAt) {
+    return '最終表示: $lastOpenedAt';
+  }
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -100,6 +100,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get playerDisplayNameSectionTitle => '参加者表示名';
 
   @override
+  String playerDisplayNameInputLabel(int playerNumber, String sourceName) {
+    return '参加者$playerNumber：$sourceName';
+  }
+
+  @override
   String get resetInputsButton => '入力項目のリセット';
 
   @override

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -1,0 +1,1 @@
+export 'app_localizations.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -174,6 +174,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -224,6 +229,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   jni:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   cupertino_icons: ^1.0.8
   http: ^1.2.2
   uuid: ^4.5.1
@@ -17,6 +19,7 @@ dependencies:
   google_fonts: ^8.1.0
   shared_preferences: ^2.5.5
   web: ^1.1.1
+  intl: any
 
 dev_dependencies:
   flutter_test:
@@ -24,4 +27,5 @@ dev_dependencies:
   flutter_lints: ^5.0.0
 
 flutter:
+  generate: true
   uses-material-design: true


### PR DESCRIPTION
## 概要

web #56 として、Lanske web に Flutter l10n を導入し、主要画面の ja / en ローカライズ基盤を追加しました。

今回のスコープでは、ja / en の文言リソースと `AppLocalizations` 経由の参照へ移行します。  
ただし、手動言語切り替え UI と初回自動言語選択は ver0.2 以降の別 Issue に分離し、現時点では `locale: const Locale('ja')` により日本語表示を維持します。

closes #56

## 変更内容

- Flutter l10n を導入
  - `flutter_localizations` / `intl` を追加
  - `flutter.generate: true` を追加
  - `l10n.yaml` を追加
  - `lib/l10n/app_ja.arb` / `app_en.arb` を追加
  - 生成済み `app_localizations*.dart` を追加
- `MaterialApp` に l10n 設定を追加
  - `localizationsDelegates`
  - `supportedLocales`
  - `locale: const Locale('ja')`
- 主要画面・主要 widget の文言を l10n 化
  - `EventSetupPage`
  - `SchedulePage`
  - `RestoredSchedulePage`
  - `EventListPage`
  - Event setup 関連 widget
  - Schedule 表示関連 widget
- 残っていた日本語 fallback を整理
  - data / infrastructure 層の fallback は l10n を持ち込まず、英語の中立的な fallback に変更
- `contributing.md` のブランチ prefix 例を `feature/` から `feat/` に整理

## スコープ外

以下は #56 では実装しません。

- 手動言語切り替え UI
- 初回アクセス時の自動言語選択
- ブラウザストレージによる選択言語保存
- `/en/` などの path 分離
- SEO 向けの多言語ページ分離
- 利用規約などの厳密な英訳

手動切替・初回自動選択の検討は #71、ハンバーガーメニュー視認性改善は #70 に分離済みです。

## 確認内容

- [x] `dart format lib/`
- [x] `flutter analyze`
- [x] `flutter test`
- [x] `locale: const Locale('en')` に一時変更して主要画面の英語表示を確認
- [x] 表示確認後、`locale: const Locale('ja')` に戻っていることを確認
- [x] `rg -n "[ぁ-んァ-ヶ一-龠]" lib --glob '!lib/l10n/app_*.arb' --glob '!lib/l10n/app_localizations*.dart'` で、コメント以外に日本語直書きが残っていないことを目視確認

## docs / OpenAPI 更新要否

- docs: `docs/contributing.md` を更新済み
- OpenAPI: web 側の l10n 対応のみのため更新不要