### PR TITLE
🎾 feat: add court display settings refs #59

### DIFF
--- a/lib/features/doubles_scheduler/application/event_repository.dart
+++ b/lib/features/doubles_scheduler/application/event_repository.dart
@@ -17,4 +17,9 @@ abstract class EventRepository {
     required String eventId,
     required String generatedScheduleId,
   });
+
+  Future<SavedEventAggregate> updateCourtSettings({
+    required String eventId,
+    required List<SavedEventCourtSetting> courtSettings,
+  });
 }

--- a/lib/features/doubles_scheduler/application/saved_event_aggregate_helpers.dart
+++ b/lib/features/doubles_scheduler/application/saved_event_aggregate_helpers.dart
@@ -9,5 +9,6 @@ SavedEventAggregate replaceSavedEventInAggregate(
     players: aggregate.players,
     share: aggregate.share,
     importRecord: aggregate.importRecord,
+    courtSettings: aggregate.courtSettings,
   );
 }

--- a/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
+++ b/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
@@ -18,12 +18,14 @@ class InMemoryEventRepository implements EventRepository {
   final Map<String, List<SavedEventPlayer>> _playersByEventId = {};
   final Map<String, SavedEventShare> _sharesByPublicId = {};
   final Map<String, SavedEventImport> _importsByEventId = {};
+  final Map<String, List<SavedEventCourtSetting>> _courtSettingsByEventId = {};
 
   @override
   Future<SavedEventAggregate> createFromDraft(EventDraft draft) async {
     final now = DateTime.now();
     final eventId = _uuid.v4();
     final publicId = _generateUniquePublicId();
+    final courtSettings = buildDefaultCourtSettings(draft.courts);
 
     final event = SavedEvent(
       id: eventId,
@@ -77,12 +79,14 @@ class InMemoryEventRepository implements EventRepository {
     if (importRecord != null) {
       _importsByEventId[eventId] = importRecord;
     }
+    _courtSettingsByEventId[eventId] = courtSettings;
 
     return SavedEventAggregate(
       event: event,
       players: players,
       share: share,
       importRecord: importRecord,
+      courtSettings: courtSettings,
     );
   }
 
@@ -100,6 +104,8 @@ class InMemoryEventRepository implements EventRepository {
       players: _playersByEventId[eventId] ?? const [],
       share: share,
       importRecord: _importsByEventId[eventId],
+      courtSettings: _courtSettingsByEventId[eventId] ??
+          buildDefaultCourtSettings(event.courtCount),
     );
   }
 
@@ -151,6 +157,42 @@ class InMemoryEventRepository implements EventRepository {
 
     _eventsById[eventId] = updated;
     return updated;
+  }
+
+  @override
+  Future<SavedEventAggregate> updateCourtSettings({
+    required String eventId,
+    required List<SavedEventCourtSetting> courtSettings,
+  }) async {
+    final event = _eventsById[eventId];
+    if (event == null) {
+      throw StateError('event not found: $eventId');
+    }
+
+    if (event.hasAdoptedSchedule) {
+      throw StateError('event already adopted: $eventId');
+    }
+
+    final updatedEvent = event.copyWith(
+      updatedAt: DateTime.now(),
+    );
+
+    _eventsById[eventId] = updatedEvent;
+    _courtSettingsByEventId[eventId] = List.unmodifiable(courtSettings);
+
+    final share = _sharesByPublicId[updatedEvent.publicId];
+    if (share == null) {
+      throw StateError('share not found: ${updatedEvent.publicId}');
+    }
+
+    return SavedEventAggregate(
+      event: updatedEvent,
+      players: _playersByEventId[eventId] ?? const [],
+      share: share,
+      importRecord: _importsByEventId[eventId],
+      courtSettings: _courtSettingsByEventId[eventId] ??
+          buildDefaultCourtSettings(updatedEvent.courtCount),
+    );
   }
 
   String _generateUniquePublicId() {

--- a/lib/features/doubles_scheduler/data/json_event_repository.dart
+++ b/lib/features/doubles_scheduler/data/json_event_repository.dart
@@ -73,6 +73,7 @@ class JsonEventRepository implements EventRepository {
       players: players,
       share: share,
       importRecord: importRecord,
+      courtSettings: buildDefaultCourtSettings(draft.courts),
     );
 
     await _saveAggregate(aggregate);
@@ -142,6 +143,37 @@ class JsonEventRepository implements EventRepository {
     return updatedEvent;
   }
 
+  @override
+  Future<SavedEventAggregate> updateCourtSettings({
+    required String eventId,
+    required List<SavedEventCourtSetting> courtSettings,
+  }) async {
+    final aggregate = await _findByEventId(eventId);
+    if (aggregate == null) {
+      throw StateError('event not found: $eventId');
+    }
+
+    if (aggregate.event.hasAdoptedSchedule) {
+      throw StateError('event already adopted: $eventId');
+    }
+
+    final updatedEvent = aggregate.event.copyWith(
+      updatedAt: DateTime.now(),
+    );
+
+    final updatedAggregate = SavedEventAggregate(
+      event: updatedEvent,
+      players: aggregate.players,
+      share: aggregate.share,
+      importRecord: aggregate.importRecord,
+      courtSettings: courtSettings,
+    );
+
+    await _saveAggregate(updatedAggregate);
+
+    return updatedAggregate;
+  }
+
   Future<SavedEventAggregate?> _findByEventId(String eventId) async {
     final data = await _store.findByEventId(eventId);
     if (data == null) return null;
@@ -165,6 +197,7 @@ class JsonEventRepository implements EventRepository {
       players: aggregate.players,
       share: aggregate.share,
       importRecord: aggregate.importRecord,
+      courtSettings: aggregate.courtSettings,
     );
   }
 

--- a/lib/features/doubles_scheduler/domain/saved_event_models.dart
+++ b/lib/features/doubles_scheduler/domain/saved_event_models.dart
@@ -276,12 +276,15 @@ class SavedEventAggregate {
     required this.players,
     required this.share,
     this.importRecord,
-  });
+    List<SavedEventCourtSetting>? courtSettings,
+  }) : courtSettings =
+            courtSettings ?? buildDefaultCourtSettings(event.courtCount);
 
   final SavedEvent event;
   final List<SavedEventPlayer> players;
   final SavedEventShare share;
   final SavedEventImport? importRecord;
+  final List<SavedEventCourtSetting> courtSettings;
 
   Map<String, dynamic> toJson() {
     return {
@@ -292,6 +295,9 @@ class SavedEventAggregate {
       }).toList(growable: false),
       'share': share.toJson(),
       'importRecord': importRecord?.toJson(),
+      'courtSettings': courtSettings.map((setting) {
+        return setting.toJson();
+      }).toList(growable: false),
     };
   }
 
