### PR TITLE
✨ feat: allow removing participant inputs refs #57

### DIFF
--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -82,6 +82,8 @@ class _EventSetupPageState extends State<EventSetupPage> {
     return _hasUrlInput;
   }
 
+  bool get _canRemovePlayer => _displayNameControllers.length > _minPlayerCount;
+
   @override
   void initState() {
     super.initState();
@@ -167,10 +169,12 @@ class _EventSetupPageState extends State<EventSetupPage> {
       _sourceDisplayNames.add(defaultName);
 
       focusNode.addListener(() {
-        if (index >= _displayNameControllers.length) return;
+        final currentIndex = _displayNameFocusNodes.indexOf(focusNode);
+        if (currentIndex < 0) return;
+        if (currentIndex >= _displayNameControllers.length) return;
 
-        final controller = _displayNameControllers[index];
-        final currentDefault = _defaultDisplayNames[index];
+        final controller = _displayNameControllers[currentIndex];
+        final currentDefault = _defaultDisplayNames[currentIndex];
 
         if (focusNode.hasFocus) {
           if (controller.text == currentDefault) {
@@ -180,7 +184,7 @@ class _EventSetupPageState extends State<EventSetupPage> {
         }
 
         if (controller.text.trim().isEmpty) {
-          final fallback = _sourceDisplayNames[index];
+          final fallback = _sourceDisplayNames[currentIndex];
           controller.text = (fallback != null && fallback.isNotEmpty)
               ? fallback
               : currentDefault;
@@ -198,19 +202,7 @@ class _EventSetupPageState extends State<EventSetupPage> {
       _sourceDisplayNames.removeLast();
     }
 
-    if (!_loadedFromUrl) {
-      for (var i = 0; i < _displayNameControllers.length; i++) {
-        final defaultName = circledNumber(i + 1);
-        final currentText = _displayNameControllers[i].text.trim();
-
-        _defaultDisplayNames[i] = defaultName;
-        _sourceDisplayNames[i] = defaultName;
-
-        if (currentText.isEmpty || currentText == _defaultDisplayNames[i]) {
-          _displayNameControllers[i].text = defaultName;
-        }
-      }
-    }
+    _refreshManualDisplayNameDefaults();
   }
 
   void _setCourts(int value, {bool resetPlayerCountToDefault = false}) {
@@ -229,6 +221,43 @@ class _EventSetupPageState extends State<EventSetupPage> {
       _playerCountController.text = clamped.toString();
       _syncDisplayNameControllers();
     });
+  }
+
+  void _removePlayerAt(int index) {
+    if (!_canRemovePlayer) return;
+    if (index < 0 || index >= _displayNameControllers.length) return;
+
+    FocusScope.of(context).unfocus();
+
+    setState(() {
+      _displayNameControllers.removeAt(index).dispose();
+      _displayNameFocusNodes.removeAt(index).dispose();
+      _defaultDisplayNames.removeAt(index);
+      _sourceDisplayNames.removeAt(index);
+
+      _playerCountController.text = _displayNameControllers.length.toString();
+      _refreshManualDisplayNameDefaults();
+    });
+  }
+
+  void _refreshManualDisplayNameDefaults() {
+    if (_loadedFromUrl) return;
+
+    for (var i = 0; i < _displayNameControllers.length; i++) {
+      final previousDefault = _defaultDisplayNames[i];
+      final previousSource = _sourceDisplayNames[i];
+      final currentText = _displayNameControllers[i].text.trim();
+      final nextDefault = circledNumber(i + 1);
+
+      _defaultDisplayNames[i] = nextDefault;
+      _sourceDisplayNames[i] = nextDefault;
+
+      if (currentText.isEmpty ||
+          currentText == previousDefault ||
+          currentText == previousSource) {
+        _displayNameControllers[i].text = nextDefault;
+      }
+    }
   }
 
   void _decrementCourts() =>
@@ -625,6 +654,8 @@ class _EventSetupPageState extends State<EventSetupPage> {
                         isLoadingEvent: _isLoadingEvent,
                         onReset: _resetInputs,
                         onSubmit: _submitForm,
+                        canRemovePlayer: _canRemovePlayer,
+                        onRemovePlayer: _removePlayerAt,
                       ),
                       const SizedBox(height: 80),
                     ],

--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -220,6 +220,10 @@ class _EventSetupPageState extends State<EventSetupPage> {
     setState(() {
       _playerCountController.text = clamped.toString();
       _syncDisplayNameControllers();
+
+      if (_loadedFromUrl) {
+        _refreshAutoNumberDisplayNames();
+      }
     });
   }
 
@@ -236,7 +240,12 @@ class _EventSetupPageState extends State<EventSetupPage> {
       _sourceDisplayNames.removeAt(index);
 
       _playerCountController.text = _displayNameControllers.length.toString();
-      _refreshManualDisplayNameDefaults();
+
+      if (_loadedFromUrl) {
+        _refreshAutoNumberDisplayNames();
+      } else {
+        _refreshManualDisplayNameDefaults();
+      }
     });
   }
 
@@ -256,6 +265,42 @@ class _EventSetupPageState extends State<EventSetupPage> {
           currentText == previousDefault ||
           currentText == previousSource) {
         _displayNameControllers[i].text = nextDefault;
+      }
+    }
+  }
+
+  bool _isAutoNumberDisplayName(String? value) {
+    final text = value?.trim() ?? '';
+    if (text.isEmpty) return true;
+
+    for (var i = 1; i <= _maxPlayerCountForCourts(_maxCourts); i++) {
+      if (text == circledNumber(i)) return true;
+    }
+
+    return false;
+  }
+
+  void _refreshAutoNumberDisplayNames() {
+    for (var i = 0; i < _displayNameControllers.length; i++) {
+      final expectedName = circledNumber(i + 1);
+      final currentDefault = _defaultDisplayNames[i];
+      final currentSource = _sourceDisplayNames[i];
+      final currentText = _displayNameControllers[i].text.trim();
+
+      final defaultIsAutoNumber = _isAutoNumberDisplayName(currentDefault);
+      final sourceIsAutoNumber = _isAutoNumberDisplayName(currentSource);
+      final textIsAutoNumberOrEmpty =
+          currentText.isEmpty || _isAutoNumberDisplayName(currentText);
+
+      if (!defaultIsAutoNumber || !sourceIsAutoNumber) {
+        continue;
+      }
+
+      _defaultDisplayNames[i] = expectedName;
+      _sourceDisplayNames[i] = expectedName;
+
+      if (textIsAutoNumberOrEmpty) {
+        _displayNameControllers[i].text = expectedName;
       }
     }
   }

