### PR TITLE
🔗 feat: handle web publish and adopt flow refs #89

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,10 +239,38 @@ web から接続する core API の base URL は、`AppConfig.coreApiBaseUrl` �
 
 - generate
 - get
-- adopt
+
+採用状態は、web 側の event / view state として扱う。
+backend 側の generated schedule snapshot は、通常の採用操作では更新しない。
 
 ver0.1 では、環境別設定ファイルや secret 管理の本格化は行わず、`dart-define` による明示的な切り替えを優先する。
 
+### 10.2 共有URLと採用状態
+
+共有URLは `publicId` を入口にする。
+web 側の `events/{publicId}` 相当の document に、現在表示・採用する backend 側 generated schedule snapshot の ID を保存する。
+
+最小 schema 方針：
+
+```txt
+events/{publicId}
+  event.publicId
+  event.currentGeneratedScheduleId
+  event.adoptedGeneratedScheduleId
+  event.adoptedAt
+  event.visibility
+  event.visibleUntilRoundNo
+  event.expiresAt
+  event.revision
+  event.createdAt
+  event.updatedAt
+```
+
+`expiresAt` は作成から10日後を初期値として持つ。
+ただし、ver0.1.x では期限切れによる非表示処理はまだ行わない。
+
+将来の試合カード進行状況・対戦成績は、event 本体ではなく、試合カード単位の subcollection で扱う想定とする。
+`events/{publicId}/matchCards/{roundNo}_{courtNo}` のような形を候補にし、document が存在しない場合は既定で「試合前」とみなせるようにする。
 
 ---
 

--- a/docs/release-checklist-ver0.1.md
+++ b/docs/release-checklist-ver0.1.md
@@ -52,7 +52,6 @@
 
 - [ ] `generate` が正常動作する
 - [ ] `get` が正常動作する
-- [ ] `adopt` が正常動作する
 - [ ] 不正 request が想定通り error になる
 - [ ] 未対応条件が想定通り error になる
 - [ ] 存在しない generated_schedule_id が想定通り error になる
@@ -63,7 +62,7 @@
 - [ ] local 開発 origin の扱いを確認した
 - [ ] Codespaces preview origin の扱いを確認した
 - [ ] 不要な origin を許可しすぎていない
-- [ ] 公開 web から generate / get / adopt 時に CORS error が出ない
+- [ ] 公開 web から generate / get 時に CORS error が出ない
 
 ---
 
@@ -100,7 +99,10 @@
 - [ ] import 情報が保存される
 - [ ] `currentGeneratedScheduleId` が保存される
 - [ ] `adoptedGeneratedScheduleId` が保存される
-- [ ] generated_schedule 本体は web 側に保存せず、core 側 ID 参照のみである
+- [ ] `adoptedAt` が保存される
+- [ ] `expiresAt` が保存される
+- [ ] `revision` が保存される
+- [ ] generated_schedule 本体は web 側に保存せず、backend 側 ID 参照のみである
 
 ### Firestore Rules
 
@@ -251,7 +253,8 @@ ver0.1 対応条件について、公開環境または本番相当環境で gen
 
 - [ ] 公開 web が表示できる
 - [ ] 本番 core API に接続できる
-- [ ] generate / get / adopt が本番相当環境で動く
+- [ ] generate / get が本番相当環境で動く
+- [ ] web 側の adopt state 更新が本番相当環境で動く
 - [ ] 共有URL reopening が動く
 - [ ] リロード復元が動く
 - [ ] Firestore rules / API key / secret scanning の扱いを説明できる

--- a/lib/features/doubles_scheduler/application/generated_schedule_service.dart
+++ b/lib/features/doubles_scheduler/application/generated_schedule_service.dart
@@ -28,12 +28,12 @@ class GeneratedScheduleService {
     return _apiClient.getById(generatedScheduleId);
   }
 
-  Future<Map<String, dynamic>> adopt(String generatedScheduleId) async {
+  Future<Map<String, dynamic>> adopt(String generatedScheduleId) {
     // Adoption is represented by the web event/view state.
     // The backend generated schedule snapshot is not mutated here.
-    return {
+    return Future.value({
       'generated_schedule_id': generatedScheduleId,
       'adopted': true,
-    };
+    });
   }
 }