@@ -307,6 +313,20 @@ class SavedEventAggregate {
       throw const FormatException('share is required');
     }
 
+    final event = SavedEvent.fromJson(eventJson);
+    final courtSettingsValue = json['courtSettings'];
+    final courtSettings = courtSettingsValue is List
+        ? courtSettingsValue.map((item) {
+            if (item is! Map) {
+              throw FormatException('invalid court setting item: $item');
+            }
+
+            return SavedEventCourtSetting.fromJson(
+              item.map((key, value) => MapEntry(key.toString(), value)),
+            );
+          }).toList(growable: false)
+        : buildDefaultCourtSettings(event.courtCount);
+
     // TODO(ver0.2): Remove the legacy participants fallback.
     final playersValue = json['players'] ?? json['participants'];
     if (playersValue is! List) {
@@ -316,7 +336,7 @@ class SavedEventAggregate {
     final importRecordJson = _nullableMapFromJson(json['importRecord']);
 
     return SavedEventAggregate(
-      event: SavedEvent.fromJson(eventJson),
+      event: event,
       players: playersValue.map((item) {
         if (item is! Map) {
           throw FormatException('invalid player item: $item');
@@ -330,6 +350,7 @@ class SavedEventAggregate {
       importRecord: importRecordJson == null
           ? null
           : SavedEventImport.fromJson(importRecordJson),
+      courtSettings: courtSettings,
     );
   }
 }
@@ -408,4 +429,38 @@ SavedEventStatus _savedEventStatusFromJson(Object? value) {
     (status) => status.name == value,
     orElse: () => SavedEventStatus.draft,
   );
+}
+
+class SavedEventCourtSetting {
+  SavedEventCourtSetting({
+    required this.courtNumber,
+    required this.displayLabel,
+  });
+
+  final int courtNumber;
+  final String displayLabel;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'courtNumber': courtNumber,
+      'displayLabel': displayLabel,
+    };
+  }
+
+  factory SavedEventCourtSetting.fromJson(Map<String, dynamic> json) {
+    return SavedEventCourtSetting(
+      courtNumber: _intFromJson(json['courtNumber']),
+      displayLabel: json['displayLabel']?.toString() ?? '',
+    );
+  }
+}
+
+List<SavedEventCourtSetting> buildDefaultCourtSettings(int courtCount) {
+  return List.generate(courtCount, (index) {
+    final courtNumber = index + 1;
+    return SavedEventCourtSetting(
+      courtNumber: courtNumber,
+      displayLabel: courtNumber.toString(),
+    );
+  });
 }

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -17,8 +17,9 @@ import '../domain/saved_event_models.dart';
 import '../infrastructure/generated_schedule_api_client.dart';
 import 'event_list_page.dart';
 import 'models/event_draft.dart';
-import 'widgets/schedule_action_buttons.dart';
+import 'widgets/court_display_settings_dialog.dart';
 import 'widgets/schedule_event_summary_card.dart';
+import 'widgets/schedule_operation_panel.dart';
 import 'widgets/schedule_players_card.dart';
 import 'widgets/schedule_rounds_view.dart';
 import 'widgets/schedule_section_card.dart';
@@ -111,6 +112,27 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         playerId: player.id,
       );
     }).toList(growable: false);
+  }
+
+  List<SavedEventCourtSetting> get _courtSettings {
+    return _savedEvent?.courtSettings ??
+        buildDefaultCourtSettings(_savedEvent?.courtSettings.length ??
+            _savedEvent?.event.courtCount ??
+            0);
+  }
+
+  Map<int, String> get _courtLabelByNumber {
+    return {
+      for (final setting in _courtSettings)
+        setting.courtNumber: setting.displayLabel,
+    };
+  }
+
+  String get _courtDisplaySummary {
+    final settings = _courtSettings.toList()
+      ..sort((a, b) => a.courtNumber.compareTo(b.courtNumber));
+
+    return settings.map((setting) => setting.displayLabel).join(' / ');
   }
 
   void _toggleSelectedPlayer(String playerId) {
@@ -515,6 +537,36 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     );
   }
 
