### PR TITLE
✨ feat: add schedule history clear action refs #61

### DIFF
--- a/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
@@ -48,4 +48,32 @@ class LocalScheduleHistoryStore {
 
     await prefs.setString(_key, jsonEncode(limited));
   }
+
+  Future<void> clearAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
+
+  Future<void> clearExceptPublicId(String publicId) async {
+    final keepPublicId = publicId.trim().toUpperCase();
+    if (keepPublicId.isEmpty) {
+      await clearAll();
+      return;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    final current = await findAll();
+
+    final kept = current
+        .where((item) => item.publicId.trim().toUpperCase() == keepPublicId)
+        .map((item) => item.toJson())
+        .toList(growable: false);
+
+    if (kept.isEmpty) {
+      await prefs.remove(_key);
+      return;
+    }
+
+    await prefs.setString(_key, jsonEncode(kept));
+  }
 }

--- a/lib/features/doubles_scheduler/presentation/event_list_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_list_page.dart
@@ -7,19 +7,33 @@ import '../data/local_schedule_history_store.dart';
 import 'restored_schedule_page.dart';
 
 class EventListPage extends StatefulWidget {
-  const EventListPage({super.key});
+  const EventListPage({
+    super.key,
+    this.currentPublicId,
+  });
+
+  final String? currentPublicId;
 
   @override
   State<EventListPage> createState() => _EventListPageState();
 }
 
 class _EventListPageState extends State<EventListPage> {
+  final _historyStore = LocalScheduleHistoryStore();
+
   late Future<List<LocalScheduleHistoryItem>> _itemsFuture;
+  bool _canClearHistory = false;
 
   @override
   void initState() {
     super.initState();
-    _itemsFuture = LocalScheduleHistoryStore().findAll();
+    _itemsFuture = _loadItems();
+  }
+
+  String? get _currentPublicId {
+    final publicId = widget.currentPublicId?.trim().toUpperCase();
+    if (publicId == null || publicId.isEmpty) return null;
+    return publicId;
   }
 
   String _formatDateTime(DateTime dateTime) {
@@ -54,6 +68,81 @@ class _EventListPageState extends State<EventListPage> {
     );
   }
 
+  Future<List<LocalScheduleHistoryItem>> _loadItems() async {
+    final items = await _historyStore.findAll();
+    if (!mounted) return items;
+
+    setState(() {
+      _canClearHistory = _hasClearableHistory(items);
+    });
+
+    return items;
+  }
+
+  bool _hasClearableHistory(List<LocalScheduleHistoryItem> items) {
+    final currentPublicId = _currentPublicId;
+    if (currentPublicId == null) return items.isNotEmpty;
+
+    return items.any(
+      (item) => item.publicId.trim().toUpperCase() != currentPublicId,
+    );
+  }
+
+  void _reloadItems() {
+    setState(() {
+      _itemsFuture = _loadItems();
+    });
+  }
+
+  Future<void> _confirmClearHistory() async {
+    final l10n = AppLocalizations.of(context);
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(l10n.clearScheduleHistoryConfirmTitle),
+          content: Text(l10n.clearScheduleHistoryConfirmBody),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: Text(l10n.cancelButton),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: Text(l10n.clearScheduleHistoryActionButton),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (!mounted || confirmed != true) return;
+
+    final currentPublicId = _currentPublicId;
+    if (currentPublicId == null) {
+      await _historyStore.clearAll();
+    } else {
+      await _historyStore.clearExceptPublicId(currentPublicId);
+    }
+
+    if (!mounted) return;
+
+    _showMessage(l10n.scheduleHistoryClearedMessage);
+    _reloadItems();
+  }
+
+  void _showMessage(String message) {
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.hideCurrentSnackBar();
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(message),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
@@ -61,6 +150,14 @@ class _EventListPageState extends State<EventListPage> {
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.matchTableList),
+        actions: [
+          if (_canClearHistory)
+            IconButton(
+              onPressed: _confirmClearHistory,
+              icon: const Icon(Icons.delete_sweep_outlined),
+              tooltip: l10n.clearScheduleHistoryTooltip,
+            ),
+        ],
       ),
       body: FutureBuilder<List<LocalScheduleHistoryItem>>(
         future: _itemsFuture,
@@ -87,7 +184,7 @@ class _EventListPageState extends State<EventListPage> {
 
           if (items.isEmpty) {
             return Center(
-              child: Text(l10n.scheduleNotFoundMessage),
+              child: Text(l10n.scheduleHistoryEmptyMessage),
             );
           }
 

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -576,7 +576,11 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       case _ScheduleMenuAction.list:
         Navigator.push(
           context,
-          MaterialPageRoute(builder: (_) => const EventListPage()),
+          MaterialPageRoute(
+            builder: (_) => EventListPage(
+              currentPublicId: _savedEvent?.event.publicId ?? widget.publicId,
+            ),
+          ),
         );
         break;
     }

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -505,7 +505,11 @@ class _SchedulePageState extends State<SchedulePage> {
       case _ScheduleMenuAction.list:
         Navigator.push(
           context,
-          MaterialPageRoute(builder: (_) => const EventListPage()),
+          MaterialPageRoute(
+            builder: (_) => EventListPage(
+              currentPublicId: _savedEvent?.event.publicId,
+            ),
+          ),
         );
         break;
     }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -419,5 +419,29 @@
   "closeButton": "Close",
   "@closeButton": {
     "description": "Generic close button or tooltip label."
+  },
+  "scheduleHistoryEmptyMessage": "No match table view history",
+  "@scheduleHistoryEmptyMessage": {
+    "description": "Message shown when there is no local schedule view history."
+  },
+  "clearScheduleHistoryTooltip": "Delete match table view history",
+  "@clearScheduleHistoryTooltip": {
+    "description": "Tooltip for clearing local schedule view history."
+  },
+  "clearScheduleHistoryConfirmTitle": "Delete match table view history?",
+  "@clearScheduleHistoryConfirmTitle": {
+    "description": "Dialog title for confirming local schedule view history deletion."
+  },
+  "clearScheduleHistoryConfirmBody": "This deletes the match table view history on this device. Deleted history will return to the list when opened again from a shared URL or QR code.",
+  "@clearScheduleHistoryConfirmBody": {
+    "description": "Dialog body for confirming local schedule view history deletion."
+  },
+  "clearScheduleHistoryActionButton": "Delete history",
+  "@clearScheduleHistoryActionButton": {
+    "description": "Dialog action button label for clearing local schedule view history."
+  },
+  "scheduleHistoryClearedMessage": "Match table view history deleted",
+  "@scheduleHistoryClearedMessage": {
+    "description": "Snack bar message shown after local schedule view history was cleared."
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -419,5 +419,29 @@
   "closeButton": "閉じる",
   "@closeButton": {
     "description": "Generic close button or tooltip label."
+  },
+  "scheduleHistoryEmptyMessage": "対戦表表示履歴がありません",
+  "@scheduleHistoryEmptyMessage": {
+    "description": "Message shown when there is no local schedule view history."
+  },
+  "clearScheduleHistoryTooltip": "対戦表表示履歴を削除",
+  "@clearScheduleHistoryTooltip": {
+    "description": "Tooltip for clearing local schedule view history."
+  },
+  "clearScheduleHistoryConfirmTitle": "対戦表表示履歴を削除しますか？",
+  "@clearScheduleHistoryConfirmTitle": {
+    "description": "Dialog title for confirming local schedule view history deletion."
+  },
+  "clearScheduleHistoryConfirmBody": "この端末の対戦表表示履歴を削除します。削除した履歴は、共有URLまたはQRコードから再度アクセスすると一覧に戻ります。",
+  "@clearScheduleHistoryConfirmBody": {
+    "description": "Dialog body for confirming local schedule view history deletion."
+  },
+  "clearScheduleHistoryActionButton": "履歴を削除",
+  "@clearScheduleHistoryActionButton": {
+    "description": "Dialog action button label for clearing local schedule view history."
+  },
+  "scheduleHistoryClearedMessage": "対戦表表示履歴を削除しました",
+  "@scheduleHistoryClearedMessage": {
+    "description": "Snack bar message shown after local schedule view history was cleared."
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -619,6 +619,42 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'閉じる'**
   String get closeButton;
+
+  /// Message shown when there is no local schedule view history.
+  ///
+  /// In ja, this message translates to:
+  /// **'対戦表表示履歴がありません'**
+  String get scheduleHistoryEmptyMessage;
+
+  /// Tooltip for clearing local schedule view history.
+  ///
+  /// In ja, this message translates to:
+  /// **'対戦表表示履歴を削除'**
+  String get clearScheduleHistoryTooltip;
+
+  /// Dialog title for confirming local schedule view history deletion.
+  ///
+  /// In ja, this message translates to:
+  /// **'対戦表表示履歴を削除しますか？'**
+  String get clearScheduleHistoryConfirmTitle;
+
+  /// Dialog body for confirming local schedule view history deletion.
+  ///
+  /// In ja, this message translates to:
+  /// **'この端末の対戦表表示履歴を削除します。削除した履歴は、共有URLまたはQRコードから再度アクセスすると一覧に戻ります。'**
+  String get clearScheduleHistoryConfirmBody;
+
+  /// Dialog action button label for clearing local schedule view history.
+  ///
+  /// In ja, this message translates to:
+  /// **'履歴を削除'**
+  String get clearScheduleHistoryActionButton;
+
+  /// Snack bar message shown after local schedule view history was cleared.
+  ///
+  /// In ja, this message translates to:
+  /// **'対戦表表示履歴を削除しました'**
+  String get scheduleHistoryClearedMessage;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -302,4 +302,25 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get closeButton => 'Close';
+
+  @override
+  String get scheduleHistoryEmptyMessage => 'No match table view history';
+
+  @override
+  String get clearScheduleHistoryTooltip => 'Delete match table view history';
+
+  @override
+  String get clearScheduleHistoryConfirmTitle =>
+      'Delete match table view history?';
+
+  @override
+  String get clearScheduleHistoryConfirmBody =>
+      'This deletes the match table view history on this device. Deleted history will return to the list when opened again from a shared URL or QR code.';
+
+  @override
+  String get clearScheduleHistoryActionButton => 'Delete history';
+
+  @override
+  String get scheduleHistoryClearedMessage =>
+      'Match table view history deleted';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -293,4 +293,23 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get closeButton => '閉じる';
+
+  @override
+  String get scheduleHistoryEmptyMessage => '対戦表表示履歴がありません';
+
+  @override
+  String get clearScheduleHistoryTooltip => '対戦表表示履歴を削除';
+
+  @override
+  String get clearScheduleHistoryConfirmTitle => '対戦表表示履歴を削除しますか？';
+
+  @override
+  String get clearScheduleHistoryConfirmBody =>
+      'この端末の対戦表表示履歴を削除します。削除した履歴は、共有URLまたはQRコードから再度アクセスすると一覧に戻ります。';
+
+  @override
+  String get clearScheduleHistoryActionButton => '履歴を削除';
+
+  @override
+  String get scheduleHistoryClearedMessage => '対戦表表示履歴を削除しました';
 }


### PR DESCRIPTION
## 概要

Closes #61

対戦表一覧で、ブラウザローカルに保存された対戦表表示履歴を手動削除できるようにしました。

## 内容

- `LocalScheduleHistoryStore` に履歴削除処理を追加
  - 全件削除
  - 指定した `publicId` の履歴だけ残して削除
- `EventListPage` に対戦表表示履歴の削除ボタンを追加
- 削除前の確認ダイアログを追加
- 削除対象がない場合は削除ボタンを表示しないように変更
- 対戦表ページ / 共有ページから一覧を開いた場合は、現在表示中の対戦表を履歴に残すように変更
- 対戦表表示履歴が空の場合の表示文言を追加
- 履歴削除関連の文言を l10n 対応
  - `app_ja.arb`
  - `app_en.arb`
  - generated localization files

## メモ

- 削除対象は、この端末のブラウザローカルに保存された対戦表表示履歴のみです。
- Firestore 上の event は削除しません。
- 共有URL / QRコードから再度アクセスすると、削除した対戦表は一覧に戻ります。
- 個別削除、閲覧期限、作成日時 / 更新日時を使った履歴整理は後続バージョンで扱います。

## 動作確認

- 削除対象がない場合、削除ボタンが表示されないことを確認
- 対戦表ページ / 共有ページから一覧を開いた場合、現在表示中の対戦表が削除後も残ることを確認
- TOP / イベントセットアップから一覧を開いた場合、履歴を全件削除できることを確認
- 共有URLから再度アクセスすると、削除した履歴が一覧に戻ることを確認
- `dart format lib/`
- `flutter analyze`
- `flutter test`

## Docs

- docs 更新不要
  - 今回の変更はローカルの対戦表表示履歴削除 UI の追加のみ
  - 共有URL / QRコードから再度アクセスすると一覧に戻る旨は確認ダイアログ内で明示済み
  - 