### PR TITLE
📱 improve schedule rounds responsive layout refs #75

### DIFF
--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
@@ -26,6 +26,9 @@ class ScheduleRoundsView extends StatefulWidget {
 }
 
 class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
+  static const _courtAreaSpacing = 24.0;
+  static const _courtMatchCardWidth = 300.0;
+
   final Set<String> _expandedRestRoundNumbers = {};
 
   @override
@@ -54,7 +57,6 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
     Map<String, dynamic> round,
     Map<int, String> slotToPlayerId,
   ) {
-    final l10n = AppLocalizations.of(context);
     final roundNumber = round['round_number']?.toString() ?? '-';
     final roundNumberValue = int.tryParse(roundNumber);
     final isEvenRound = roundNumberValue != null && roundNumberValue.isEven;
@@ -117,29 +119,15 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  ...courts.map((court) {
-                    return _buildCourtRow(
-                      court,
-                      slotToPlayerId,
-                    );
-                  }),
+                  _buildCourtArea(
+                    courts: courts,
+                    slotToPlayerId: slotToPlayerId,
+                  ),
                   if (isRestExpanded) ...[
                     const Divider(),
-                    Wrap(
-                      spacing: 6,
-                      runSpacing: 6,
-                      crossAxisAlignment: WrapCrossAlignment.center,
-                      children: [
-                        Text('${l10n.restLabel}:'),
-                        ...restSlotNumbers.map((slotNumber) {
-                          return _buildPlayerChip(
-                            slotNumber: slotNumber,
-                            slotToPlayerId: slotToPlayerId,
-                            size: SchedulePlayerChipSize.compact,
-                            highlightEnabled: false,
-                          );
-                        }),
-                      ],
+                    _buildRestPlayersRow(
+                      restSlotNumbers: restSlotNumbers,
+                      slotToPlayerId: slotToPlayerId,
                     ),
                   ],
                 ],
@@ -151,10 +139,107 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
     );
   }
 
-  Widget _buildCourtRow(
+  Widget _buildCourtArea({
+    required List<Map<String, dynamic>> courts,
+    required Map<int, String> slotToPlayerId,
+  }) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final maxWidth = constraints.maxWidth;
+        final courtItemWidth =
+            _courtMatchCardWidth.clamp(0.0, maxWidth).toDouble();
+        final canUseTwoColumns = courts.length >= 2 &&
+            maxWidth >= (_courtMatchCardWidth * 2 + _courtAreaSpacing);
+
+        if (courts.length == 1) {
+          return SizedBox(
+            width: maxWidth,
+            child: _buildCourtMatchCard(
+              courts.first,
+              slotToPlayerId,
+              alignment: Alignment.center,
+            ),
+          );
+        }
+
+        if (courts.length == 2 && canUseTwoColumns) {
+          final groupWidth = _courtMatchCardWidth * 2 + _courtAreaSpacing;
+
+          return Align(
+            alignment: Alignment.center,
+            child: SizedBox(
+              width: groupWidth,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SizedBox(
+                    width: _courtMatchCardWidth,
+                    child: _buildCourtMatchCard(
+                      courts[0],
+                      slotToPlayerId,
+                      alignment: Alignment.centerLeft,
+                    ),
+                  ),
+                  const SizedBox(width: _courtAreaSpacing),
+                  SizedBox(
+                    width: _courtMatchCardWidth,
+                    child: _buildCourtMatchCard(
+                      courts[1],
+                      slotToPlayerId,
+                      alignment: Alignment.centerLeft,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        if (courts.length == 2) {
+          return Column(
+            children: courts.map((court) {
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: SizedBox(
+                  width: maxWidth,
+                  child: _buildCourtMatchCard(
+                    court,
+                    slotToPlayerId,
+                    alignment: Alignment.center,
+                  ),
+                ),
+              );
+            }).toList(growable: false),
+          );
+        }
+
+        final itemWidth =
+            canUseTwoColumns ? _courtMatchCardWidth : courtItemWidth;
+
+        return Wrap(
+          alignment: WrapAlignment.start,
+          spacing: _courtAreaSpacing,
+          runSpacing: 8,
+          children: courts.map((court) {
+            return SizedBox(
+              width: itemWidth,
+              child: _buildCourtMatchCard(
+                court,
+                slotToPlayerId,
+                alignment: Alignment.centerLeft,
+              ),
+            );
+          }).toList(growable: false),
+        );
+      },
+    );
+  }
+
+  Widget _buildCourtMatchCard(
     Map<String, dynamic> court,
-    Map<int, String> slotToPlayerId,
-  ) {
+    Map<int, String> slotToPlayerId, {
+    Alignment alignment = Alignment.centerLeft,
+  }) {
     final courtNumberText = court['court_number']?.toString() ?? '-';
     final courtNumber = int.tryParse(courtNumberText);
     final defaultCourtLabel = courtNumber?.toString() ?? courtNumberText;
@@ -171,25 +256,94 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
     final team1Slots = _asIntList(court['team1_player_slots']);
     final team2Slots = _asIntList(court['team2_player_slots']);
 
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
-      child: Wrap(
-        spacing: 4,
-        runSpacing: 4,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: [
-          if (showCourtLabel)
-            Text(
-              courtLabel,
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 13,
-              ),
+    return _buildHorizontalScrollableContent(
+      alignment: alignment,
+      child: _buildCourtMatchContent(
+        courtLabel: courtLabel,
+        showCourtLabel: showCourtLabel,
+        team1Slots: team1Slots,
+        team2Slots: team2Slots,
+        slotToPlayerId: slotToPlayerId,
+      ),
+    );
+  }
+
+  Widget _buildHorizontalScrollableContent({
+    required Widget child,
+    required Alignment alignment,
+  }) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minWidth: constraints.maxWidth),
+            child: Align(
+              alignment: alignment,
+              child: child,
             ),
-          _buildTeamGroup(team1Slots, slotToPlayerId),
-          const Text('vs'),
-          _buildTeamGroup(team2Slots, slotToPlayerId),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildCourtMatchContent({
+    required String courtLabel,
+    required bool showCourtLabel,
+    required List<int> team1Slots,
+    required List<int> team2Slots,
+    required Map<int, String> slotToPlayerId,
+  }) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        if (showCourtLabel) ...[
+          Text(
+            courtLabel,
+            style: const TextStyle(
+              fontWeight: FontWeight.bold,
+              fontSize: 13,
+            ),
+          ),
+          const SizedBox(width: 8),
         ],
+        _buildTeamGroup(team1Slots, slotToPlayerId),
+        const SizedBox(width: 6),
+        const Text('vs'),
+        const SizedBox(width: 6),
+        _buildTeamGroup(team2Slots, slotToPlayerId),
+      ],
+    );
+  }
+
+  Widget _buildRestPlayersRow({
+    required List<int> restSlotNumbers,
+    required Map<int, String> slotToPlayerId,
+  }) {
+    final l10n = AppLocalizations.of(context);
+
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('${l10n.restLabel}:'),
+            const SizedBox(width: 6),
+            for (final slotNumber in restSlotNumbers) ...[
+              _buildPlayerChip(
+                slotNumber: slotNumber,
+                slotToPlayerId: slotToPlayerId,
+                size: SchedulePlayerChipSize.compact,
+                highlightEnabled: false,
+              ),
+              const SizedBox(width: 6),
+            ],
+          ],
+        ),
       ),
     );
   }