--- a/lib/features/doubles_scheduler/application/generated_schedule_service.dart
+++ b/lib/features/doubles_scheduler/application/generated_schedule_service.dart
@@ -28,7 +28,12 @@ class GeneratedScheduleService {
     return _apiClient.getById(generatedScheduleId);
   }
 
-  Future<Map<String, dynamic>> adopt(String generatedScheduleId) {
-    return _apiClient.adopt(generatedScheduleId);
+  Future<Map<String, dynamic>> adopt(String generatedScheduleId) async {
+    // Adoption is represented by the web event/view state.
+    // The backend generated schedule snapshot is not mutated here.
+    return {
+      'generated_schedule_id': generatedScheduleId,
+      'adopted': true,
+    };
   }
 }

--- a/lib/features/doubles_scheduler/application/generated_schedule_service.dart
+++ b/lib/features/doubles_scheduler/application/generated_schedule_service.dart
@@ -31,7 +31,7 @@ class GeneratedScheduleService {
   Future<Map<String, dynamic>> adopt(String generatedScheduleId) {
     // Adoption is represented by the web event/view state.
     // The backend generated schedule snapshot is not mutated here.
-    return Future.value({
+    return Future.value(<String, dynamic>{
       'generated_schedule_id': generatedScheduleId,
       'adopted': true,
     });

--- a/lib/features/doubles_scheduler/application/local_schedule_history_mapper.dart
+++ b/lib/features/doubles_scheduler/application/local_schedule_history_mapper.dart
@@ -10,6 +10,7 @@ LocalScheduleHistoryItem buildLocalScheduleHistoryItem(
     title: aggregate.event.title,
     courtCount: aggregate.event.courtCount,
     playerCount: aggregate.players.length,
+    createdAt: aggregate.event.createdAt,
     firstSavedAt: now,
     lastOpenedAt: now,
   );

--- a/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
+++ b/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
@@ -131,6 +131,7 @@ class InMemoryEventRepository implements EventRepository {
     final updated = event.copyWith(
       status: SavedEventStatus.generated,
       currentGeneratedScheduleId: generatedScheduleId,
+      revision: event.revision + 1,
       updatedAt: DateTime.now(),
     );
 
@@ -148,11 +149,14 @@ class InMemoryEventRepository implements EventRepository {
       throw StateError('event not found: $eventId');
     }
 
+    final now = DateTime.now();
     final updated = event.copyWith(
       status: SavedEventStatus.adopted,
       currentGeneratedScheduleId: generatedScheduleId,
       adoptedGeneratedScheduleId: generatedScheduleId,
-      updatedAt: DateTime.now(),
+      adoptedAt: now,
+      revision: event.revision + 1,
+      updatedAt: now,
     );
 
     _eventsById[eventId] = updated;
@@ -174,6 +178,7 @@ class InMemoryEventRepository implements EventRepository {
     }
 
     final updatedEvent = event.copyWith(
+      revision: event.revision + 1,
       updatedAt: DateTime.now(),
     );
 

--- a/lib/features/doubles_scheduler/data/json_event_repository.dart
+++ b/lib/features/doubles_scheduler/data/json_event_repository.dart
@@ -113,6 +113,7 @@ class JsonEventRepository implements EventRepository {
     final updatedEvent = event.copyWith(
       status: SavedEventStatus.generated,
       currentGeneratedScheduleId: generatedScheduleId,
+      revision: event.revision + 1,
       updatedAt: DateTime.now(),
     );
 
@@ -131,11 +132,15 @@ class JsonEventRepository implements EventRepository {
       throw StateError('event not found: $eventId');
     }
 
-    final updatedEvent = aggregate.event.copyWith(
+    final event = aggregate.event;
+    final now = DateTime.now();
+    final updatedEvent = event.copyWith(
       status: SavedEventStatus.adopted,
       currentGeneratedScheduleId: generatedScheduleId,
       adoptedGeneratedScheduleId: generatedScheduleId,
-      updatedAt: DateTime.now(),
+      adoptedAt: now,
+      revision: event.revision + 1,
+      updatedAt: now,
     );
 
     await _saveAggregate(_replaceEvent(aggregate, updatedEvent));
@@ -153,11 +158,13 @@ class JsonEventRepository implements EventRepository {
       throw StateError('event not found: $eventId');
     }
 
-    if (aggregate.event.hasAdoptedSchedule) {
+    final event = aggregate.event;
+    if (event.hasAdoptedSchedule) {
       throw StateError('event already adopted: $eventId');
     }
 
-    final updatedEvent = aggregate.event.copyWith(
+    final updatedEvent = event.copyWith(
+      revision: event.revision + 1,
       updatedAt: DateTime.now(),
     );
 

--- a/lib/features/doubles_scheduler/data/local_schedule_history_item.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_item.dart
@@ -4,6 +4,7 @@ class LocalScheduleHistoryItem {
     required this.title,
     required this.courtCount,
     required this.playerCount,
+    required this.createdAt,
     required this.firstSavedAt,
     required this.lastOpenedAt,
   });
@@ -12,6 +13,7 @@ class LocalScheduleHistoryItem {
   final String title;
   final int courtCount;
   final int playerCount;
+  final DateTime createdAt;
   final DateTime firstSavedAt;
   final DateTime lastOpenedAt;
 
@@ -21,6 +23,7 @@ class LocalScheduleHistoryItem {
       'title': title,
       'court_count': courtCount,
       'player_count': playerCount,
+      'created_at': createdAt.toIso8601String(),
       'first_saved_at': firstSavedAt.toIso8601String(),
       'last_opened_at': lastOpenedAt.toIso8601String(),
     };
@@ -29,15 +32,18 @@ class LocalScheduleHistoryItem {
   static LocalScheduleHistoryItem fromJson(Map<String, dynamic> json) {
     // TODO(ver0.2): Remove the legacy participant_count fallback.
     final rawPlayerCount = json['player_count'] ?? json['participant_count'];
+    final firstSavedAt =
+        DateTime.tryParse(json['first_saved_at'] as String? ?? '') ??
+            DateTime.now();
 
     return LocalScheduleHistoryItem(
       publicId: json['public_id'] as String? ?? '',
       title: json['title'] as String? ?? 'Untitled match table',
       courtCount: json['court_count'] as int? ?? 0,
       playerCount: rawPlayerCount as int? ?? 0,
-      firstSavedAt:
-          DateTime.tryParse(json['first_saved_at'] as String? ?? '') ??
-              DateTime.now(),
+      createdAt: DateTime.tryParse(json['created_at'] as String? ?? '') ??
+          firstSavedAt,
+      firstSavedAt: firstSavedAt,
       lastOpenedAt:
           DateTime.tryParse(json['last_opened_at'] as String? ?? '') ??
               DateTime.now(),

--- a/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
@@ -37,6 +37,7 @@ class LocalScheduleHistoryStore {
       title: item.title,
       courtCount: item.courtCount,
       playerCount: item.playerCount,
+      createdAt: previous?.createdAt ?? item.createdAt,
       firstSavedAt: previous?.firstSavedAt ?? item.firstSavedAt,
       lastOpenedAt: item.lastOpenedAt,
     );

--- a/lib/features/doubles_scheduler/domain/saved_event_models.dart
+++ b/lib/features/doubles_scheduler/domain/saved_event_models.dart
@@ -1,4 +1,10 @@
 const savedEventAggregateSchemaVersion = 1;
+const savedEventDefaultVisibility = 'unlisted';
+const savedEventDefaultExpiresInDays = 10;
+
+DateTime defaultSavedEventExpiresAt(DateTime createdAt) {
+  return createdAt.add(const Duration(days: savedEventDefaultExpiresInDays));
+}
 
 enum EventSourceType {
   tennisbear,
@@ -30,7 +36,12 @@ class SavedEvent {
     this.location,
     this.currentGeneratedScheduleId,
     this.adoptedGeneratedScheduleId,
-  });
+    this.adoptedAt,
+    this.visibility = savedEventDefaultVisibility,
+    this.visibleUntilRoundNo,
+    DateTime? expiresAt,
+    this.revision = 1,
+  }) : expiresAt = expiresAt ?? defaultSavedEventExpiresAt(createdAt);
 
   final String id;
   final String publicId;
@@ -45,6 +56,11 @@ class SavedEvent {
   final SavedEventStatus status;
   final String? currentGeneratedScheduleId;
   final String? adoptedGeneratedScheduleId;
+  final DateTime? adoptedAt;
+  final String visibility;
+  final int? visibleUntilRoundNo;
+  final DateTime expiresAt;
+  final int revision;
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -69,6 +85,11 @@ class SavedEvent {
     SavedEventStatus? status,
     String? currentGeneratedScheduleId,
     String? adoptedGeneratedScheduleId,
+    DateTime? adoptedAt,
+    String? visibility,
+    int? visibleUntilRoundNo,
+    DateTime? expiresAt,
+    int? revision,
     DateTime? updatedAt,
   }) {
     return SavedEvent(
@@ -87,6 +108,11 @@ class SavedEvent {
           currentGeneratedScheduleId ?? this.currentGeneratedScheduleId,
       adoptedGeneratedScheduleId:
           adoptedGeneratedScheduleId ?? this.adoptedGeneratedScheduleId,
+      adoptedAt: adoptedAt ?? this.adoptedAt,
+      visibility: visibility ?? this.visibility,
+      visibleUntilRoundNo: visibleUntilRoundNo ?? this.visibleUntilRoundNo,
+      expiresAt: expiresAt ?? this.expiresAt,
+      revision: revision ?? this.revision,
       createdAt: createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );
@@ -107,12 +133,19 @@ class SavedEvent {
       'status': status.name,
       'currentGeneratedScheduleId': currentGeneratedScheduleId,
       'adoptedGeneratedScheduleId': adoptedGeneratedScheduleId,
+      'adoptedAt': _nullableDateTimeToJson(adoptedAt),
+      'visibility': visibility,
+      'visibleUntilRoundNo': visibleUntilRoundNo,
+      'expiresAt': _dateTimeToJson(expiresAt),
+      'revision': revision,
       'createdAt': _dateTimeToJson(createdAt),
       'updatedAt': _dateTimeToJson(updatedAt),
     };
   }
 
   factory SavedEvent.fromJson(Map<String, dynamic> json) {
+    final createdAt = _dateTimeFromJson(json['createdAt']);
+
     return SavedEvent(
       id: json['id'].toString(),
       publicId: json['publicId'].toString(),
@@ -129,7 +162,13 @@ class SavedEvent {
           json['currentGeneratedScheduleId']?.toString(),
       adoptedGeneratedScheduleId:
           json['adoptedGeneratedScheduleId']?.toString(),
-      createdAt: _dateTimeFromJson(json['createdAt']),
+      adoptedAt: _nullableDateTimeFromJson(json['adoptedAt']),
+      visibility: json['visibility']?.toString() ?? savedEventDefaultVisibility,
+      visibleUntilRoundNo: _nullableIntFromJson(json['visibleUntilRoundNo']),
+      expiresAt: _nullableDateTimeFromJson(json['expiresAt']) ??
+          defaultSavedEventExpiresAt(createdAt),
+      revision: _nullableIntFromJson(json['revision']) ?? 1,
+      createdAt: createdAt,
       updatedAt: _dateTimeFromJson(json['updatedAt']),
     );
   }
@@ -387,6 +426,11 @@ int _intFromJson(Object? value) {
   }
 
   return parsed;
+}
+
+int? _nullableIntFromJson(Object? value) {
+  if (value == null) return null;
+  return _intFromJson(value);
 }
 
 Map<String, dynamic>? _nullableMapFromJson(Object? value) {

--- a/lib/features/doubles_scheduler/infrastructure/generated_schedule_api_client.dart
+++ b/lib/features/doubles_scheduler/infrastructure/generated_schedule_api_client.dart
@@ -43,13 +43,6 @@ class GeneratedScheduleApiClient {
     );
   }
 
-  Future<Map<String, dynamic>> adopt(String generatedScheduleId) {
-    return _requestJson(
-      method: 'POST',
-      path: '/api/v1/generated-schedules/$generatedScheduleId/adopt',
-    );
-  }
-
   Future<Map<String, dynamic>> _requestJson({
     required String method,
     required String path,

--- a/test/features/doubles_scheduler/application/event_repository_contract.dart
+++ b/test/features/doubles_scheduler/application/event_repository_contract.dart
@@ -44,6 +44,12 @@ void runEventRepositoryContractTests({
       expect(aggregate.event.status, SavedEventStatus.draft);
       expect(aggregate.event.currentGeneratedScheduleId, isNull);
       expect(aggregate.event.adoptedGeneratedScheduleId, isNull);
+      expect(aggregate.event.adoptedAt, isNull);
+      expect(aggregate.event.visibility, savedEventDefaultVisibility);
+      expect(aggregate.event.visibleUntilRoundNo, isNull);
+      expect(aggregate.event.expiresAt,
+          defaultSavedEventExpiresAt(aggregate.event.createdAt));
+      expect(aggregate.event.revision, 1);
 
       expect(aggregate.players, hasLength(6));
       expect(aggregate.players[0].displayName, '参加者1');
@@ -136,12 +142,14 @@ void runEventRepositoryContractTests({
       expect(updated.status, SavedEventStatus.generated);
       expect(updated.displayGeneratedScheduleId, 'generated-1');
       expect(updated.hasAdoptedSchedule, isFalse);
+      expect(updated.revision, created.event.revision + 1);
 
       final found = await repository.findByPublicId(created.event.publicId);
       expect(found, isNotNull);
       expect(found!.event.currentGeneratedScheduleId, 'generated-1');
       expect(found.event.adoptedGeneratedScheduleId, isNull);
       expect(found.event.status, SavedEventStatus.generated);
+      expect(found.event.revision, 2);
     });
 
     test('overwrites current generated schedule id when regenerated', () async {
@@ -163,10 +171,12 @@ void runEventRepositoryContractTests({
       expect(updated.adoptedGeneratedScheduleId, isNull);
       expect(updated.status, SavedEventStatus.generated);
       expect(updated.displayGeneratedScheduleId, 'generated-2');
+      expect(updated.revision, 3);
 
       final found = await repository.findByPublicId(created.event.publicId);
       expect(found!.event.currentGeneratedScheduleId, 'generated-2');
       expect(found.event.adoptedGeneratedScheduleId, isNull);
+      expect(found.event.revision, 3);
     });
 
     test('updates and persists adopted generated schedule id', () async {
@@ -181,15 +191,19 @@ void runEventRepositoryContractTests({
 
       expect(updated.currentGeneratedScheduleId, 'generated-1');
       expect(updated.adoptedGeneratedScheduleId, 'generated-1');
+      expect(updated.adoptedAt, isNotNull);
       expect(updated.status, SavedEventStatus.adopted);
       expect(updated.displayGeneratedScheduleId, 'generated-1');
       expect(updated.hasAdoptedSchedule, isTrue);
+      expect(updated.revision, created.event.revision + 1);
 
       final found = await repository.findByPublicId(created.event.publicId);
       expect(found, isNotNull);
       expect(found!.event.currentGeneratedScheduleId, 'generated-1');
       expect(found.event.adoptedGeneratedScheduleId, 'generated-1');
+      expect(found.event.adoptedAt, isNotNull);
       expect(found.event.status, SavedEventStatus.adopted);
+      expect(found.event.revision, 2);
     });
 
     test('throws when updating current schedule for missing event', () async {
@@ -262,12 +276,14 @@ void runEventRepositoryContractTests({
       expect(updated.courtSettings[0].displayLabel, 'A');
       expect(updated.courtSettings[1].courtNumber, 2);
       expect(updated.courtSettings[1].displayLabel, 'B');
+      expect(updated.event.revision, created.event.revision + 1);
 
       final found = await repository.findByPublicId(created.event.publicId);
       expect(found, isNotNull);
       expect(found!.courtSettings, hasLength(2));
       expect(found.courtSettings[0].displayLabel, 'A');
       expect(found.courtSettings[1].displayLabel, 'B');
+      expect(found.event.revision, 2);
     });
 
     test('keeps court settings when schedule ids are updated', () async {

--- a/test/features/doubles_scheduler/domain/saved_event_models_test.dart
+++ b/test/features/doubles_scheduler/domain/saved_event_models_test.dart
@@ -5,11 +5,14 @@ void main() {
   group('SavedEvent models JSON', () {
     final createdAt = DateTime.utc(2026, 5, 14, 4, 30);
     final updatedAt = DateTime.utc(2026, 5, 14, 4, 45);
+    final adoptedAt = DateTime.utc(2026, 5, 14, 4, 50);
+    final expiresAt = DateTime.utc(2026, 5, 24, 4, 30);
 
     SavedEventAggregate buildAggregate({
       SavedEventStatus status = SavedEventStatus.adopted,
       String? currentGeneratedScheduleId = 'generated-current',
       String? adoptedGeneratedScheduleId = 'generated-adopted',
+      DateTime? adoptedAtValue,
       SavedEventImport? importRecord,
     }) {
       final event = SavedEvent(
@@ -26,6 +29,11 @@ void main() {
         status: status,
         currentGeneratedScheduleId: currentGeneratedScheduleId,
         adoptedGeneratedScheduleId: adoptedGeneratedScheduleId,
+        adoptedAt: adoptedAtValue,
+        visibility: 'unlisted',
+        visibleUntilRoundNo: 10,
+        expiresAt: expiresAt,
+        revision: 3,
         createdAt: createdAt,
         updatedAt: updatedAt,
       );
@@ -85,7 +93,7 @@ void main() {
     }
 
     test('round trips SavedEventAggregate through JSON', () {
-      final aggregate = buildAggregate();
+      final aggregate = buildAggregate(adoptedAtValue: adoptedAt);
 
       final json = aggregate.toJson();
       final restored = SavedEventAggregate.fromJson(json);
@@ -103,6 +111,11 @@ void main() {
       expect(restored.event.sourceType, EventSourceType.tennisbear);
       expect(restored.event.sourceUrl, 'https://example.com/events/1');
       expect(restored.event.status, SavedEventStatus.adopted);
+      expect(restored.event.adoptedAt, adoptedAt);
+      expect(restored.event.visibility, 'unlisted');
+      expect(restored.event.visibleUntilRoundNo, 10);
+      expect(restored.event.expiresAt, expiresAt);
+      expect(restored.event.revision, 3);
       expect(restored.event.createdAt, createdAt);
       expect(restored.event.updatedAt, updatedAt);
 
@@ -157,6 +170,26 @@ void main() {
       expect(restored.importRecord!.parsedPlayersJson, hasLength(2));
     });
 
+    test('restores legacy event JSON with web state defaults', () {
+      final aggregate = buildAggregate();
+      final json = aggregate.toJson();
+      final eventJson = json['event'] as Map<String, dynamic>;
+
+      eventJson.remove('adoptedAt');
+      eventJson.remove('visibility');
+      eventJson.remove('visibleUntilRoundNo');
+      eventJson.remove('expiresAt');
+      eventJson.remove('revision');
+
+      final restored = SavedEventAggregate.fromJson(json);
+
+      expect(restored.event.adoptedAt, isNull);
+      expect(restored.event.visibility, savedEventDefaultVisibility);
+      expect(restored.event.visibleUntilRoundNo, isNull);
+      expect(restored.event.expiresAt, defaultSavedEventExpiresAt(createdAt));
+      expect(restored.event.revision, 1);
+    });
+
     test('round trips generated schedule refs through JSON', () {
       final aggregate = buildAggregate(
         status: SavedEventStatus.generated,
@@ -178,6 +211,7 @@ void main() {
         status: SavedEventStatus.adopted,
         currentGeneratedScheduleId: 'generated-1',
         adoptedGeneratedScheduleId: 'generated-1',
+        adoptedAtValue: adoptedAt,
       );
 
       final restored = SavedEventAggregate.fromJson(aggregate.toJson());
@@ -185,6 +219,7 @@ void main() {
       expect(restored.event.status, SavedEventStatus.adopted);
       expect(restored.event.currentGeneratedScheduleId, 'generated-1');
       expect(restored.event.adoptedGeneratedScheduleId, 'generated-1');
+      expect(restored.event.adoptedAt, adoptedAt);
       expect(restored.event.displayGeneratedScheduleId, 'generated-1');
       expect(restored.event.hasAdoptedSchedule, isTrue);
     });


### PR DESCRIPTION
## 概要

web #89「生成済み対戦表の publish / adopt flow を web 側で扱う」対応です。

生成済み対戦表の採用状態を、backend 側 generated schedule snapshot の状態遷移ではなく、web 側の event / view state として扱うようにしました。

これにより、通常導線では backend の adopt endpoint に依存せず、`events/{publicId}` 相当の Firestore document 側で採用状態を管理します。

## 変更内容

* `SavedEvent` の web event state schema を拡張
  * `adoptedAt`
  * `visibility`
  * `visibleUntilRoundNo`
  * `expiresAt`
  * `revision`
* `expiresAt` の初期値を `createdAt + 10日` として保持
  * 今回は保持のみ
  * 期限切れによる非表示処理は未実装
* generate 成功時に `currentGeneratedScheduleId` と `revision` を更新
* adopt 時に backend adopt endpoint を呼ばず、web 側 event state を更新
  * `status: adopted`
  * `adoptedGeneratedScheduleId`
  * `adoptedAt`
  * `revision`
* local history に `createdAt` を追加
  * 既存 local storage 互換として、`created_at` が無い場合は `first_saved_at` に fallback
* `GeneratedScheduleApiClient` から backend adopt API 呼び出しを削除
* repository contract / model JSON test を更新
* docs を更新
  * `docs/architecture.md`
  * `docs/release-checklist-ver0.1.md`

## やらないこと

この PR では以下は扱いません。

* backend adopt endpoint の削除
* 対戦表のソート
* 対戦表の削除
* 期限切れによる非表示処理
* archived 判定 UI
* 試合カード単位の進行状況
* 試合カード単位の対戦成績
* score sheet / 勝敗集計
* ownership / login / 権限管理
* l10n 文言追加

## 動作確認

* `dart format lib/ test/` 実行済み
* `flutter analyze` 実行済み
* `flutter test` 実行済み

### DB なし backend + Firestore repository mode 確認

backend 側は `DATABASE_URL` を unset した状態で起動しました。

backend log で以下を確認しました。

```text
db init skipped: DATABASE_URL is empty and ENABLE_CLOUD_SQL is not true
```

web 側は以下で起動しました。

```bash
flutter run -d chrome \
  --dart-define=LANSKE_CORE_API_BASE_URL=http://localhost:8080 \
  --dart-define=LANSKE_EVENT_REPOSITORY=firestore
```

以下を確認しました。

* generate が成功すること
* get / reload が成功すること
* adopt が成功すること
* shared URL reopening が成功すること
* adopt 後、Firestore `events/{publicId}` に web 側 event state が保存されること
  * `status: adopted`
  * `visibility: unlisted`
  * `visibleUntilRoundNo: null`
* local PostgreSQL にレコードが追加されていないこと
* Cloud SQL にレコードが追加されていないこと

## docs / l10n / Firestore rules

* docs 更新あり
  * `docs/architecture.md`
  * `docs/release-checklist-ver0.1.md`
* ユーザー向け文言変更なしのため l10n 更新なし
* Firestore への保存確認済みのため、今回 Firestore rules 更新なし

## リリース順序メモ

backend 側の adopt endpoint に依存しない web 実装へ先に切り替えるため、リリース順序は以下を想定します。

1. web preview deploy
2. web preview 簡易確認
3. web prod deploy
4. web prod 簡易確認
5. backend 側の不要 endpoint 整理
6. backend deploy
7. backend リリースチェックリスト実施

`旧backend + 新web` は成立する想定です。

一方で、backend 側の不要 endpoint 整理後は `新backend + 旧web` が成立しない可能性があるため、web 側を先に反映します。

Closes #89