--- a/lib/features/doubles_scheduler/presentation/widgets/event_setup_detail_section.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/event_setup_detail_section.dart
@@ -14,6 +14,8 @@ class EventSetupDetailSection extends StatelessWidget {
     required this.isLoadingEvent,
     required this.onReset,
     required this.onSubmit,
+    required this.canRemovePlayer,
+    required this.onRemovePlayer,
   });
 
   final TextEditingController eventNameController;
@@ -23,6 +25,8 @@ class EventSetupDetailSection extends StatelessWidget {
   final bool isLoadingEvent;
   final VoidCallback onReset;
   final VoidCallback onSubmit;
+  final bool canRemovePlayer;
+  final ValueChanged<int> onRemovePlayer;
 
   @override
   Widget build(BuildContext context) {
@@ -51,6 +55,8 @@ class EventSetupDetailSection extends StatelessWidget {
           focusNodes: displayNameFocusNodes,
           sourceDisplayNames: sourceDisplayNames,
           isLoadingEvent: isLoadingEvent,
+          canRemovePlayer: canRemovePlayer,
+          onRemovePlayer: onRemovePlayer,
         ),
         const SizedBox(height: 20),
         EventSetupActionButtons(

--- a/lib/features/doubles_scheduler/presentation/widgets/event_setup_display_name_grid.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/event_setup_display_name_grid.dart
@@ -32,27 +32,19 @@ class EventSetupDisplayNameGrid extends StatelessWidget {
             sourceDisplayNames[index] ?? circledNumber(index + 1);
 
         return SizedBox(
-          width: 200,
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: TextFormField(
-                  controller: controllers[index],
-                  focusNode: focusNodes[index],
-                  enabled: !isLoadingEvent,
-                  decoration: InputDecoration(
-                    labelText: l10n.playerDisplayNameInputLabel(
-                      index + 1,
-                      sourceName,
-                    ),
-                    border: const OutlineInputBorder(),
-                    isDense: true,
-                  ),
-                ),
+          width: 160,
+          child: TextFormField(
+            controller: controllers[index],
+            focusNode: focusNodes[index],
+            enabled: !isLoadingEvent,
+            decoration: InputDecoration(
+              labelText: l10n.playerDisplayNameInputLabel(
+                index + 1,
+                sourceName,
               ),
-              const SizedBox(width: 4),
-              IconButton(
+              border: const OutlineInputBorder(),
+              isDense: true,
+              suffixIcon: IconButton(
                 tooltip: canRemovePlayer
                     ? l10n.removePlayerTooltip
                     : l10n.cannotRemovePlayerTooltip,
@@ -61,8 +53,13 @@ class EventSetupDisplayNameGrid extends StatelessWidget {
                     : () => onRemovePlayer(index),
                 icon: const Icon(Icons.remove_circle_outline),
                 visualDensity: VisualDensity.compact,
+                padding: EdgeInsets.zero,
               ),
-            ],
+              suffixIconConstraints: const BoxConstraints(
+                minWidth: 36,
+                minHeight: 36,
+              ),
+            ),
           ),
         );
       }),

--- a/lib/features/doubles_scheduler/presentation/widgets/event_setup_display_name_grid.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/event_setup_display_name_grid.dart
@@ -9,12 +9,16 @@ class EventSetupDisplayNameGrid extends StatelessWidget {
     required this.focusNodes,
     required this.sourceDisplayNames,
     required this.isLoadingEvent,
+    required this.canRemovePlayer,
+    required this.onRemovePlayer,
   });
 
   final List<TextEditingController> controllers;
   final List<FocusNode> focusNodes;
   final List<String?> sourceDisplayNames;
   final bool isLoadingEvent;
+  final bool canRemovePlayer;
+  final ValueChanged<int> onRemovePlayer;
 
   @override
   Widget build(BuildContext context) {
@@ -28,19 +32,37 @@ class EventSetupDisplayNameGrid extends StatelessWidget {
             sourceDisplayNames[index] ?? circledNumber(index + 1);
 
         return SizedBox(
-          width: 140,
-          child: TextFormField(
-            controller: controllers[index],
-            focusNode: focusNodes[index],
-            enabled: !isLoadingEvent,
-            decoration: InputDecoration(
-              labelText: l10n.playerDisplayNameInputLabel(
-                index + 1,
-                sourceName,
+          width: 200,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: TextFormField(
+                  controller: controllers[index],
+                  focusNode: focusNodes[index],
+                  enabled: !isLoadingEvent,
+                  decoration: InputDecoration(
+                    labelText: l10n.playerDisplayNameInputLabel(
+                      index + 1,
+                      sourceName,
+                    ),
+                    border: const OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                ),
               ),
-              border: const OutlineInputBorder(),
-              isDense: true,
-            ),
+              const SizedBox(width: 4),
+              IconButton(
+                tooltip: canRemovePlayer
+                    ? l10n.removePlayerTooltip
+                    : l10n.cannotRemovePlayerTooltip,
+                onPressed: isLoadingEvent || !canRemovePlayer
+                    ? null
+                    : () => onRemovePlayer(index),
+                icon: const Icon(Icons.remove_circle_outline),
+                visualDensity: VisualDensity.compact,
+              ),
+            ],
           ),
         );
       }),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -323,5 +323,13 @@
         "example": "2026/05/22 23:10"
       }
     }