@@ -218,11 +372,15 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
       return const Text('-');
     }
 
-    return Wrap(
-      spacing: 6,
-      runSpacing: 6,
-      crossAxisAlignment: WrapCrossAlignment.center,
-      children: _buildTeamChips(slotNumbers, slotToPlayerId),
+    final chips = _buildTeamChips(slotNumbers, slotToPlayerId);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (var i = 0; i < chips.length; i++) ...[
+          if (i > 0) const SizedBox(width: 6),
+          chips[i],
+        ],
+      ],
     );
   }
 


### PR DESCRIPTION
## 概要

対戦表画面のラウンド表示をレスポンシブ表示に対応しました。

`ScheduleRoundsView` 周辺のレイアウトを整理し、スマホ幅で `チームA vs チームB` が不自然に改行されにくいようにしました。

Closes #75

## 変更内容

- `ScheduleRoundsView` のコート表示部分を `_buildCourtArea` / `_buildCourtMatchCard` / `_buildCourtMatchContent` に分割
- `チームA vs チームB` を固定グループ化し、途中改行されにくい表示に変更
- 1面時は試合表示エリアを中央寄せ
- 2面時は、幅が足りる場合に2面分を横並び表示
- 2面時に横並びできない幅では、各コート表示を縦並び・中央寄せ
- 極小幅では横スクロールで逃がせるように調整
- 展開時の休憩一覧を左寄せ・横並び・横スクロール対応に変更
- #59 で追加したコート表示ラベルの表示方針を維持
  - 1面標準ラベル `1` は非表示
  - 1面カスタムラベルは表示
  - 2面ではコートラベルを常に表示

## 確認内容

- 1面 / 標準ラベル `1`
  - コートラベルが非表示になること
  - 試合表示が中央寄せされること
- 1面 / カスタムラベル
  - コートラベルが表示されること
  - 試合表示が中央寄せされること
- 2面 / 横幅あり
  - 2面分のコート表示が横並びになること
  - 横並び全体が自然に中央寄せされること
- 2面 / 横幅不足
  - コート表示が縦並びになること
  - 各コート表示が中央寄せされること
- コート表示ラベル
  - `1 / 2`
  - `A / B`
  - `左 / 右`
  - `前 / 奥`
- 休憩一覧
  - 左寄せで表示されること
  - 折り返さず、横スクロールで確認できること
- 365px 未満相当の極小幅
  - 今回の確認対象外
  - ただし、対戦表示部分は横スクロールで逃がせることを確認

## やらないこと

- core API の変更
- 対戦表生成ロジックの変更
- コート表示名 / コート位置の入力・保持
- プレイヤーチップのサイズ・角丸・フォント調整
- 3面以上の本格対応
- 印刷 / PDF / 画像出力
- drag & drop 並び替え

## 補足

3面以上は今回の表示確認対象外です。

ただし、コード上は最大2列で並べる構造にしており、3面以上でも最低限破綻しにくい形にしています。

プレイヤーチップの縦長化・角丸・表示名フォント調整は、#75 には含めず、ver0.2 の別 Issue 候補として扱います。

## テスト

- [x] `dart format lib/`
- [x] `flutter analyze`
- [x] `flutter test`

## docs / OpenAPI

- docs 更新なし
- OpenAPI 更新なし