### PR TITLE
📱 feat: improve display name grid responsiveness refs #58

### DIFF
--- a/lib/features/doubles_scheduler/presentation/widgets/event_setup_display_name_grid.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/event_setup_display_name_grid.dart
@@ -20,49 +20,86 @@ class EventSetupDisplayNameGrid extends StatelessWidget {
   final bool canRemovePlayer;
   final ValueChanged<int> onRemovePlayer;
 
+  static const _horizontalPadding = 10.0;
+  static const _itemSpacing = 20.0;
+  static const _runSpacing = 12.0;
+  static const _maxItemWidth = 300.0;
+
+  int _columnCountForWidth(double width) {
+    if (width >= 720) return 4;
+    if (width >= 540) return 3;
+    if (width >= 360) return 2;
+    return 1;
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
 
-    return Wrap(
-      spacing: 12,
-      runSpacing: 12,
-      children: List.generate(controllers.length, (index) {
-        final sourceName =
-            sourceDisplayNames[index] ?? circledNumber(index + 1);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final maxWidth = constraints.maxWidth;
+        final columnCount = _columnCountForWidth(maxWidth);
+        final availableWidth = maxWidth - (_horizontalPadding * 2);
+        final itemWidth =
+            ((availableWidth - (_itemSpacing * (columnCount - 1))) /
+                    columnCount)
+                .clamp(0.0, _maxItemWidth)
+                .toDouble();
+        final gridWidth =
+            itemWidth * columnCount + _itemSpacing * (columnCount - 1);
 
-        return SizedBox(
-          width: 160,
-          child: TextFormField(
-            controller: controllers[index],
-            focusNode: focusNodes[index],
-            enabled: !isLoadingEvent,
-            decoration: InputDecoration(
-              labelText: l10n.playerDisplayNameInputLabel(
-                index + 1,
-                sourceName,
-              ),
-              border: const OutlineInputBorder(),
-              isDense: true,
-              suffixIcon: IconButton(
-                tooltip: canRemovePlayer
-                    ? l10n.removePlayerTooltip
-                    : l10n.cannotRemovePlayerTooltip,
-                onPressed: isLoadingEvent || !canRemovePlayer
-                    ? null
-                    : () => onRemovePlayer(index),
-                icon: const Icon(Icons.remove_circle_outline),
-                visualDensity: VisualDensity.compact,
-                padding: EdgeInsets.zero,
-              ),
-              suffixIconConstraints: const BoxConstraints(
-                minWidth: 36,
-                minHeight: 36,
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: _horizontalPadding),
+          child: Align(
+            alignment: Alignment.center,
+            child: SizedBox(
+              width: gridWidth,
+              child: Wrap(
+                alignment: WrapAlignment.start,
+                spacing: _itemSpacing,
+                runSpacing: _runSpacing,
+                children: List.generate(controllers.length, (index) {
+                  final sourceName =
+                      sourceDisplayNames[index] ?? circledNumber(index + 1);
+
+                  return SizedBox(
+                    width: itemWidth,
+                    child: TextFormField(
+                      controller: controllers[index],
+                      focusNode: focusNodes[index],
+                      enabled: !isLoadingEvent,
+                      decoration: InputDecoration(
+                        labelText: l10n.playerDisplayNameInputLabel(
+                          index + 1,
+                          sourceName,
+                        ),
+                        border: const OutlineInputBorder(),
+                        isDense: true,
+                        suffixIcon: IconButton(
+                          tooltip: canRemovePlayer
+                              ? l10n.removePlayerTooltip
+                              : l10n.cannotRemovePlayerTooltip,
+                          onPressed: isLoadingEvent || !canRemovePlayer
+                              ? null
+                              : () => onRemovePlayer(index),
+                          icon: const Icon(Icons.remove_circle_outline),
+                          visualDensity: VisualDensity.compact,
+                          padding: EdgeInsets.zero,
+                        ),
+                        suffixIconConstraints: const BoxConstraints(
+                          minWidth: 36,
+                          minHeight: 36,
+                        ),
+                      ),
+                    ),
+                  );
+                }),
               ),
             ),
           ),
         );
-      }),
+      },
     );
   }
 }


### PR DESCRIPTION
## 概要

参加者表示名入力欄のレスポンシブ表示を改善しました。

Closes #58

## 変更内容

- `EventSetupDisplayNameGrid` を `LayoutBuilder` ベースのレスポンシブ表示に変更
- 画面幅に応じて 1列 / 2列 / 3列 / 4列を切り替えるように調整
  - 360px 以上: 2列
  - 540px 以上: 3列
  - 720px 以上: 4列
- 列数上限を4列に固定
- 入力欄の最大幅を 300px に設定
- grid 全体は中央寄せしつつ、各行の入力欄は左寄せに調整
  - 最終行だけ中央に寄って、人数変更時に横位置が動く挙動を避けるため

## 確認内容

- Pixel 5 / iPhone SE2 相当幅で2列表示になることを確認
- iPad 10.5 相当幅で4列表示になることを確認
- PC browser 幅で最大4列表示になることを確認
- 参加者削除ボタン込みで入力欄が崩れないことを確認
- 人数変更時に入力欄の並びが不自然に横移動しないことを確認
- 入力・編集・generate 導線が壊れていないことを確認

## 実行した確認

- `dart format lib/`
- `flutter analyze`
- `flutter test`

## 補足

- 365px 未満の極小幅は今回の確認対象外
- 新規文言追加はないため、ARB / l10n の更新はなし
- docs 更新は不要