+  },
+  "removePlayerTooltip": "Remove this player",
+  "@removePlayerTooltip": {
+    "description": "Tooltip for removing a player input field."
+  },
+  "cannotRemovePlayerTooltip": "Cannot remove because the minimum player count has been reached.",
+  "@cannotRemovePlayerTooltip": {
+    "description": "Tooltip shown when a player input field cannot be removed because the minimum player count has been reached."
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -323,5 +323,13 @@
         "example": "2026/05/22 23:10"
       }
     }
+  },
+  "removePlayerTooltip": "この参加者を削除",
+  "@removePlayerTooltip": {
+    "description": "Tooltip for removing a player input field."
+  },
+  "cannotRemovePlayerTooltip": "最低人数のため削除できません",
+  "@cannotRemovePlayerTooltip": {
+    "description": "Tooltip shown when a player input field cannot be removed because the minimum player count has been reached."
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -493,6 +493,18 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'最終表示: {lastOpenedAt}'**
   String lastOpenedAtLabel(String lastOpenedAt);
+
+  /// Tooltip for removing a player input field.
+  ///
+  /// In ja, this message translates to:
+  /// **'この参加者を削除'**
+  String get removePlayerTooltip;
+
+  /// Tooltip shown when a player input field cannot be removed because the minimum player count has been reached.
+  ///
+  /// In ja, this message translates to:
+  /// **'最低人数のため削除できません'**
+  String get cannotRemovePlayerTooltip;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -233,4 +233,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String lastOpenedAtLabel(String lastOpenedAt) {
     return 'Last opened: $lastOpenedAt';
   }
+
+  @override
+  String get removePlayerTooltip => 'Remove this player';
+
+  @override
+  String get cannotRemovePlayerTooltip =>
+      'Cannot remove because the minimum player count has been reached.';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -226,4 +226,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String lastOpenedAtLabel(String lastOpenedAt) {
     return '最終表示: $lastOpenedAt';
   }
+
+  @override
+  String get removePlayerTooltip => 'この参加者を削除';
+
+  @override
+  String get cannotRemovePlayerTooltip => '最低人数のため削除できません';
 }