+  Future<void> _changeCourtDisplay() async {
+    final savedEvent = _savedEvent;
+    if (savedEvent == null || _hasAdoptedSchedule) return;
+
+    final nextSettings = await showDialog<List<SavedEventCourtSetting>>(
+      context: context,
+      builder: (context) {
+        return CourtDisplaySettingsDialog(
+          courtCount: savedEvent.event.courtCount,
+          initialSettings: _courtSettings,
+        );
+      },
+    );
+
+    if (!mounted || nextSettings == null) return;
+
+    final updatedAggregate = await appEventRepository.updateCourtSettings(
+      eventId: savedEvent.event.id,
+      courtSettings: nextSettings,
+    );
+
+    if (!mounted) return;
+
+    setState(() {
+      _savedEvent = updatedAggregate;
+    });
+
+    await _saveScheduleHistory(updatedAggregate);
+  }
+
   void _handleMenu(_ScheduleMenuAction action) {
     switch (action) {
       case _ScheduleMenuAction.top:
@@ -609,7 +661,12 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           if (!_hasAdoptedSchedule) ...[
             const SizedBox(height: 12),
             ScheduleSectionCard(
-              child: ScheduleActionButtons(
+              child: ScheduleOperationPanel(
+                courtDisplaySummary: _courtDisplaySummary,
+                canChangeCourtDisplay:
+                    !_hasAdoptedSchedule && _savedEvent != null,
+                onChangeCourtDisplay: _changeCourtDisplay,
+                showActionButtons: !_hasAdoptedSchedule,
                 isLoading: _isLoading,
                 isAdopting: _isAdopting,
                 generateButtonLabel: _generateButtonLabel(l10n),
@@ -636,6 +693,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
                     courtCount: savedEvent.event.courtCount,
                     selectedPlayerId: _selectedPlayerId,
                     onPlayerSelected: _toggleSelectedPlayer,
+                    courtLabelByNumber: _courtLabelByNumber,
                   ),
           ),
         ],

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -658,25 +658,23 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
             selectedPlayerId: _selectedPlayerId,
             onPlayerSelected: _toggleSelectedPlayer,
           ),
-          if (!_hasAdoptedSchedule) ...[
-            const SizedBox(height: 12),
-            ScheduleSectionCard(
-              child: ScheduleOperationPanel(
-                courtDisplaySummary: _courtDisplaySummary,
-                canChangeCourtDisplay:
-                    !_hasAdoptedSchedule && _savedEvent != null,
-                onChangeCourtDisplay: _changeCourtDisplay,
-                showActionButtons: !_hasAdoptedSchedule,
-                isLoading: _isLoading,
-                isAdopting: _isAdopting,
-                generateButtonLabel: _generateButtonLabel(l10n),
-                canAdopt:
-                    _generatedScheduleId != null && _scheduleResponse != null,
-                onGenerate: _requestGenerateSchedule,
-                onAdopt: _adoptSchedule,
-              ),
+          const SizedBox(height: 12),
+          ScheduleSectionCard(
+            child: ScheduleOperationPanel(
+              courtDisplaySummary: _courtDisplaySummary,
+              canChangeCourtDisplay:
+                  !_hasAdoptedSchedule && _savedEvent != null,
+              onChangeCourtDisplay: _changeCourtDisplay,
+              showActionButtons: !_hasAdoptedSchedule,
+              isLoading: _isLoading,
+              isAdopting: _isAdopting,
+              generateButtonLabel: _generateButtonLabel(l10n),
+              canAdopt:
+                  _generatedScheduleId != null && _scheduleResponse != null,
+              onGenerate: _requestGenerateSchedule,
+              onAdopt: _adoptSchedule,
             ),
-          ],
+          ),
           const SizedBox(height: 12),
           ScheduleSectionCard(
             title: l10n.matchTableTitle,

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -523,25 +523,21 @@ class _SchedulePageState extends State<SchedulePage> {
           selectedPlayerId: _selectedPlayerId,
           onPlayerSelected: _toggleSelectedPlayer,
         ),
-        if (!_hasAdoptedSchedule) ...[
-          const SizedBox(height: 12),
-          ScheduleSectionCard(
-            child: ScheduleOperationPanel(
-              courtDisplaySummary: _courtDisplaySummary,
-              canChangeCourtDisplay:
-                  !_hasAdoptedSchedule && _savedEvent != null,
-              onChangeCourtDisplay: _changeCourtDisplay,
-              showActionButtons: !_hasAdoptedSchedule,
-              isLoading: _isLoading,
-              isAdopting: _isAdopting,
-              generateButtonLabel: _generateButtonLabel(l10n),
-              canAdopt:
-                  _generatedScheduleId != null && _scheduleResponse != null,
-              onGenerate: _requestGenerateSchedule,
-              onAdopt: _adoptSchedule,
-            ),
+        const SizedBox(height: 12),
+        ScheduleSectionCard(
+          child: ScheduleOperationPanel(
+            courtDisplaySummary: _courtDisplaySummary,
+            canChangeCourtDisplay: !_hasAdoptedSchedule && _savedEvent != null,
+            onChangeCourtDisplay: _changeCourtDisplay,
+            showActionButtons: !_hasAdoptedSchedule,
+            isLoading: _isLoading,
+            isAdopting: _isAdopting,
+            generateButtonLabel: _generateButtonLabel(l10n),
+            canAdopt: _generatedScheduleId != null && _scheduleResponse != null,
+            onGenerate: _requestGenerateSchedule,
+            onAdopt: _adoptSchedule,
           ),
-        ],
+        ),
         const SizedBox(height: 12),
         ScheduleSectionCard(
           title: l10n.matchTableTitle,

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -15,8 +15,9 @@ import '../infrastructure/generated_schedule_api_client.dart';
 import 'event_list_page.dart';
 import 'event_setup_page.dart';
 import 'models/event_draft.dart';
-import 'widgets/schedule_action_buttons.dart';
+import 'widgets/court_display_settings_dialog.dart';
 import 'widgets/schedule_event_summary_card.dart';
+import 'widgets/schedule_operation_panel.dart';
 import 'widgets/schedule_players_card.dart';
 import 'widgets/schedule_rounds_view.dart';
 import 'widgets/schedule_section_card.dart';
@@ -97,6 +98,25 @@ class _SchedulePageState extends State<SchedulePage> {
         playerId: entry.value.id,
       );
     }).toList(growable: false);
+  }
+
+  List<SavedEventCourtSetting> get _courtSettings {
+    return _savedEvent?.courtSettings ??
+        buildDefaultCourtSettings(widget.draft.courts);
+  }
+
+  Map<int, String> get _courtLabelByNumber {
+    return {
+      for (final setting in _courtSettings)
+        setting.courtNumber: setting.displayLabel,
+    };
+  }
+
+  String get _courtDisplaySummary {
+    final settings = _courtSettings.toList()
+      ..sort((a, b) => a.courtNumber.compareTo(b.courtNumber));
+
+    return settings.map((setting) => setting.displayLabel).join(' / ');
   }
 
   void _toggleSelectedPlayer(String playerId) {
@@ -426,6 +446,36 @@ class _SchedulePageState extends State<SchedulePage> {
     );
   }
 
+  Future<void> _changeCourtDisplay() async {
+    final savedEvent = _savedEvent;
+    if (savedEvent == null || _hasAdoptedSchedule) return;
+
+    final nextSettings = await showDialog<List<SavedEventCourtSetting>>(
+      context: context,
+      builder: (context) {
+        return CourtDisplaySettingsDialog(
+          courtCount: savedEvent.event.courtCount,
+          initialSettings: _courtSettings,
+        );
+      },
+    );
+
+    if (!mounted || nextSettings == null) return;
+
+    final updatedAggregate = await appEventRepository.updateCourtSettings(
+      eventId: savedEvent.event.id,
+      courtSettings: nextSettings,
+    );
+
+    if (!mounted) return;
+
+    setState(() {
+      _savedEvent = updatedAggregate;
+    });
+
+    await _saveScheduleHistory(updatedAggregate);
+  }
+
   void _handleMenu(_ScheduleMenuAction action) {
     switch (action) {
       case _ScheduleMenuAction.top:
@@ -476,7 +526,12 @@ class _SchedulePageState extends State<SchedulePage> {
         if (!_hasAdoptedSchedule) ...[
           const SizedBox(height: 12),
           ScheduleSectionCard(
-            child: ScheduleActionButtons(
+            child: ScheduleOperationPanel(
+              courtDisplaySummary: _courtDisplaySummary,
+              canChangeCourtDisplay:
+                  !_hasAdoptedSchedule && _savedEvent != null,
+              onChangeCourtDisplay: _changeCourtDisplay,
+              showActionButtons: !_hasAdoptedSchedule,
               isLoading: _isLoading,
               isAdopting: _isAdopting,
               generateButtonLabel: _generateButtonLabel(l10n),
@@ -503,6 +558,7 @@ class _SchedulePageState extends State<SchedulePage> {
                   courtCount: widget.draft.courts,
                   selectedPlayerId: _selectedPlayerId,
                   onPlayerSelected: _toggleSelectedPlayer,
+                  courtLabelByNumber: _courtLabelByNumber,
                 ),
         ),
         if (_errorMessage != null) ...[

--- a/lib/features/doubles_scheduler/presentation/widgets/court_display_settings_dialog.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/court_display_settings_dialog.dart
@@ -256,27 +256,21 @@ class _CourtDisplaySettingsDialogState
   }
 
   List<String> _leftRightPresetLabels(BuildContext context) {
-    final labels = _directionLabels(
-      context,
-      japaneseStart: '左',
-      japaneseEnd: '右',
-      englishStart: 'L',
-      englishEnd: 'R',
-    );
+    final l10n = AppLocalizations.of(context);
 
-    return _edgePresetLabels(labels.start, labels.end);
+    return _edgePresetLabels(
+      l10n.courtDisplayLabelLeft,
+      l10n.courtDisplayLabelRight,
+    );
   }
 
   List<String> _frontBackPresetLabels(BuildContext context) {
-    final labels = _directionLabels(
-      context,
-      japaneseStart: '前',
-      japaneseEnd: '奥',
-      englishStart: 'F',
-      englishEnd: 'B',
-    );
+    final l10n = AppLocalizations.of(context);
 
-    return _edgePresetLabels(labels.start, labels.end);
+    return _edgePresetLabels(
+      l10n.courtDisplayLabelFront,
+      l10n.courtDisplayLabelBack,
+    );
   }
 
   List<String> _edgePresetLabels(String start, String end) {
@@ -294,22 +288,6 @@ class _CourtDisplaySettingsDialogState
 
       return (index + 1).toString();
     });
-  }
-
-  ({String start, String end}) _directionLabels(
-    BuildContext context, {
-    required String japaneseStart,
-    required String japaneseEnd,
-    required String englishStart,
-    required String englishEnd,
-  }) {
-    final languageCode = Localizations.localeOf(context).languageCode;
-
-    if (languageCode == 'ja') {
-      return (start: japaneseStart, end: japaneseEnd);
-    }
-
-    return (start: englishStart, end: englishEnd);
   }
 
   bool _sameLabels(List<String> a, List<String> b) {

--- a/lib/features/doubles_scheduler/presentation/widgets/court_display_settings_dialog.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/court_display_settings_dialog.dart
@@ -1,0 +1,324 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
+
+import '../../domain/saved_event_models.dart';
+
+class CourtDisplaySettingsDialog extends StatefulWidget {
+  const CourtDisplaySettingsDialog({
+    super.key,
+    required this.courtCount,
+    required this.initialSettings,
+  });
+
+  final int courtCount;
+  final List<SavedEventCourtSetting> initialSettings;
+
+  @override
+  State<CourtDisplaySettingsDialog> createState() =>
+      _CourtDisplaySettingsDialogState();
+}
+
+class _CourtDisplaySettingsDialogState
+    extends State<CourtDisplaySettingsDialog> {
+  late final List<TextEditingController> _controllers;
+
+  bool _isCustomMode = false;
+  bool _didResolveInitialMode = false;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+
+    final initialLabelByCourtNumber = {
+      for (final setting in widget.initialSettings)
+        setting.courtNumber: setting.displayLabel,
+    };
+
+    _controllers = List.generate(widget.courtCount, (index) {
+      final courtNumber = index + 1;
+      final label = initialLabelByCourtNumber[courtNumber]?.trim();
+
+      return TextEditingController(
+        text: label == null || label.isEmpty ? courtNumber.toString() : label,
+      );
+    });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    if (_didResolveInitialMode) return;
+
+    final currentLabels = _currentLabels();
+
+    _isCustomMode = !_sameLabels(currentLabels, _numberPresetLabels()) &&
+        !_sameLabels(currentLabels, _letterPresetLabels()) &&
+        !_sameLabels(currentLabels, _leftRightPresetLabels(context)) &&
+        !_sameLabels(currentLabels, _frontBackPresetLabels(context));
+
+    _didResolveInitialMode = true;
+  }
+
+  @override
+  void dispose() {
+    for (final controller in _controllers) {
+      controller.dispose();
+    }
+
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return AlertDialog(
+      title: Text(l10n.displaySettingsDialogTitle),
+      content: SingleChildScrollView(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                l10n.courtDisplaySectionTitle,
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  _buildPresetChip(
+                    label: l10n.courtDisplayPresetNumbers,
+                    labels: _numberPresetLabels(),
+                  ),
+                  _buildPresetChip(
+                    label: l10n.courtDisplayPresetLetters,
+                    labels: _letterPresetLabels(),
+                  ),
+                  _buildPresetChip(
+                    label: l10n.courtDisplayPresetLeftRight,
+                    labels: _leftRightPresetLabels(context),
+                  ),
+                  _buildPresetChip(
+                    label: l10n.courtDisplayPresetFrontBack,
+                    labels: _frontBackPresetLabels(context),
+                  ),
+                  ChoiceChip(
+                    label: Text(l10n.courtDisplayPresetCustom),
+                    selected: _isCustomMode,
+                    onSelected: (_) {
+                      setState(() {
+                        _isCustomMode = true;
+                        _errorMessage = null;
+                      });
+                    },
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Wrap(
+                spacing: 12,
+                runSpacing: 12,
+                children: List.generate(widget.courtCount, (index) {
+                  final courtNumber = index + 1;
+
+                  return SizedBox(
+                    width: 96,
+                    child: TextField(
+                      controller: _controllers[index],
+                      enabled: _isCustomMode,
+                      textAlign: TextAlign.center,
+                      textInputAction: TextInputAction.next,
+                      inputFormatters: [
+                        LengthLimitingTextInputFormatter(1),
+                      ],
+                      decoration: InputDecoration(
+                        isDense: true,
+                        labelText: l10n.courtDisplayInputLabel(courtNumber),
+                        border: const OutlineInputBorder(),
+                      ),
+                      onChanged: (_) {
+                        if (_errorMessage == null) return;
+
+                        setState(() {
+                          _errorMessage = null;
+                        });
+                      },
+                    ),
+                  );
+                }),
+              ),
+              if (_errorMessage != null) ...[
+                const SizedBox(height: 12),
+                Text(
+                  _errorMessage!,
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.error,
+                    fontSize: 13,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(l10n.cancelButton),
+        ),
+        FilledButton(
+          onPressed: _submit,
+          child: Text(l10n.confirmButton),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPresetChip({
+    required String label,
+    required List<String> labels,
+  }) {
+    final isSelected = !_isCustomMode && _sameLabels(_currentLabels(), labels);
+
+    return ChoiceChip(
+      label: Text(label),
+      selected: isSelected,
+      onSelected: (_) => _applyPreset(labels),
+    );
+  }
+
+  void _applyPreset(List<String> labels) {
+    setState(() {
+      for (var index = 0; index < _controllers.length; index += 1) {
+        _controllers[index].text = labels[index];
+      }
+
+      _isCustomMode = false;
+      _errorMessage = null;
+    });
+  }
+
+  void _submit() {
+    final l10n = AppLocalizations.of(context);
+    final labels = _currentLabels();
+
+    if (labels.any((label) => label.isEmpty)) {
+      setState(() {
+        _errorMessage = l10n.courtDisplayEmptyError;
+      });
+      return;
+    }
+
+    if (labels.toSet().length != labels.length) {
+      setState(() {
+        _errorMessage = l10n.courtDisplayDuplicateError;
+      });
+      return;
+    }
+
+    final settings = List.generate(widget.courtCount, (index) {
+      return SavedEventCourtSetting(
+        courtNumber: index + 1,
+        displayLabel: labels[index],
+      );
+    });
+
+    Navigator.pop(context, settings);
+  }
+
+  List<String> _currentLabels() {
+    return _controllers.map((controller) {
+      return controller.text.trim();
+    }).toList(growable: false);
+  }
+
+  List<String> _numberPresetLabels() {
+    return List.generate(widget.courtCount, (index) {
+      return (index + 1).toString();
+    });
+  }
+
+  List<String> _letterPresetLabels() {
+    return List.generate(widget.courtCount, (index) {
+      if (index < 26) {
+        return String.fromCharCode('A'.codeUnitAt(0) + index);
+      }
+
+      return (index + 1).toString();
+    });
+  }
+
+  List<String> _leftRightPresetLabels(BuildContext context) {
+    final labels = _directionLabels(
+      context,
+      japaneseStart: '左',
+      japaneseEnd: '右',
+      englishStart: 'L',
+      englishEnd: 'R',
+    );
+
+    return _edgePresetLabels(labels.start, labels.end);
+  }
+
+  List<String> _frontBackPresetLabels(BuildContext context) {
+    final labels = _directionLabels(
+      context,
+      japaneseStart: '前',
+      japaneseEnd: '奥',
+      englishStart: 'F',
+      englishEnd: 'B',
+    );
+
+    return _edgePresetLabels(labels.start, labels.end);
+  }
+
+  List<String> _edgePresetLabels(String start, String end) {
+    if (widget.courtCount <= 1) {
+      return [start];
+    }
+
+    if (widget.courtCount == 2) {
+      return [start, end];
+    }
+
+    return List.generate(widget.courtCount, (index) {
+      if (index == 0) return start;
+      if (index == widget.courtCount - 1) return end;
+
+      return (index + 1).toString();
+    });
+  }
+
+  ({String start, String end}) _directionLabels(
+    BuildContext context, {
+    required String japaneseStart,
+    required String japaneseEnd,
+    required String englishStart,
+    required String englishEnd,
+  }) {
+    final languageCode = Localizations.localeOf(context).languageCode;
+
+    if (languageCode == 'ja') {
+      return (start: japaneseStart, end: japaneseEnd);
+    }
+
+    return (start: englishStart, end: englishEnd);
+  }
+
+  bool _sameLabels(List<String> a, List<String> b) {
+    if (a.length != b.length) return false;
+
+    for (var index = 0; index < a.length; index += 1) {
+      if (a[index] != b[index]) return false;
+    }
+
+    return true;
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_operation_panel.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_operation_panel.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
+
+import 'schedule_action_buttons.dart';
+
+class ScheduleOperationPanel extends StatelessWidget {
+  const ScheduleOperationPanel({
+    super.key,
+    required this.courtDisplaySummary,
+    required this.canChangeCourtDisplay,
+    required this.onChangeCourtDisplay,
+    required this.showActionButtons,
+    required this.isLoading,
+    required this.isAdopting,
+    required this.generateButtonLabel,
+    required this.canAdopt,
+    required this.onGenerate,
+    required this.onAdopt,
+  });
+
+  final String courtDisplaySummary;
+  final bool canChangeCourtDisplay;
+  final VoidCallback? onChangeCourtDisplay;
+
+  final bool showActionButtons;
+  final bool isLoading;
+  final bool isAdopting;
+  final String generateButtonLabel;
+  final bool canAdopt;
+  final VoidCallback? onGenerate;
+  final VoidCallback? onAdopt;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Wrap(
+          spacing: 8,
+          runSpacing: 4,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            Text(
+              l10n.courtDisplaySummary(courtDisplaySummary),
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+            if (canChangeCourtDisplay)
+              TextButton.icon(
+                onPressed: onChangeCourtDisplay,
+                icon: const Icon(Icons.tune, size: 18),
+                label: Text(l10n.changeCourtDisplayButton),
+              ),
+          ],
+        ),
+        if (showActionButtons) ...[
+          const SizedBox(height: 8),
+          ScheduleActionButtons(
+            isLoading: isLoading,
+            isAdopting: isAdopting,
+            generateButtonLabel: generateButtonLabel,
+            canAdopt: canAdopt,
+            onGenerate: onGenerate,
+            onAdopt: onAdopt,
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
@@ -11,6 +11,7 @@ class ScheduleRoundsView extends StatefulWidget {
     required this.courtCount,
     this.selectedPlayerId,
     this.onPlayerSelected,
+    required this.courtLabelByNumber,
   });
 
   final Map<String, dynamic>? scheduleResponse;
@@ -18,6 +19,7 @@ class ScheduleRoundsView extends StatefulWidget {
   final int courtCount;
   final String? selectedPlayerId;
   final ValueChanged<String>? onPlayerSelected;
+  final Map<int, String> courtLabelByNumber;
 
   @override
   State<ScheduleRoundsView> createState() => _ScheduleRoundsViewState();
@@ -155,7 +157,19 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
     Map<int, String> slotToPlayerId, {
     required bool showCourtNumber,
   }) {
-    final courtNumber = court['court_number']?.toString() ?? '-';
+    final courtNumberText = court['court_number']?.toString() ?? '-';
+    final courtNumber = int.tryParse(courtNumberText);
+    final defaultCourtLabel = courtNumber?.toString() ?? courtNumberText;
+    final configuredCourtLabel =
+        courtNumber == null ? null : widget.courtLabelByNumber[courtNumber];
+
+    final courtLabel =
+        configuredCourtLabel == null || configuredCourtLabel.trim().isEmpty
+            ? defaultCourtLabel
+            : configuredCourtLabel.trim();
+
+    final hasCustomCourtLabel = courtLabel != defaultCourtLabel;
+    final showCourtLabel = widget.courtCount >= 2 || hasCustomCourtLabel;
     final team1Slots = _asIntList(court['team1_player_slots']);
     final team2Slots = _asIntList(court['team2_player_slots']);
 
@@ -166,9 +180,9 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
         runSpacing: 4,
         crossAxisAlignment: WrapCrossAlignment.center,
         children: [
-          if (showCourtNumber)
+          if (showCourtLabel)
             Text(
-              courtNumber,
+              courtLabel,
               style: const TextStyle(
                 fontWeight: FontWeight.bold,
                 fontSize: 13,

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
@@ -121,7 +121,6 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
                     return _buildCourtRow(
                       court,
                       slotToPlayerId,
-                      showCourtNumber: widget.courtCount >= 2,
                     );
                   }),
                   if (isRestExpanded) ...[
@@ -154,9 +153,8 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
 
   Widget _buildCourtRow(
     Map<String, dynamic> court,
-    Map<int, String> slotToPlayerId, {
-    required bool showCourtNumber,
-  }) {
+    Map<int, String> slotToPlayerId,
+  ) {
     final courtNumberText = court['court_number']?.toString() ?? '-';
     final courtNumber = int.tryParse(courtNumberText);
     final defaultCourtLabel = courtNumber?.toString() ?? courtNumberText;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -395,5 +395,21 @@
   "confirmButton": "OK",
   "@confirmButton": {
     "description": "Generic confirmation button label."
+  },
+  "courtDisplayLabelLeft": "L",
+  "@courtDisplayLabelLeft": {
+    "description": "One-character court display label for left."
+  },
+  "courtDisplayLabelRight": "R",
+  "@courtDisplayLabelRight": {
+    "description": "One-character court display label for right."
+  },
+  "courtDisplayLabelFront": "F",
+  "@courtDisplayLabelFront": {
+    "description": "One-character court display label for front."
+  },
+  "courtDisplayLabelBack": "B",
+  "@courtDisplayLabelBack": {
+    "description": "One-character court display label for back."
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -331,5 +331,69 @@
   "cannotRemovePlayerTooltip": "Cannot remove because the minimum player count has been reached.",
   "@cannotRemovePlayerTooltip": {
     "description": "Tooltip shown when a player input field cannot be removed because the minimum player count has been reached."
+  },
+  "courtDisplaySummary": "Court display: {courtLabels}",
+  "@courtDisplaySummary": {
+    "description": "Summary text for current court display labels.",
+    "placeholders": {
+      "courtLabels": {
+        "type": "String",
+        "example": "A / B"
+      }
+    }
+  },
+  "changeCourtDisplayButton": "Change",
+  "@changeCourtDisplayButton": {
+    "description": "Button label for changing court display settings."
+  },
+  "displaySettingsDialogTitle": "Display settings",
+  "@displaySettingsDialogTitle": {
+    "description": "Dialog title for display settings."
+  },
+  "courtDisplaySectionTitle": "Court display",
+  "@courtDisplaySectionTitle": {
+    "description": "Section title for court display settings."
+  },
+  "courtDisplayPresetNumbers": "1 / 2",
+  "@courtDisplayPresetNumbers": {
+    "description": "Preset label for numeric court display."
+  },
+  "courtDisplayPresetLetters": "A / B",
+  "@courtDisplayPresetLetters": {
+    "description": "Preset label for alphabetic court display."
+  },
+  "courtDisplayPresetLeftRight": "Left / Right",
+  "@courtDisplayPresetLeftRight": {
+    "description": "Preset label for left-right court display."
+  },
+  "courtDisplayPresetFrontBack": "Front / Back",
+  "@courtDisplayPresetFrontBack": {
+    "description": "Preset label for front-back court display."
+  },
+  "courtDisplayPresetCustom": "Custom",
+  "@courtDisplayPresetCustom": {
+    "description": "Preset label for custom court display."
+  },
+  "courtDisplayInputLabel": "Court {courtNumber}",
+  "@courtDisplayInputLabel": {
+    "description": "Input label for each court display label.",
+    "placeholders": {
+      "courtNumber": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "courtDisplayEmptyError": "Enter a court display label.",
+  "@courtDisplayEmptyError": {
+    "description": "Validation error shown when a court display label is empty."
+  },
+  "courtDisplayDuplicateError": "Court display labels must be unique.",
+  "@courtDisplayDuplicateError": {
+    "description": "Validation error shown when court display labels are duplicated."
+  },
+  "confirmButton": "OK",
+  "@confirmButton": {
+    "description": "Generic confirmation button label."
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -331,5 +331,69 @@
   "cannotRemovePlayerTooltip": "最低人数のため削除できません",
   "@cannotRemovePlayerTooltip": {
     "description": "Tooltip shown when a player input field cannot be removed because the minimum player count has been reached."
+  },
+  "courtDisplaySummary": "コート表示: {courtLabels}",
+  "@courtDisplaySummary": {
+    "description": "Summary text for current court display labels.",
+    "placeholders": {
+      "courtLabels": {
+        "type": "String",
+        "example": "A / B"
+      }
+    }
+  },
+  "changeCourtDisplayButton": "変更",
+  "@changeCourtDisplayButton": {
+    "description": "Button label for changing court display settings."
+  },
+  "displaySettingsDialogTitle": "表示の変更",
+  "@displaySettingsDialogTitle": {
+    "description": "Dialog title for display settings."
+  },
+  "courtDisplaySectionTitle": "コート表示",
+  "@courtDisplaySectionTitle": {
+    "description": "Section title for court display settings."
+  },
+  "courtDisplayPresetNumbers": "1 / 2",
+  "@courtDisplayPresetNumbers": {
+    "description": "Preset label for numeric court display."
+  },
+  "courtDisplayPresetLetters": "A / B",
+  "@courtDisplayPresetLetters": {
+    "description": "Preset label for alphabetic court display."
+  },
+  "courtDisplayPresetLeftRight": "左 / 右",
+  "@courtDisplayPresetLeftRight": {
+    "description": "Preset label for left-right court display."
+  },
+  "courtDisplayPresetFrontBack": "前 / 奥",
+  "@courtDisplayPresetFrontBack": {
+    "description": "Preset label for front-back court display."
+  },
+  "courtDisplayPresetCustom": "任意",
+  "@courtDisplayPresetCustom": {
+    "description": "Preset label for custom court display."
+  },
+  "courtDisplayInputLabel": "コート{courtNumber}",
+  "@courtDisplayInputLabel": {
+    "description": "Input label for each court display label.",
+    "placeholders": {
+      "courtNumber": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "courtDisplayEmptyError": "コート表示を入力してください",
+  "@courtDisplayEmptyError": {
+    "description": "Validation error shown when a court display label is empty."
+  },
+  "courtDisplayDuplicateError": "コート表示が重複しています",
+  "@courtDisplayDuplicateError": {
+    "description": "Validation error shown when court display labels are duplicated."
+  },
+  "confirmButton": "決定",
+  "@confirmButton": {
+    "description": "Generic confirmation button label."
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -395,5 +395,21 @@
   "confirmButton": "決定",
   "@confirmButton": {
     "description": "Generic confirmation button label."
+  },
+  "courtDisplayLabelLeft": "左",
+  "@courtDisplayLabelLeft": {
+    "description": "One-character court display label for left."
+  },
+  "courtDisplayLabelRight": "右",
+  "@courtDisplayLabelRight": {
+    "description": "One-character court display label for right."
+  },
+  "courtDisplayLabelFront": "前",
+  "@courtDisplayLabelFront": {
+    "description": "One-character court display label for front."
+  },
+  "courtDisplayLabelBack": "奥",
+  "@courtDisplayLabelBack": {
+    "description": "One-character court display label for back."
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -583,6 +583,30 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'決定'**
   String get confirmButton;
+
+  /// One-character court display label for left.
+  ///
+  /// In ja, this message translates to:
+  /// **'左'**
+  String get courtDisplayLabelLeft;
+
+  /// One-character court display label for right.
+  ///
+  /// In ja, this message translates to:
+  /// **'右'**
+  String get courtDisplayLabelRight;
+
+  /// One-character court display label for front.
+  ///
+  /// In ja, this message translates to:
+  /// **'前'**
+  String get courtDisplayLabelFront;
+
+  /// One-character court display label for back.
+  ///
+  /// In ja, this message translates to:
+  /// **'奥'**
+  String get courtDisplayLabelBack;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -505,6 +505,84 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'最低人数のため削除できません'**
   String get cannotRemovePlayerTooltip;
+
+  /// Summary text for current court display labels.
+  ///
+  /// In ja, this message translates to:
+  /// **'コート表示: {courtLabels}'**
+  String courtDisplaySummary(String courtLabels);
+
+  /// Button label for changing court display settings.
+  ///
+  /// In ja, this message translates to:
+  /// **'変更'**
+  String get changeCourtDisplayButton;
+
+  /// Dialog title for display settings.
+  ///
+  /// In ja, this message translates to:
+  /// **'表示の変更'**
+  String get displaySettingsDialogTitle;
+
+  /// Section title for court display settings.
+  ///
+  /// In ja, this message translates to:
+  /// **'コート表示'**
+  String get courtDisplaySectionTitle;
+
+  /// Preset label for numeric court display.
+  ///
+  /// In ja, this message translates to:
+  /// **'1 / 2'**
+  String get courtDisplayPresetNumbers;
+
+  /// Preset label for alphabetic court display.
+  ///
+  /// In ja, this message translates to:
+  /// **'A / B'**
+  String get courtDisplayPresetLetters;
+
+  /// Preset label for left-right court display.
+  ///
+  /// In ja, this message translates to:
+  /// **'左 / 右'**
+  String get courtDisplayPresetLeftRight;
+
+  /// Preset label for front-back court display.
+  ///
+  /// In ja, this message translates to:
+  /// **'前 / 奥'**
+  String get courtDisplayPresetFrontBack;
+
+  /// Preset label for custom court display.
+  ///
+  /// In ja, this message translates to:
+  /// **'任意'**
+  String get courtDisplayPresetCustom;
+
+  /// Input label for each court display label.
+  ///
+  /// In ja, this message translates to:
+  /// **'コート{courtNumber}'**
+  String courtDisplayInputLabel(int courtNumber);
+
+  /// Validation error shown when a court display label is empty.
+  ///
+  /// In ja, this message translates to:
+  /// **'コート表示を入力してください'**
+  String get courtDisplayEmptyError;
+
+  /// Validation error shown when court display labels are duplicated.
+  ///
+  /// In ja, this message translates to:
+  /// **'コート表示が重複しています'**
+  String get courtDisplayDuplicateError;
+
+  /// Generic confirmation button label.
+  ///
+  /// In ja, this message translates to:
+  /// **'決定'**
+  String get confirmButton;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -284,4 +284,16 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get confirmButton => 'OK';
+
+  @override
+  String get courtDisplayLabelLeft => 'L';
+
+  @override
+  String get courtDisplayLabelRight => 'R';
+
+  @override
+  String get courtDisplayLabelFront => 'F';
+
+  @override
+  String get courtDisplayLabelBack => 'B';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -240,4 +240,48 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get cannotRemovePlayerTooltip =>
       'Cannot remove because the minimum player count has been reached.';
+
+  @override
+  String courtDisplaySummary(String courtLabels) {
+    return 'Court display: $courtLabels';
+  }
+
+  @override
+  String get changeCourtDisplayButton => 'Change';
+
+  @override
+  String get displaySettingsDialogTitle => 'Display settings';
+
+  @override
+  String get courtDisplaySectionTitle => 'Court display';
+
+  @override
+  String get courtDisplayPresetNumbers => '1 / 2';
+
+  @override
+  String get courtDisplayPresetLetters => 'A / B';
+
+  @override
+  String get courtDisplayPresetLeftRight => 'Left / Right';
+
+  @override
+  String get courtDisplayPresetFrontBack => 'Front / Back';
+
+  @override
+  String get courtDisplayPresetCustom => 'Custom';
+
+  @override
+  String courtDisplayInputLabel(int courtNumber) {
+    return 'Court $courtNumber';
+  }
+
+  @override
+  String get courtDisplayEmptyError => 'Enter a court display label.';
+
+  @override
+  String get courtDisplayDuplicateError =>
+      'Court display labels must be unique.';
+
+  @override
+  String get confirmButton => 'OK';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -232,4 +232,47 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get cannotRemovePlayerTooltip => '最低人数のため削除できません';
+
+  @override
+  String courtDisplaySummary(String courtLabels) {
+    return 'コート表示: $courtLabels';
+  }
+
+  @override
+  String get changeCourtDisplayButton => '変更';
+
+  @override
+  String get displaySettingsDialogTitle => '表示の変更';
+
+  @override
+  String get courtDisplaySectionTitle => 'コート表示';
+
+  @override
+  String get courtDisplayPresetNumbers => '1 / 2';
+
+  @override
+  String get courtDisplayPresetLetters => 'A / B';
+
+  @override
+  String get courtDisplayPresetLeftRight => '左 / 右';
+
+  @override
+  String get courtDisplayPresetFrontBack => '前 / 奥';
+
+  @override
+  String get courtDisplayPresetCustom => '任意';
+
+  @override
+  String courtDisplayInputLabel(int courtNumber) {
+    return 'コート$courtNumber';
+  }
+
+  @override
+  String get courtDisplayEmptyError => 'コート表示を入力してください';
+
+  @override
+  String get courtDisplayDuplicateError => 'コート表示が重複しています';
+
+  @override
+  String get confirmButton => '決定';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -275,4 +275,16 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get confirmButton => '決定';
+
+  @override
+  String get courtDisplayLabelLeft => '左';
+
+  @override
+  String get courtDisplayLabelRight => '右';
+
+  @override
+  String get courtDisplayLabelFront => '前';
+
+  @override
+  String get courtDisplayLabelBack => '奥';
 }

--- a/test/features/doubles_scheduler/application/event_repository_contract.dart
+++ b/test/features/doubles_scheduler/application/event_repository_contract.dart
@@ -215,5 +215,148 @@ void runEventRepositoryContractTests({
         throwsA(isA<StateError>()),
       );
     });
+
+    test('creates default court settings from draft court count', () async {
+      final repository = createRepository();
+
+      final aggregate = await repository.createFromDraft(
+        buildDraft(courts: 2),
+      );
+
+      expect(aggregate.courtSettings, hasLength(2));
+      expect(aggregate.courtSettings[0].courtNumber, 1);
+      expect(aggregate.courtSettings[0].displayLabel, '1');
+      expect(aggregate.courtSettings[1].courtNumber, 2);
+      expect(aggregate.courtSettings[1].displayLabel, '2');
+
+      final found = await repository.findByPublicId(aggregate.event.publicId);
+      expect(found, isNotNull);
+      expect(found!.courtSettings, hasLength(2));
+      expect(found.courtSettings[0].displayLabel, '1');
+      expect(found.courtSettings[1].displayLabel, '2');
+    });
+
+    test('updates and persists court settings', () async {
+      final repository = createRepository();
+
+      final created = await repository.createFromDraft(
+        buildDraft(courts: 2),
+      );
+
+      final updated = await repository.updateCourtSettings(
+        eventId: created.event.id,
+        courtSettings: [
+          SavedEventCourtSetting(
+            courtNumber: 1,
+            displayLabel: 'A',
+          ),
+          SavedEventCourtSetting(
+            courtNumber: 2,
+            displayLabel: 'B',
+          ),
+        ],
+      );
+
+      expect(updated.courtSettings, hasLength(2));
+      expect(updated.courtSettings[0].courtNumber, 1);
+      expect(updated.courtSettings[0].displayLabel, 'A');
+      expect(updated.courtSettings[1].courtNumber, 2);
+      expect(updated.courtSettings[1].displayLabel, 'B');
+
+      final found = await repository.findByPublicId(created.event.publicId);
+      expect(found, isNotNull);
+      expect(found!.courtSettings, hasLength(2));
+      expect(found.courtSettings[0].displayLabel, 'A');
+      expect(found.courtSettings[1].displayLabel, 'B');
+    });
+
+    test('keeps court settings when schedule ids are updated', () async {
+      final repository = createRepository();
+
+      final created = await repository.createFromDraft(
+        buildDraft(courts: 2),
+      );
+
+      await repository.updateCourtSettings(
+        eventId: created.event.id,
+        courtSettings: [
+          SavedEventCourtSetting(
+            courtNumber: 1,
+            displayLabel: '前',
+          ),
+          SavedEventCourtSetting(
+            courtNumber: 2,
+            displayLabel: '奥',
+          ),
+        ],
+      );
+
+      await repository.updateCurrentGeneratedScheduleId(
+        eventId: created.event.id,
+        generatedScheduleId: 'generated-1',
+      );
+
+      final generated = await repository.findByPublicId(created.event.publicId);
+      expect(generated, isNotNull);
+      expect(generated!.courtSettings[0].displayLabel, '前');
+      expect(generated.courtSettings[1].displayLabel, '奥');
+
+      await repository.updateAdoptedGeneratedScheduleId(
+        eventId: created.event.id,
+        generatedScheduleId: 'generated-1',
+      );
+
+      final adopted = await repository.findByPublicId(created.event.publicId);
+      expect(adopted, isNotNull);
+      expect(adopted!.courtSettings[0].displayLabel, '前');
+      expect(adopted.courtSettings[1].displayLabel, '奥');
+    });
+
+    test('throws when updating court settings for adopted event', () async {
+      final repository = createRepository();
+
+      final created = await repository.createFromDraft(
+        buildDraft(courts: 2),
+      );
+
+      await repository.updateAdoptedGeneratedScheduleId(
+        eventId: created.event.id,
+        generatedScheduleId: 'generated-1',
+      );
+
+      expect(
+        () => repository.updateCourtSettings(
+          eventId: created.event.id,
+          courtSettings: [
+            SavedEventCourtSetting(
+              courtNumber: 1,
+              displayLabel: 'A',
+            ),
+            SavedEventCourtSetting(
+              courtNumber: 2,
+              displayLabel: 'B',
+            ),
+          ],
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('throws when updating court settings for missing event', () async {
+      final repository = createRepository();
+
+      expect(
+        () => repository.updateCourtSettings(
+          eventId: 'missing-event',
+          courtSettings: [
+            SavedEventCourtSetting(
+              courtNumber: 1,
+              displayLabel: 'A',
+            ),
+          ],
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
   });
 }


### PR DESCRIPTION
## 概要

コート表示名を web 側で設定・保存・表示できるようにしました。

これまで対戦表では core の `court_number` をそのまま表示していましたが、今回から web 側で `court_number` ごとの表示ラベルを保持し、`1 / 2`、`A / B`、`左 / 右`、`前 / 奥`、任意1文字の表示に変更できるようにしています。

Closes #59

## 変更内容

- `SavedEventAggregate` にコート表示設定 `courtSettings` を追加
- `court_number` ごとの `displayLabel` を保存・復元できるようにした
- `EventRepository` に `updateCourtSettings` を追加
- `JsonEventRepository` / `InMemoryEventRepository` でコート表示設定の保存・更新に対応
- generated / adopted schedule id 更新時にも `courtSettings` を保持するようにした
- 対戦表の操作エリアに `コート表示: 1 / 2 [変更]` を追加
- 採用前はコート表示を変更可能、採用後は設定サマリのみ表示して変更不可にした
- コート表示変更ダイアログを追加
  - `1 / 2`
  - `A / B`
  - `左 / 右`
  - `前 / 奥`
  - 任意1文字
- 対戦表表示で `court_number` ではなく、web 側の表示ラベルを使うようにした
- 1面では標準 `1` の場合はコートラベルを非表示、任意ラベルの場合は表示
- 2面ではコートラベルを常に表示
- コート表示関連文言を ja / en の l10n に追加
- repository contract test にコート表示設定の保存・保持・採用後変更不可のテストを追加

## 確認内容

- 1面 / 2面で画面表示を確認
- コート表示の変更ダイアログを確認
- `1 / 2`、`A / B`、`左 / 右`、`前 / 奥`、任意入力を確認
- 採用後に設定サマリが残り、変更ボタンが出ないことを確認
- 共有URL reopening / reload 復元でコート表示が保持されることを確認

## 実行確認

- [x] dart format lib/ test/
- [x] flutter analyze
- [x] flutter test

## 補足

対戦表画面のレスポンシブ表示調整は #75 で扱うため、本PRではコート表示設定の入力・保存・復元・表示反映に範囲を絞っています。