### PR TITLE
📝 fix: open feedback form in new tab refs #85

### DIFF
--- a/web/support/index.html
+++ b/web/support/index.html
@@ -55,10 +55,10 @@
       background:
         radial-gradient(circle at 18% 28%, rgba(255, 230, 86, 0.95) 0 10px, transparent 11px),
         radial-gradient(circle at 78% 64%, rgba(255, 230, 86, 0.95) 0 10px, transparent 11px),
-        linear-gradient(92deg, transparent 0 14%, rgba(255,255,255,0.92) 14.3% 15.2%, transparent 15.5%),
-        linear-gradient(92deg, transparent 0 82%, rgba(255,255,255,0.92) 82.3% 83.2%, transparent 83.5%),
-        linear-gradient(0deg, transparent 0 22%, rgba(255,255,255,0.92) 22.5% 23.6%, transparent 24%),
-        linear-gradient(0deg, transparent 0 75%, rgba(255,255,255,0.92) 75.5% 76.6%, transparent 77%),
+        linear-gradient(92deg, transparent 0 14%, rgba(255, 255, 255, 0.92) 14.3% 15.2%, transparent 15.5%),
+        linear-gradient(92deg, transparent 0 82%, rgba(255, 255, 255, 0.92) 82.3% 83.2%, transparent 83.5%),
+        linear-gradient(0deg, transparent 0 22%, rgba(255, 255, 255, 0.92) 22.5% 23.6%, transparent 24%),
+        linear-gradient(0deg, transparent 0 75%, rgba(255, 255, 255, 0.92) 75.5% 76.6%, transparent 77%),
         linear-gradient(90deg, transparent 0 49%, rgba(10, 92, 67, 0.82) 49.4% 50.4%, transparent 50.8%),
         linear-gradient(180deg, #8fd19e 0%, #5bbd8e 100%);
       position: relative;
@@ -216,7 +216,8 @@
           まずは軽量な静的ページとして運用します。
         </p>
         <div class="actions">
-          <a class="button primary" href="https://forms.gle/xbXuJsZnfh5QrqjP8">フィードバックフォームを開く</a>
+          <a class="button primary" href="https://forms.gle/xbXuJsZnfh5QrqjP8" target="_blank"
+            rel="noopener noreferrer">フィードバックフォームを別タブで開く</a>
           <a class="button secondary" href="/">らんすけを開く</a>
         </div>
       </div>


### PR DESCRIPTION
## 概要

support ページのフィードバックフォームリンクを、同一タブではなく別タブで開くように変更しました。

これにより、フォーム送信後も元のらんすけ support ページへ戻りやすくなります。

## 変更内容

* `web/support/index.html` のフィードバックフォームリンクに `target="_blank"` を追加
* `rel="noopener noreferrer"` を追加
* ボタン文言を「フィードバックフォームを別タブで開く」に変更

## 確認

* [x] support ページが表示されることを確認
* [x] フィードバックフォームが別タブで開くことを確認
* [x] 元の support ページが残ることを確認
* [x] 「らんすけを開く」導線が動くことを確認
* [x] デプロイ前に Cloud Logging で直近アクセス有無を確認
* [x] 本番デプロイ後に公開環境で動作確認

## docs / README 更新

* 今回は support ページのリンク挙動のみの変更のため、docs / README 更新なし

Closes #85