### PR DESCRIPTION
## 概要

参加者入力画面で、参加者入力欄を個別に削除できるようにしました。

Closes #57

## 変更内容

- 参加者表示名入力欄に削除ボタンを追加
- 最低参加者数を下回る場合は削除できないように制御
- 参加者削除時に controller / focus node / default display name / source display name を同期して削除
- 削除後に人数表示を現在の入力欄数へ同期
- 中間削除後も focus node が古い index を参照しないように修正
- 未入力・デフォルト表示名の場合は、削除後の表示順に合わせて自動番号を再採番
- 削除ボタンの tooltip 文言を l10n に追加

## 補足

面数変更・人数変更によって表示対象外になった参加者名の保持・復元は、今回の対象外としています。

この対応を入れると、デフォルト表示名と手入力名の扱い、再度人数を増やした場合の復元、TennisBear 取り込み後の状態管理が複雑になるため、#57 では「表示中の参加者入力欄を個別削除できること」に範囲を絞りました。

## 確認

- [x] 参加者入力欄を個別に削除できること
- [x] 削除後に後続の表示順が詰まること
- [x] 未入力・デフォルト表示名の場合、削除後の表示順に合わせて自動番号が再採番されること
- [x] 最低参加者数を下回る削除ができないこと
- [x] 削除後に人数表示が現在の入力欄数と一致すること
- [x] 削除ボタンが入力欄内に表示されること
- [x] TennisBear 取り込み後の編集でも削除できること
- [x] dart format lib/
- [x] flutter analyze
- [x] flutter test

## docs / OpenAPI 更新要否

- docs 更新: 不要
- OpenAPI 更新: 不要（core API 変更なし）