### PR TITLE
✨ feat: show share URL QR code refs #60

### DIFF
--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -23,6 +23,7 @@ import 'widgets/schedule_operation_panel.dart';
 import 'widgets/schedule_players_card.dart';
 import 'widgets/schedule_rounds_view.dart';
 import 'widgets/schedule_section_card.dart';
+import 'widgets/schedule_share_dialog.dart';
 
 class RestoredSchedulePage extends StatefulWidget {
   const RestoredSchedulePage({
@@ -619,6 +620,18 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     _showMessage(l10n.shareUrlCopiedMessage);
   }
 
+  void _showShareDialog() {
+    showDialog<void>(
+      context: context,
+      builder: (_) {
+        return ScheduleShareDialog(
+          shareUrl: _buildShareUrl(),
+          onCopyShareUrl: _copyShareUrl,
+        );
+      },
+    );
+  }
+
   void _showMessage(String message) {
     final messenger = ScaffoldMessenger.of(context);
     messenger.hideCurrentSnackBar();
@@ -644,7 +657,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           )
         else ...[
           ScheduleEventSummaryCard(
-            onCopyShareUrl: _copyShareUrl,
+            onShareUrl: _showShareDialog,
             onRefresh: _reloadSchedule,
             canRefresh: _generatedScheduleId != null,
           ),

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -21,6 +21,7 @@ import 'widgets/schedule_operation_panel.dart';
 import 'widgets/schedule_players_card.dart';
 import 'widgets/schedule_rounds_view.dart';
 import 'widgets/schedule_section_card.dart';
+import 'widgets/schedule_share_dialog.dart';
 
 class SchedulePage extends StatefulWidget {
   const SchedulePage({super.key, required this.draft});
@@ -232,6 +233,26 @@ class _SchedulePageState extends State<SchedulePage> {
 
     await Clipboard.setData(ClipboardData(text: shareUrl));
     _showMessage(l10n.shareUrlCopiedMessage);
+  }
+
+  void _showShareDialog() {
+    final l10n = AppLocalizations.of(context);
+    final shareUrl = _buildShareUrl();
+
+    if (shareUrl == null) {
+      _showMessage(l10n.shareUrlCreateFailedMessage);
+      return;
+    }
+
+    showDialog<void>(
+      context: context,
+      builder: (_) {
+        return ScheduleShareDialog(
+          shareUrl: shareUrl,
+          onCopyShareUrl: _copyShareUrl,
+        );
+      },
+    );
   }
 
   void _showMessage(String message) {
@@ -509,7 +530,7 @@ class _SchedulePageState extends State<SchedulePage> {
       padding: const EdgeInsets.all(4),
       children: [
         ScheduleEventSummaryCard(
-          onCopyShareUrl: _savedEvent == null ? null : _copyShareUrl,
+          onShareUrl: _savedEvent == null ? null : _showShareDialog,
           onRefresh: _reloadSchedule,
           canRefresh: _generatedScheduleId != null,
         ),

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -1,38 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
 
-import 'schedule_share_dialog.dart';
-
 class ScheduleEventSummaryCard extends StatelessWidget {
   const ScheduleEventSummaryCard({
     super.key,
     this.onShareUrl,
-    this.onCopyShareUrl,
     this.onRefresh,
     this.canRefresh = true,
   });
 
   final VoidCallback? onShareUrl;
-  final VoidCallback? onCopyShareUrl;
   final VoidCallback? onRefresh;
   final bool canRefresh;
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final shareAction = onShareUrl ??
-        (onCopyShareUrl == null
-            ? null
-            : () {
-                showDialog<void>(
-                  context: context,
-                  builder: (_) {
-                    return ScheduleShareDialog(
-                      onCopyShareUrl: onCopyShareUrl!,
-                    );
-                  },
-                );
-              });
 
     return Card(
       child: Padding(
@@ -45,9 +28,9 @@ class ScheduleEventSummaryCard extends StatelessWidget {
               runSpacing: 4,
               crossAxisAlignment: WrapCrossAlignment.center,
               children: [
-                if (shareAction != null)
+                if (onShareUrl != null)
                   OutlinedButton.icon(
-                    onPressed: shareAction,
+                    onPressed: onShareUrl,
                     icon: const Icon(Icons.share),
                     label: const Text('URLを共有'),
                   ),

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -32,7 +32,7 @@ class ScheduleEventSummaryCard extends StatelessWidget {
                   OutlinedButton.icon(
                     onPressed: onShareUrl,
                     icon: const Icon(Icons.share),
-                    label: const Text('URLを共有'),
+                    label: Text(l10n.shareUrlButton),
                   ),
                 if (onRefresh != null)
                   FilledButton.tonalIcon(

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -4,12 +4,12 @@ import 'package:srp_lanske/l10n/l10n.dart';
 class ScheduleEventSummaryCard extends StatelessWidget {
   const ScheduleEventSummaryCard({
     super.key,
-    this.onCopyShareUrl,
+    this.onShareUrl,
     this.onRefresh,
     this.canRefresh = true,
   });
 
-  final VoidCallback? onCopyShareUrl;
+  final VoidCallback? onShareUrl;
   final VoidCallback? onRefresh;
   final bool canRefresh;
 
@@ -28,11 +28,11 @@ class ScheduleEventSummaryCard extends StatelessWidget {
               runSpacing: 4,
               crossAxisAlignment: WrapCrossAlignment.center,
               children: [
-                if (onCopyShareUrl != null)
+                if (onShareUrl != null)
                   OutlinedButton.icon(
-                    onPressed: onCopyShareUrl,
-                    icon: const Icon(Icons.copy),
-                    label: Text(l10n.copyUrlButton),
+                    onPressed: onShareUrl,
+                    icon: const Icon(Icons.share),
+                    label: Text(l10n.shareUrlButton),
                   ),
                 if (onRefresh != null)
                   FilledButton.tonalIcon(

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -49,7 +49,7 @@ class ScheduleEventSummaryCard extends StatelessWidget {
                   OutlinedButton.icon(
                     onPressed: shareAction,
                     icon: const Icon(Icons.share),
-                    label: Text(l10n.shareUrlButton),
+                    label: const Text('URLを共有'),
                   ),
                 if (onRefresh != null)
                   FilledButton.tonalIcon(

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -5,17 +5,20 @@ class ScheduleEventSummaryCard extends StatelessWidget {
   const ScheduleEventSummaryCard({
     super.key,
     this.onShareUrl,
+    this.onCopyShareUrl,
     this.onRefresh,
     this.canRefresh = true,
   });
 
   final VoidCallback? onShareUrl;
+  final VoidCallback? onCopyShareUrl;
   final VoidCallback? onRefresh;
   final bool canRefresh;
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final shareAction = onShareUrl ?? onCopyShareUrl;
 
     return Card(
       child: Padding(
@@ -28,9 +31,9 @@ class ScheduleEventSummaryCard extends StatelessWidget {
               runSpacing: 4,
               crossAxisAlignment: WrapCrossAlignment.center,
               children: [
-                if (onShareUrl != null)
+                if (shareAction != null)
                   OutlinedButton.icon(
-                    onPressed: onShareUrl,
+                    onPressed: shareAction,
                     icon: const Icon(Icons.share),
                     label: Text(l10n.shareUrlButton),
                   ),

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
 
+import 'schedule_share_dialog.dart';
+
 class ScheduleEventSummaryCard extends StatelessWidget {
   const ScheduleEventSummaryCard({
     super.key,
@@ -18,7 +20,19 @@ class ScheduleEventSummaryCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final shareAction = onShareUrl ?? onCopyShareUrl;
+    final shareAction = onShareUrl ??
+        (onCopyShareUrl == null
+            ? null
+            : () {
+                showDialog<void>(
+                  context: context,
+                  builder: (_) {
+                    return ScheduleShareDialog(
+                      onCopyShareUrl: onCopyShareUrl!,
+                    );
+                  },
+                );
+              });
 
     return Card(
       child: Padding(

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_share_dialog.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_share_dialog.dart
@@ -14,13 +14,19 @@ class ScheduleShareDialog extends StatelessWidget {
     final l10n = AppLocalizations.of(context);
 
     return AlertDialog(
-      titlePadding: const EdgeInsets.fromLTRB(24, 20, 12, 0),
+      titlePadding: const EdgeInsets.fromLTRB(24, 16, 8, 0),
       title: Row(
         children: [
           const Expanded(child: Text('URLを共有')),
           IconButton(
             tooltip: '閉じる',
             onPressed: () => Navigator.pop(context),
+            iconSize: 36,
+            constraints: const BoxConstraints.tightFor(
+              width: 56,
+              height: 56,
+            ),
+            padding: EdgeInsets.zero,
             icon: const Icon(Icons.cancel_presentation),
           ),
         ],

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_share_dialog.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_share_dialog.dart
@@ -20,9 +20,9 @@ class ScheduleShareDialog extends StatelessWidget {
       titlePadding: const EdgeInsets.fromLTRB(24, 16, 8, 0),
       title: Row(
         children: [
-          const Expanded(child: Text('URLを共有')),
+          Expanded(child: Text(l10n.shareUrlButton)),
           IconButton(
-            tooltip: '閉じる',
+            tooltip: l10n.closeButton,
             onPressed: () => Navigator.pop(context),
             iconSize: 36,
             constraints: const BoxConstraints.tightFor(

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_share_dialog.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_share_dialog.dart
@@ -4,11 +4,9 @@ import 'package:srp_lanske/l10n/l10n.dart';
 class ScheduleShareDialog extends StatelessWidget {
   const ScheduleShareDialog({
     super.key,
-    required this.shareUrl,
     required this.onCopyShareUrl,
   });
 
-  final String shareUrl;
   final VoidCallback onCopyShareUrl;
 
   @override
@@ -16,15 +14,15 @@ class ScheduleShareDialog extends StatelessWidget {
     final l10n = AppLocalizations.of(context);
 
     return AlertDialog(
-      title: Text(l10n.shareUrlDialogTitle),
+      title: const Text('URLを共有'),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          ScheduleShareQrPlaceholder(shareUrl: shareUrl),
+          const ScheduleShareQrPlaceholder(),
           const SizedBox(height: 12),
           Text(
-            l10n.shareQrDescription,
+            l10n.shareUrlDescription,
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.bodySmall,
           ),
@@ -42,7 +40,7 @@ class ScheduleShareDialog extends StatelessWidget {
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),
-          child: Text(l10n.closeButton),
+          child: const Text('閉じる'),
         ),
       ],
     );
@@ -50,20 +48,14 @@ class ScheduleShareDialog extends StatelessWidget {
 }
 
 class ScheduleShareQrPlaceholder extends StatelessWidget {
-  const ScheduleShareQrPlaceholder({
-    super.key,
-    required this.shareUrl,
-  });
-
-  final String shareUrl;
+  const ScheduleShareQrPlaceholder({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
     final colorScheme = Theme.of(context).colorScheme;
 
     return Semantics(
-      label: l10n.shareQrPlaceholderSemanticLabel,
+      label: 'QRコード表示枠',
       child: Container(
         width: 220,
         height: 220,
@@ -84,7 +76,7 @@ class ScheduleShareQrPlaceholder extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
               child: Text(
-                l10n.shareQrPlaceholderLabel,
+                'QRコードをここに表示します',
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                       color: colorScheme.onSurfaceVariant,

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_share_dialog.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_share_dialog.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:pretty_qr_code/pretty_qr_code.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
 
 class ScheduleShareDialog extends StatelessWidget {
   const ScheduleShareDialog({
     super.key,
+    required this.shareUrl,
     required this.onCopyShareUrl,
   });
 
+  final String shareUrl;
   final VoidCallback onCopyShareUrl;
 
   @override
@@ -35,7 +38,7 @@ class ScheduleShareDialog extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          const ScheduleShareQrPlaceholder(),
+          ScheduleShareQrCode(data: shareUrl),
           const SizedBox(height: 12),
           SizedBox(
             width: double.infinity,
@@ -51,44 +54,54 @@ class ScheduleShareDialog extends StatelessWidget {
   }
 }
 
-class ScheduleShareQrPlaceholder extends StatelessWidget {
-  const ScheduleShareQrPlaceholder({super.key});
+class ScheduleShareQrCode extends StatefulWidget {
+  const ScheduleShareQrCode({
+    super.key,
+    required this.data,
+  });
+
+  final String data;
+
+  @override
+  State<ScheduleShareQrCode> createState() => _ScheduleShareQrCodeState();
+}
+
+class _ScheduleShareQrCodeState extends State<ScheduleShareQrCode> {
+  late QrImage _qrImage;
+
+  @override
+  void initState() {
+    super.initState();
+    _qrImage = _buildQrImage(widget.data);
+  }
+
+  @override
+  void didUpdateWidget(ScheduleShareQrCode oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.data != widget.data) {
+      _qrImage = _buildQrImage(widget.data);
+    }
+  }
+
+  QrImage _buildQrImage(String data) {
+    final qrCode = QrCode.fromData(
+      data: data,
+      errorCorrectLevel: QrErrorCorrectLevel.H,
+    );
+
+    return QrImage(qrCode);
+  }
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Semantics(
-      label: 'QRコード表示枠',
-      child: Container(
-        width: 220,
-        height: 220,
-        decoration: BoxDecoration(
-          color: colorScheme.surfaceContainerHighest,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: colorScheme.outlineVariant),
-        ),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.qr_code_2,
-              size: 80,
-              color: colorScheme.onSurfaceVariant,
-            ),
-            const SizedBox(height: 12),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Text(
-                'QRコードをここに表示します',
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: colorScheme.onSurfaceVariant,
-                      fontWeight: FontWeight.w600,
-                    ),
-              ),
-            ),
-          ],
+    return SizedBox(
+      width: 220,
+      height: 220,
+      child: PrettyQrView(
+        qrImage: _qrImage,
+        decoration: const PrettyQrDecoration(
+          quietZone: PrettyQrQuietZone.standard,
         ),
       ),
     );

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_share_dialog.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_share_dialog.dart
@@ -14,18 +14,22 @@ class ScheduleShareDialog extends StatelessWidget {
     final l10n = AppLocalizations.of(context);
 
     return AlertDialog(
-      title: const Text('URLを共有'),
+      titlePadding: const EdgeInsets.fromLTRB(24, 20, 12, 0),
+      title: Row(
+        children: [
+          const Expanded(child: Text('URLを共有')),
+          IconButton(
+            tooltip: '閉じる',
+            onPressed: () => Navigator.pop(context),
+            icon: const Icon(Icons.cancel_presentation),
+          ),
+        ],
+      ),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           const ScheduleShareQrPlaceholder(),
-          const SizedBox(height: 12),
-          Text(
-            l10n.shareUrlDescription,
-            textAlign: TextAlign.center,
-            style: Theme.of(context).textTheme.bodySmall,
-          ),
           const SizedBox(height: 12),
           SizedBox(
             width: double.infinity,
@@ -37,12 +41,6 @@ class ScheduleShareDialog extends StatelessWidget {
           ),
         ],
       ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: const Text('閉じる'),
-        ),
-      ],
     );
   }
 }

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_share_dialog.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_share_dialog.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
+
+class ScheduleShareDialog extends StatelessWidget {
+  const ScheduleShareDialog({
+    super.key,
+    required this.shareUrl,
+    required this.onCopyShareUrl,
+  });
+
+  final String shareUrl;
+  final VoidCallback onCopyShareUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return AlertDialog(
+      title: Text(l10n.shareUrlDialogTitle),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          ScheduleShareQrPlaceholder(shareUrl: shareUrl),
+          const SizedBox(height: 12),
+          Text(
+            l10n.shareQrDescription,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: 12),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton.icon(
+              onPressed: onCopyShareUrl,
+              icon: const Icon(Icons.copy),
+              label: Text(l10n.copyUrlButton),
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(l10n.closeButton),
+        ),
+      ],
+    );
+  }
+}
+
+class ScheduleShareQrPlaceholder extends StatelessWidget {
+  const ScheduleShareQrPlaceholder({
+    super.key,
+    required this.shareUrl,
+  });
+
+  final String shareUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Semantics(
+      label: l10n.shareQrPlaceholderSemanticLabel,
+      child: Container(
+        width: 220,
+        height: 220,
+        decoration: BoxDecoration(
+          color: colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: colorScheme.outlineVariant),
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.qr_code_2,
+              size: 80,
+              color: colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 12),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Text(
+                l10n.shareQrPlaceholderLabel,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -411,5 +411,13 @@
   "courtDisplayLabelBack": "B",
   "@courtDisplayLabelBack": {
     "description": "One-character court display label for back."
+  },
+  "shareUrlButton": "Share URL",
+  "@shareUrlButton": {
+    "description": "Button and dialog title label for sharing a schedule URL."
+  },
+  "closeButton": "Close",
+  "@closeButton": {
+    "description": "Generic close button or tooltip label."
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -411,5 +411,13 @@
   "courtDisplayLabelBack": "奥",
   "@courtDisplayLabelBack": {
     "description": "One-character court display label for back."
+  },
+  "shareUrlButton": "URLを共有",
+  "@shareUrlButton": {
+    "description": "Button and dialog title label for sharing a schedule URL."
+  },
+  "closeButton": "閉じる",
+  "@closeButton": {
+    "description": "Generic close button or tooltip label."
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -607,6 +607,18 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'奥'**
   String get courtDisplayLabelBack;
+
+  /// Button and dialog title label for sharing a schedule URL.
+  ///
+  /// In ja, this message translates to:
+  /// **'URLを共有'**
+  String get shareUrlButton;
+
+  /// Generic close button or tooltip label.
+  ///
+  /// In ja, this message translates to:
+  /// **'閉じる'**
+  String get closeButton;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -296,4 +296,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get courtDisplayLabelBack => 'B';
+
+  @override
+  String get shareUrlButton => 'Share URL';
+
+  @override
+  String get closeButton => 'Close';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -287,4 +287,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get courtDisplayLabelBack => '奥';
+
+  @override
+  String get shareUrlButton => 'URLを共有';
+
+  @override
+  String get closeButton => '閉じる';
 }

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -1,1 +1,7 @@
 export 'app_localizations.dart';
+
+extension ShareUrlLocalizations on AppLocalizations {
+  String get shareUrlButton => localeName == 'en' ? 'Share URL' : 'URLを共有';
+
+  String get closeButton => localeName == 'en' ? 'Close' : '閉じる';
+}

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -1,9 +1,1 @@
-import 'app_localizations.dart';
-
 export 'app_localizations.dart';
-
-extension ShareUrlLocalizations on AppLocalizations {
-  String get shareUrlButton => localeName == 'en' ? 'Share URL' : 'URLを共有';
-
-  String get closeButton => localeName == 'en' ? 'Close' : '閉じる';
-}

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -1,3 +1,5 @@
+import 'app_localizations.dart';
+
 export 'app_localizations.dart';
 
 extension ShareUrlLocalizations on AppLocalizations {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -413,6 +413,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pretty_qr_code:
+    dependency: "direct main"
+    description:
+      name: pretty_qr_code
+      sha256: "474f8a4512113fba06f14a6ec9bbf42353b4e651d7a520e3096f2a9b6bbe7a8a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.6.0"
   pub_semver:
     dependency: transitive
     description:
@@ -421,6 +429,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   record_use:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   shared_preferences: ^2.5.5
   web: ^1.1.1
   intl: any
+  pretty_qr_code: ^3.6.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 概要

web #60「共有URLをQRコードで表示できるようにする」の対応です。

共有URLの操作を、外側の「URLをコピー」ボタンから「URLを共有」ボタンに変更し、共有ダイアログ内でQRコード表示とURLコピーを行えるようにしました。

## 変更内容

- `pretty_qr_code` を追加
- `ScheduleShareDialog` を追加
  - 共有URLのQRコードを表示
  - ダイアログ内に `URLをコピー` ボタンを表示
  - 右上に押しやすい閉じるアイコンを表示
- `ScheduleEventSummaryCard` の共有導線を変更
  - 外側ボタンを `URLをコピー` から `URLを共有` に変更
  - アイコンを copy から share に変更
- `SchedulePage` / `RestoredSchedulePage` から共有ダイアログを開くように変更
  - 既存の共有URL生成処理を使い、コピーURLとQR表示URLが一致するようにした
- QRコード生成を `StatefulWidget` 化
  - `QrImage` を `build` 内で毎回生成しないようにした
  - エラー訂正レベルは `QrErrorCorrectLevel.H` を指定
- `shareUrlButton` / `closeButton` を l10n に追加
  - `app_ja.arb`
  - `app_en.arb`
  - generated localizations

## やらないこと

- QR画像保存
- 印刷用レイアウト
- OS共有シート対応
- QR中央へのらんすけアイコン埋め込み
  - favicon流用では角の黒背景が見えたため、今verでは見送り
  - 必要なら別途、QR埋め込み用画像を用意して対応する

## 確認

- [x] `flutter analyze`
- [x] QRコード表示確認
- [x] QRコード読み取り確認
- [x] `flutter gen-l10n`
- [x] l10n の暫定 extension を撤去し、ARB / generated localizations に反映
- [x] `flutter test`

## Notes

- ダイアログ外タップでも閉じられるよう、`showDialog` の `barrierDismissible` は明示的に無効化していません。
- 閉じるアイコンは、操作が分かりやすく押しやすいように `56 x 56` のタップ領域を確保しています。

Closes #60