### PR TITLE
🧹 fix: replace deprecated dropdown value refs #96

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -3,6 +3,7 @@ import 'package:srp_lanske/l10n/l10n.dart';
 
 import '../features/doubles_scheduler/presentation/event_setup_page.dart';
 import '../features/doubles_scheduler/presentation/restored_schedule_page.dart';
+import '../features/team_scheduler/presentation/team_setup_page.dart';
 import 'theme/app_theme.dart';
 
 class App extends StatelessWidget {
@@ -10,10 +11,11 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final publicId = Uri.base.queryParameters['sid']?.trim();
+    final uri = Uri.base;
+    final publicId = uri.queryParameters['sid']?.trim();
 
     final home = publicId == null || publicId.isEmpty
-        ? const EventSetupPage()
+        ? _homeForPath(uri.path)
         : RestoredSchedulePage(publicId: publicId);
 
     return MaterialApp(
@@ -25,5 +27,13 @@ class App extends StatelessWidget {
       theme: appTheme,
       home: home,
     );
+  }
+
+  Widget _homeForPath(String path) {
+    if (path == '/team') {
+      return const TeamSetupPage();
+    }
+
+    return const EventSetupPage();
   }
 }

--- a/lib/features/team_scheduler/presentation/models/team_setup_draft.dart
+++ b/lib/features/team_scheduler/presentation/models/team_setup_draft.dart
@@ -1,0 +1,33 @@
+import 'dart:convert';
+
+class TeamSetupDraft {
+  const TeamSetupDraft({
+    required this.courts,
+    required this.teamCount,
+    required this.activeTeamCountPerRound,
+    required this.teamSize,
+    required this.participantCount,
+  });
+
+  final int courts;
+  final int teamCount;
+  final int activeTeamCountPerRound;
+  final int teamSize;
+  final int participantCount;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'scheduleType': 'team',
+      'courts': courts,
+      'teamCount': teamCount,
+      'activeTeamCountPerRound': activeTeamCountPerRound,
+      'teamSize': teamSize,
+      'participantCount': participantCount,
+    };
+  }
+
+  @override
+  String toString() {
+    return const JsonEncoder.withIndent('  ').convert(toJson());
+  }
+}

--- a/lib/features/team_scheduler/presentation/models/team_setup_draft.dart
+++ b/lib/features/team_scheduler/presentation/models/team_setup_draft.dart
@@ -2,27 +2,24 @@ import 'dart:convert';
 
 class TeamSetupDraft {
   const TeamSetupDraft({
-    required this.courts,
-    required this.teamCount,
-    required this.activeTeamCountPerRound,
-    required this.teamSize,
+    required this.concurrentMatchCount,
     required this.participantCount,
+    required this.teamCount,
+    required this.teamsPerMatch,
   });
 
-  final int courts;
-  final int teamCount;
-  final int activeTeamCountPerRound;
-  final int teamSize;
+  final int concurrentMatchCount;
   final int participantCount;
+  final int teamCount;
+  final int teamsPerMatch;
 
   Map<String, dynamic> toJson() {
     return {
       'scheduleType': 'team',
-      'courts': courts,
-      'teamCount': teamCount,
-      'activeTeamCountPerRound': activeTeamCountPerRound,
-      'teamSize': teamSize,
+      'concurrentMatchCount': concurrentMatchCount,
       'participantCount': participantCount,
+      'teamCount': teamCount,
+      'teamsPerMatch': teamsPerMatch,
     };
   }
 

--- a/lib/features/team_scheduler/presentation/models/team_setup_draft.dart
+++ b/lib/features/team_scheduler/presentation/models/team_setup_draft.dart
@@ -4,13 +4,13 @@ class TeamSetupDraft {
   const TeamSetupDraft({
     required this.concurrentMatchCount,
     required this.participantCount,
-    required this.teamCount,
+    required this.preferredTeamSize,
     required this.teamsPerMatch,
   });
 
   final int concurrentMatchCount;
   final int participantCount;
-  final int teamCount;
+  final int preferredTeamSize;
   final int teamsPerMatch;
 
   Map<String, dynamic> toJson() {
@@ -18,7 +18,7 @@ class TeamSetupDraft {
       'scheduleType': 'team',
       'concurrentMatchCount': concurrentMatchCount,
       'participantCount': participantCount,
-      'teamCount': teamCount,
+      'preferredTeamSize': preferredTeamSize,
       'teamsPerMatch': teamsPerMatch,
     };
   }

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -1,0 +1,319 @@
+import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
+import 'package:srp_lanske/shared/utils/external_link.dart';
+
+import 'models/team_setup_draft.dart';
+import 'widgets/team_setup_number_field.dart';
+
+const _topPagePath = '/';
+
+class TeamSetupPage extends StatefulWidget {
+  const TeamSetupPage({super.key});
+
+  @override
+  State<TeamSetupPage> createState() => _TeamSetupPageState();
+}
+
+class _TeamSetupPageState extends State<TeamSetupPage> {
+  static const _minCourts = 1;
+  static const _maxCourts = 5;
+  static const _minTeamCount = 2;
+  static const _maxTeamCount = 25;
+  static const _minParticipantCount = 2;
+  static const _maxParticipantCount = 50;
+  static const _minTeamSize = 1;
+  static const _maxTeamSize = 25;
+  static const _minActiveTeamCountPerRound = 2;
+  static const _maxActiveTeamCountPerRound = 25;
+
+  int _courts = 1;
+  int _teamCount = 4;
+  int _activeTeamCountPerRound = 2;
+  int _teamSize = 2;
+  int _participantCount = 8;
+
+  int get _effectiveMaxTeamCount => _maxTeamCount.clamp(
+        _minTeamCount,
+        _participantCount,
+      );
+
+  int get _effectiveMaxTeamSize => _maxTeamSize.clamp(
+        _minTeamSize,
+        _participantCount,
+      );
+
+  int get _effectiveMaxActiveTeamCountPerRound => _maxActiveTeamCountPerRound
+      .clamp(_minActiveTeamCountPerRound, _teamCount);
+
+  TeamSetupDraft get _draft => TeamSetupDraft(
+        courts: _courts,
+        teamCount: _teamCount,
+        activeTeamCountPerRound: _activeTeamCountPerRound,
+        teamSize: _teamSize,
+        participantCount: _participantCount,
+      );
+
+  void _syncDependentValues() {
+    _teamCount = _teamCount.clamp(_minTeamCount, _effectiveMaxTeamCount);
+    _activeTeamCountPerRound = _activeTeamCountPerRound.clamp(
+      _minActiveTeamCountPerRound,
+      _effectiveMaxActiveTeamCountPerRound,
+    );
+    _teamSize = _teamSize.clamp(_minTeamSize, _effectiveMaxTeamSize);
+  }
+
+  void _setCourts(int value) {
+    setState(() {
+      _courts = value.clamp(_minCourts, _maxCourts);
+    });
+  }
+
+  void _setTeamCount(int value) {
+    setState(() {
+      _teamCount = value.clamp(_minTeamCount, _effectiveMaxTeamCount);
+      _syncDependentValues();
+    });
+  }
+
+  void _setActiveTeamCountPerRound(int value) {
+    setState(() {
+      _activeTeamCountPerRound = value.clamp(
+        _minActiveTeamCountPerRound,
+        _effectiveMaxActiveTeamCountPerRound,
+      );
+    });
+  }
+
+  void _setTeamSize(int value) {
+    setState(() {
+      _teamSize = value.clamp(_minTeamSize, _effectiveMaxTeamSize);
+      final nextParticipantCount = (_teamCount * _teamSize).clamp(
+        _minParticipantCount,
+        _maxParticipantCount,
+      );
+      _participantCount = nextParticipantCount;
+      _syncDependentValues();
+    });
+  }
+
+  void _setParticipantCount(int value) {
+    setState(() {
+      _participantCount = value.clamp(_minParticipantCount, _maxParticipantCount);
+      _syncDependentValues();
+    });
+  }
+
+  void _resetInputs() {
+    setState(() {
+      _courts = 1;
+      _teamCount = 4;
+      _activeTeamCountPerRound = 2;
+      _teamSize = 2;
+      _participantCount = 8;
+    });
+  }
+
+  void _submitMock() {
+    final l10n = AppLocalizations.of(context);
+    final draft = _draft;
+
+    debugPrint(draft.toString());
+
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.hideCurrentSnackBar();
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(l10n.teamSetupCreatedMessage),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
+  Widget _buildNumberFields(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final useTwoColumns = constraints.maxWidth >= 760;
+        final itemWidth = useTwoColumns
+            ? (constraints.maxWidth - 12) / 2
+            : constraints.maxWidth;
+
+        return Wrap(
+          spacing: 12,
+          runSpacing: 12,
+          children: [
+            SizedBox(
+              width: itemWidth,
+              child: TeamSetupNumberField(
+                label: l10n.courtCountLabel,
+                value: _courts,
+                minValue: _minCourts,
+                maxValue: _maxCourts,
+                onChanged: _setCourts,
+                tooltipDecrement: l10n.decrementCourtCountTooltip,
+                tooltipIncrement: l10n.incrementCourtCountTooltip,
+              ),
+            ),
+            SizedBox(
+              width: itemWidth,
+              child: TeamSetupNumberField(
+                label: l10n.teamCountLabel,
+                value: _teamCount,
+                minValue: _minTeamCount,
+                maxValue: _effectiveMaxTeamCount,
+                onChanged: _setTeamCount,
+                tooltipDecrement: l10n.decrementTeamCountTooltip,
+                tooltipIncrement: l10n.incrementTeamCountTooltip,
+              ),
+            ),
+            SizedBox(
+              width: itemWidth,
+              child: TeamSetupNumberField(
+                label: l10n.activeTeamCountPerRoundLabel,
+                value: _activeTeamCountPerRound,
+                minValue: _minActiveTeamCountPerRound,
+                maxValue: _effectiveMaxActiveTeamCountPerRound,
+                onChanged: _setActiveTeamCountPerRound,
+                tooltipDecrement:
+                    l10n.decrementActiveTeamCountPerRoundTooltip,
+                tooltipIncrement:
+                    l10n.incrementActiveTeamCountPerRoundTooltip,
+              ),
+            ),
+            SizedBox(
+              width: itemWidth,
+              child: TeamSetupNumberField(
+                label: l10n.teamSizeLabel,
+                value: _teamSize,
+                minValue: _minTeamSize,
+                maxValue: _effectiveMaxTeamSize,
+                onChanged: _setTeamSize,
+                tooltipDecrement: l10n.decrementTeamSizeTooltip,
+                tooltipIncrement: l10n.incrementTeamSizeTooltip,
+                helpText: l10n.teamSetupDerivedTeamSizeHelp,
+              ),
+            ),
+            SizedBox(
+              width: itemWidth,
+              child: TeamSetupNumberField(
+                label: l10n.participantCountLabel,
+                value: _participantCount,
+                minValue: _minParticipantCount,
+                maxValue: _maxParticipantCount,
+                onChanged: _setParticipantCount,
+                tooltipDecrement: l10n.decrementParticipantCountTooltip,
+                tooltipIncrement: l10n.incrementParticipantCountTooltip,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.teamSetupTitle),
+        actions: [
+          PopupMenuButton<String>(
+            onSelected: (value) {
+              if (value == 'top') {
+                openUrlInCurrentTab(_topPagePath);
+              }
+            },
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: 'top',
+                child: Text(l10n.topPageMenu),
+              ),
+            ],
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(12),
+          children: [
+            Text(
+              l10n.teamSetupInstruction,
+              style: const TextStyle(fontSize: 16),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.teamSetupSupportedConditions,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              l10n.teamSetupInputUpperLimitNote,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 16),
+            _buildNumberFields(context),
+            const SizedBox(height: 16),
+            Card(
+              elevation: 0,
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n.teamSetupMockNoticeTitle,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(l10n.teamSetupMockNoticeBody),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                FilledButton.tonal(
+                  onPressed: _resetInputs,
+                  style: FilledButton.styleFrom(
+                    minimumSize: Size.zero,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 12,
+                    ),
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                  child: Text(l10n.resetTeamSetupButton),
+                ),
+                const SizedBox(width: 12),
+                FilledButton(
+                  onPressed: _submitMock,
+                  style: FilledButton.styleFrom(
+                    minimumSize: Size.zero,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 20,
+                      vertical: 14,
+                    ),
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                  child: Text(
+                    l10n.generateTeamScheduleButton,
+                    style: const TextStyle(fontSize: 18),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 80),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -12,22 +12,19 @@ class TeamSetupPage extends StatefulWidget {
 }
 
 class _TeamSetupPageState extends State<TeamSetupPage> {
-  static const _minCourts = 1;
-  static const _maxCourts = 5;
-  static const _minTeamCount = 2;
-  static const _maxTeamCount = 25;
+  static const _minConcurrentMatchCount = 1;
+  static const _maxConcurrentMatchCount = 5;
   static const _minParticipantCount = 2;
   static const _maxParticipantCount = 50;
-  static const _minTeamSize = 1;
-  static const _maxTeamSize = 25;
-  static const _minActiveTeamCountPerRound = 2;
-  static const _maxActiveTeamCountPerRound = 25;
+  static const _minTeamCount = 2;
+  static const _maxTeamCount = 25;
+  static const _minTeamsPerMatch = 2;
+  static const _maxTeamsPerMatch = 25;
 
-  int _courts = 1;
-  int _teamCount = 4;
-  int _activeTeamCountPerRound = 2;
-  int _teamSize = 2;
+  int _concurrentMatchCount = 1;
   int _participantCount = 8;
+  int _teamCount = 4;
+  int _teamsPerMatch = 2;
 
   int _clampInt(int value, int minValue, int maxValue) =>
       value.clamp(minValue, maxValue).toInt();
@@ -35,63 +32,40 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
   int get _effectiveMaxTeamCount =>
       _clampInt(_maxTeamCount, _minTeamCount, _participantCount);
 
-  int get _effectiveMaxTeamSize =>
-      _clampInt(_maxTeamSize, _minTeamSize, _participantCount);
-
-  int get _effectiveMaxActiveTeamCountPerRound => _clampInt(
-        _maxActiveTeamCountPerRound,
-        _minActiveTeamCountPerRound,
+  int get _effectiveMaxTeamsPerMatch => _clampInt(
+        _maxTeamsPerMatch,
+        _minTeamsPerMatch,
         _teamCount,
       );
 
+  int get _minMemberCountPerTeam => _participantCount ~/ _teamCount;
+
+  int get _maxMemberCountPerTeam =>
+      (_participantCount / _teamCount).ceil().toInt();
+
   TeamSetupDraft get _draft => TeamSetupDraft(
-        courts: _courts,
-        teamCount: _teamCount,
-        activeTeamCountPerRound: _activeTeamCountPerRound,
-        teamSize: _teamSize,
+        concurrentMatchCount: _concurrentMatchCount,
         participantCount: _participantCount,
+        teamCount: _teamCount,
+        teamsPerMatch: _teamsPerMatch,
       );
 
   void _syncDependentValues() {
     _teamCount = _clampInt(_teamCount, _minTeamCount, _effectiveMaxTeamCount);
-    _activeTeamCountPerRound = _clampInt(
-      _activeTeamCountPerRound,
-      _minActiveTeamCountPerRound,
-      _effectiveMaxActiveTeamCountPerRound,
+    _teamsPerMatch = _clampInt(
+      _teamsPerMatch,
+      _minTeamsPerMatch,
+      _effectiveMaxTeamsPerMatch,
     );
-    _teamSize = _clampInt(_teamSize, _minTeamSize, _effectiveMaxTeamSize);
   }
 
-  void _setCourts(int value) {
-    setState(() => _courts = _clampInt(value, _minCourts, _maxCourts));
-  }
-
-  void _setTeamCount(int value) {
+  void _setConcurrentMatchCount(int value) {
     setState(() {
-      _teamCount = _clampInt(value, _minTeamCount, _effectiveMaxTeamCount);
-      _syncDependentValues();
-    });
-  }
-
-  void _setActiveTeamCountPerRound(int value) {
-    setState(() {
-      _activeTeamCountPerRound = _clampInt(
+      _concurrentMatchCount = _clampInt(
         value,
-        _minActiveTeamCountPerRound,
-        _effectiveMaxActiveTeamCountPerRound,
+        _minConcurrentMatchCount,
+        _maxConcurrentMatchCount,
       );
-    });
-  }
-
-  void _setTeamSize(int value) {
-    setState(() {
-      _teamSize = _clampInt(value, _minTeamSize, _effectiveMaxTeamSize);
-      _participantCount = _clampInt(
-        _teamCount * _teamSize,
-        _minParticipantCount,
-        _maxParticipantCount,
-      );
-      _syncDependentValues();
     });
   }
 
@@ -106,13 +80,29 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
     });
   }
 
+  void _setTeamCount(int value) {
+    setState(() {
+      _teamCount = _clampInt(value, _minTeamCount, _effectiveMaxTeamCount);
+      _syncDependentValues();
+    });
+  }
+
+  void _setTeamsPerMatch(int value) {
+    setState(() {
+      _teamsPerMatch = _clampInt(
+        value,
+        _minTeamsPerMatch,
+        _effectiveMaxTeamsPerMatch,
+      );
+    });
+  }
+
   void _resetInputs() {
     setState(() {
-      _courts = 1;
-      _teamCount = 4;
-      _activeTeamCountPerRound = 2;
-      _teamSize = 2;
+      _concurrentMatchCount = 1;
       _participantCount = 8;
+      _teamCount = 4;
+      _teamsPerMatch = 2;
     });
   }
 
@@ -146,13 +136,27 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
             SizedBox(
               width: itemWidth,
               child: TeamSetupNumberField(
-                label: l10n.courtCountLabel,
-                value: _courts,
-                minValue: _minCourts,
-                maxValue: _maxCourts,
-                onChanged: _setCourts,
-                tooltipDecrement: l10n.decrementCourtCountTooltip,
-                tooltipIncrement: l10n.incrementCourtCountTooltip,
+                label: l10n.concurrentMatchCountLabel,
+                value: _concurrentMatchCount,
+                minValue: _minConcurrentMatchCount,
+                maxValue: _maxConcurrentMatchCount,
+                onChanged: _setConcurrentMatchCount,
+                tooltipDecrement:
+                    l10n.decrementConcurrentMatchCountTooltip,
+                tooltipIncrement:
+                    l10n.incrementConcurrentMatchCountTooltip,
+              ),
+            ),
+            SizedBox(
+              width: itemWidth,
+              child: TeamSetupNumberField(
+                label: l10n.participantCountLabel,
+                value: _participantCount,
+                minValue: _minParticipantCount,
+                maxValue: _maxParticipantCount,
+                onChanged: _setParticipantCount,
+                tooltipDecrement: l10n.decrementParticipantCountTooltip,
+                tooltipIncrement: l10n.incrementParticipantCountTooltip,
               ),
             ),
             SizedBox(
@@ -170,40 +174,13 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
             SizedBox(
               width: itemWidth,
               child: TeamSetupNumberField(
-                label: l10n.activeTeamCountPerRoundLabel,
-                value: _activeTeamCountPerRound,
-                minValue: _minActiveTeamCountPerRound,
-                maxValue: _effectiveMaxActiveTeamCountPerRound,
-                onChanged: _setActiveTeamCountPerRound,
-                tooltipDecrement:
-                    l10n.decrementActiveTeamCountPerRoundTooltip,
-                tooltipIncrement:
-                    l10n.incrementActiveTeamCountPerRoundTooltip,
-              ),
-            ),
-            SizedBox(
-              width: itemWidth,
-              child: TeamSetupNumberField(
-                label: l10n.teamSizeLabel,
-                value: _teamSize,
-                minValue: _minTeamSize,
-                maxValue: _effectiveMaxTeamSize,
-                onChanged: _setTeamSize,
-                tooltipDecrement: l10n.decrementTeamSizeTooltip,
-                tooltipIncrement: l10n.incrementTeamSizeTooltip,
-                helpText: l10n.teamSetupDerivedTeamSizeHelp,
-              ),
-            ),
-            SizedBox(
-              width: itemWidth,
-              child: TeamSetupNumberField(
-                label: l10n.participantCountLabel,
-                value: _participantCount,
-                minValue: _minParticipantCount,
-                maxValue: _maxParticipantCount,
-                onChanged: _setParticipantCount,
-                tooltipDecrement: l10n.decrementParticipantCountTooltip,
-                tooltipIncrement: l10n.incrementParticipantCountTooltip,
+                label: l10n.teamsPerMatchLabel,
+                value: _teamsPerMatch,
+                minValue: _minTeamsPerMatch,
+                maxValue: _effectiveMaxTeamsPerMatch,
+                onChanged: _setTeamsPerMatch,
+                tooltipDecrement: l10n.decrementTeamsPerMatchTooltip,
+                tooltipIncrement: l10n.incrementTeamsPerMatchTooltip,
               ),
             ),
           ],
@@ -212,89 +189,127 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
     );
   }
 
+  Widget _buildMemberCountSummary(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return Card(
+      elevation: 0,
+      color: Colors.blue.shade50,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.teamMemberCountSummary(
+                _minMemberCountPerTeam,
+                _maxMemberCountPerTeam,
+              ),
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Text(l10n.teamMemberCountSummaryHelp),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
 
-    return Scaffold(
-      appBar: AppBar(title: Text(l10n.teamSetupTitle)),
-      body: SafeArea(
-        child: ListView(
-          padding: const EdgeInsets.all(12),
-          children: [
-            Text(
-              l10n.teamSetupInstruction,
-              style: const TextStyle(fontSize: 16),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              l10n.teamSetupSupportedConditions,
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-            const SizedBox(height: 4),
-            Text(
-              l10n.teamSetupInputUpperLimitNote,
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-            const SizedBox(height: 16),
-            _buildNumberFields(context),
-            const SizedBox(height: 16),
-            Card(
-              elevation: 0,
-              child: Padding(
-                padding: const EdgeInsets.all(12),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      l10n.teamSetupMockNoticeTitle,
-                      style: const TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.bold,
+    return Theme(
+      data: Theme.of(context).copyWith(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        scaffoldBackgroundColor: Colors.blue.shade50,
+      ),
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(l10n.teamSetupTitle),
+          backgroundColor: Colors.blue.shade700,
+          foregroundColor: Colors.white,
+        ),
+        body: SafeArea(
+          child: ListView(
+            padding: const EdgeInsets.all(12),
+            children: [
+              Text(
+                l10n.teamSetupInstruction,
+                style: const TextStyle(fontSize: 16),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                l10n.teamSetupSupportedConditions,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                l10n.teamSetupInputUpperLimitNote,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              const SizedBox(height: 16),
+              _buildNumberFields(context),
+              const SizedBox(height: 16),
+              _buildMemberCountSummary(context),
+              const SizedBox(height: 16),
+              Card(
+                elevation: 0,
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        l10n.teamSetupMockNoticeTitle,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(l10n.teamSetupMockNoticeBody),
-                  ],
+                      const SizedBox(height: 8),
+                      Text(l10n.teamSetupMockNoticeBody),
+                    ],
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(height: 20),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                FilledButton.tonal(
-                  onPressed: _resetInputs,
-                  style: FilledButton.styleFrom(
-                    minimumSize: Size.zero,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 16,
-                      vertical: 12,
+              const SizedBox(height: 20),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  FilledButton.tonal(
+                    onPressed: _resetInputs,
+                    style: FilledButton.styleFrom(
+                      minimumSize: Size.zero,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 12,
+                      ),
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     ),
-                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    child: Text(l10n.resetTeamSetupButton),
                   ),
-                  child: Text(l10n.resetTeamSetupButton),
-                ),
-                const SizedBox(width: 12),
-                FilledButton(
-                  onPressed: _submitMock,
-                  style: FilledButton.styleFrom(
-                    minimumSize: Size.zero,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 20,
-                      vertical: 14,
+                  const SizedBox(width: 12),
+                  FilledButton(
+                    onPressed: _submitMock,
+                    style: FilledButton.styleFrom(
+                      minimumSize: Size.zero,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 20,
+                        vertical: 14,
+                      ),
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     ),
-                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    child: Text(
+                      l10n.generateTeamScheduleButton,
+                      style: const TextStyle(fontSize: 18),
+                    ),
                   ),
-                  child: Text(
-                    l10n.generateTeamScheduleButton,
-                    style: const TextStyle(fontSize: 18),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 80),
-          ],
+                ],
+              ),
+              const SizedBox(height: 80),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -16,42 +16,77 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
   static const _maxConcurrentMatchCount = 5;
   static const _minParticipantCount = 2;
   static const _maxParticipantCount = 50;
-  static const _minTeamCount = 2;
-  static const _maxTeamCount = 25;
+  static const _minPreferredTeamSize = 1;
+  static const _maxPreferredTeamSize = 25;
   static const _minTeamsPerMatch = 2;
   static const _maxTeamsPerMatch = 25;
 
   int _concurrentMatchCount = 1;
   int _participantCount = 8;
-  int _teamCount = 4;
+  int _preferredTeamSize = 2;
   int _teamsPerMatch = 2;
 
   int _clampInt(int value, int minValue, int maxValue) =>
       value.clamp(minValue, maxValue).toInt();
 
-  int get _effectiveMaxTeamCount =>
-      _clampInt(_maxTeamCount, _minTeamCount, _participantCount);
+  int get _effectiveMaxPreferredTeamSize {
+    final maxValue = (_participantCount - 1).clamp(
+      _minPreferredTeamSize,
+      _maxPreferredTeamSize,
+    );
+    return maxValue.toInt();
+  }
+
+  int get _derivedTeamCount =>
+      (_participantCount / _preferredTeamSize).ceil().toInt();
 
   int get _effectiveMaxTeamsPerMatch => _clampInt(
         _maxTeamsPerMatch,
         _minTeamsPerMatch,
-        _teamCount,
+        _derivedTeamCount,
       );
 
-  int get _minMemberCountPerTeam => _participantCount ~/ _teamCount;
+  List<int> get _teamMemberCounts {
+    final teamCount = _derivedTeamCount;
+    final base = _participantCount ~/ teamCount;
+    final remainder = _participantCount % teamCount;
 
-  int get _maxMemberCountPerTeam =>
-      (_participantCount / _teamCount).ceil().toInt();
+    return List<int>.generate(
+      teamCount,
+      (index) => index < remainder ? base + 1 : base,
+      growable: false,
+    );
+  }
+
+  String get _teamDistributionText {
+    final counts = _teamMemberCounts;
+    final grouped = <int, int>{};
+
+    for (final count in counts) {
+      grouped[count] = (grouped[count] ?? 0) + 1;
+    }
+
+    final entries = grouped.entries.toList()
+      ..sort((a, b) => b.key.compareTo(a.key));
+
+    return entries.map((entry) {
+      return '${entry.key}人×${entry.value}チーム';
+    }).join(' / ');
+  }
 
   TeamSetupDraft get _draft => TeamSetupDraft(
         concurrentMatchCount: _concurrentMatchCount,
         participantCount: _participantCount,
-        teamCount: _teamCount,
+        preferredTeamSize: _preferredTeamSize,
         teamsPerMatch: _teamsPerMatch,
       );
 
   void _syncDependentValues() {
-    _teamCount = _clampInt(_teamCount, _minTeamCount, _effectiveMaxTeamCount);
+    _preferredTeamSize = _clampInt(
+      _preferredTeamSize,
+      _minPreferredTeamSize,
+      _effectiveMaxPreferredTeamSize,
+    );
     _teamsPerMatch = _clampInt(
       _teamsPerMatch,
       _minTeamsPerMatch,
@@ -80,9 +115,13 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
     });
   }
 
-  void _setTeamCount(int value) {
+  void _setPreferredTeamSize(int value) {
     setState(() {
-      _teamCount = _clampInt(value, _minTeamCount, _effectiveMaxTeamCount);
+      _preferredTeamSize = _clampInt(
+        value,
+        _minPreferredTeamSize,
+        _effectiveMaxPreferredTeamSize,
+      );
       _syncDependentValues();
     });
   }
@@ -101,7 +140,7 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
     setState(() {
       _concurrentMatchCount = 1;
       _participantCount = 8;
-      _teamCount = 4;
+      _preferredTeamSize = 2;
       _teamsPerMatch = 2;
     });
   }
@@ -109,6 +148,7 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
   void _submitMock() {
     final l10n = AppLocalizations.of(context);
     debugPrint(_draft.toString());
+
     final messenger = ScaffoldMessenger.of(context);
     messenger.hideCurrentSnackBar();
     messenger.showSnackBar(
@@ -141,10 +181,8 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
                 minValue: _minConcurrentMatchCount,
                 maxValue: _maxConcurrentMatchCount,
                 onChanged: _setConcurrentMatchCount,
-                tooltipDecrement:
-                    l10n.decrementConcurrentMatchCountTooltip,
-                tooltipIncrement:
-                    l10n.incrementConcurrentMatchCountTooltip,
+                tooltipDecrement: l10n.decrementConcurrentMatchCountTooltip,
+                tooltipIncrement: l10n.incrementConcurrentMatchCountTooltip,
               ),
             ),
             SizedBox(
@@ -162,13 +200,13 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
             SizedBox(
               width: itemWidth,
               child: TeamSetupNumberField(
-                label: l10n.teamCountLabel,
-                value: _teamCount,
-                minValue: _minTeamCount,
-                maxValue: _effectiveMaxTeamCount,
-                onChanged: _setTeamCount,
-                tooltipDecrement: l10n.decrementTeamCountTooltip,
-                tooltipIncrement: l10n.incrementTeamCountTooltip,
+                label: l10n.preferredTeamSizeLabel,
+                value: _preferredTeamSize,
+                minValue: _minPreferredTeamSize,
+                maxValue: _effectiveMaxPreferredTeamSize,
+                onChanged: _setPreferredTeamSize,
+                tooltipDecrement: l10n.decrementPreferredTeamSizeTooltip,
+                tooltipIncrement: l10n.incrementPreferredTeamSizeTooltip,
               ),
             ),
             SizedBox(
@@ -189,29 +227,55 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
     );
   }
 
-  Widget _buildMemberCountSummary(BuildContext context) {
+  Widget _buildSummaryCards(BuildContext context) {
     final l10n = AppLocalizations.of(context);
 
-    return Card(
-      elevation: 0,
-      color: Colors.blue.shade50,
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              l10n.teamMemberCountSummary(
-                _minMemberCountPerTeam,
-                _maxMemberCountPerTeam,
-              ),
-              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+    return Column(
+      children: [
+        Card(
+          elevation: 0,
+          color: Colors.white,
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l10n.teamCountSummary(_derivedTeamCount),
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(l10n.teamCountSummaryHelp),
+              ],
             ),
-            const SizedBox(height: 8),
-            Text(l10n.teamMemberCountSummaryHelp),
-          ],
+          ),
         ),
-      ),
+        const SizedBox(height: 12),
+        Card(
+          elevation: 0,
+          color: Colors.white,
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l10n.teamDistributionSummary(_teamDistributionText),
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(l10n.teamDistributionSummaryHelp),
+              ],
+            ),
+          ),
+        ),
+      ],
     );
   }
 
@@ -227,8 +291,10 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
       child: Scaffold(
         appBar: AppBar(
           title: Text(l10n.teamSetupTitle),
-          backgroundColor: Colors.blue.shade700,
-          foregroundColor: Colors.white,
+          backgroundColor: Colors.blue.shade100,
+          foregroundColor: Colors.black87,
+          surfaceTintColor: Colors.transparent,
+          elevation: 0,
         ),
         body: SafeArea(
           child: ListView(
@@ -251,10 +317,11 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
               const SizedBox(height: 16),
               _buildNumberFields(context),
               const SizedBox(height: 16),
-              _buildMemberCountSummary(context),
+              _buildSummaryCards(context),
               const SizedBox(height: 16),
               Card(
                 elevation: 0,
+                color: Colors.white,
                 child: Padding(
                   padding: const EdgeInsets.all(12),
                   child: Column(

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -1,11 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
-import 'package:srp_lanske/shared/utils/external_link.dart';
 
 import 'models/team_setup_draft.dart';
 import 'widgets/team_setup_number_field.dart';
-
-const _topPagePath = '/';
 
 class TeamSetupPage extends StatefulWidget {
   const TeamSetupPage({super.key});
@@ -32,18 +29,20 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
   int _teamSize = 2;
   int _participantCount = 8;
 
-  int get _effectiveMaxTeamCount => _maxTeamCount.clamp(
-        _minTeamCount,
-        _participantCount,
-      );
+  int _clampInt(int value, int minValue, int maxValue) =>
+      value.clamp(minValue, maxValue).toInt();
 
-  int get _effectiveMaxTeamSize => _maxTeamSize.clamp(
-        _minTeamSize,
-        _participantCount,
-      );
+  int get _effectiveMaxTeamCount =>
+      _clampInt(_maxTeamCount, _minTeamCount, _participantCount);
 
-  int get _effectiveMaxActiveTeamCountPerRound => _maxActiveTeamCountPerRound
-      .clamp(_minActiveTeamCountPerRound, _teamCount);
+  int get _effectiveMaxTeamSize =>
+      _clampInt(_maxTeamSize, _minTeamSize, _participantCount);
+
+  int get _effectiveMaxActiveTeamCountPerRound => _clampInt(
+        _maxActiveTeamCountPerRound,
+        _minActiveTeamCountPerRound,
+        _teamCount,
+      );
 
   TeamSetupDraft get _draft => TeamSetupDraft(
         courts: _courts,
@@ -54,30 +53,30 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
       );
 
   void _syncDependentValues() {
-    _teamCount = _teamCount.clamp(_minTeamCount, _effectiveMaxTeamCount);
-    _activeTeamCountPerRound = _activeTeamCountPerRound.clamp(
+    _teamCount = _clampInt(_teamCount, _minTeamCount, _effectiveMaxTeamCount);
+    _activeTeamCountPerRound = _clampInt(
+      _activeTeamCountPerRound,
       _minActiveTeamCountPerRound,
       _effectiveMaxActiveTeamCountPerRound,
     );
-    _teamSize = _teamSize.clamp(_minTeamSize, _effectiveMaxTeamSize);
+    _teamSize = _clampInt(_teamSize, _minTeamSize, _effectiveMaxTeamSize);
   }
 
   void _setCourts(int value) {
-    setState(() {
-      _courts = value.clamp(_minCourts, _maxCourts);
-    });
+    setState(() => _courts = _clampInt(value, _minCourts, _maxCourts));
   }
 
   void _setTeamCount(int value) {
     setState(() {
-      _teamCount = value.clamp(_minTeamCount, _effectiveMaxTeamCount);
+      _teamCount = _clampInt(value, _minTeamCount, _effectiveMaxTeamCount);
       _syncDependentValues();
     });
   }
 
   void _setActiveTeamCountPerRound(int value) {
     setState(() {
-      _activeTeamCountPerRound = value.clamp(
+      _activeTeamCountPerRound = _clampInt(
+        value,
         _minActiveTeamCountPerRound,
         _effectiveMaxActiveTeamCountPerRound,
       );
@@ -86,19 +85,23 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
 
   void _setTeamSize(int value) {
     setState(() {
-      _teamSize = value.clamp(_minTeamSize, _effectiveMaxTeamSize);
-      final nextParticipantCount = (_teamCount * _teamSize).clamp(
+      _teamSize = _clampInt(value, _minTeamSize, _effectiveMaxTeamSize);
+      _participantCount = _clampInt(
+        _teamCount * _teamSize,
         _minParticipantCount,
         _maxParticipantCount,
       );
-      _participantCount = nextParticipantCount;
       _syncDependentValues();
     });
   }
 
   void _setParticipantCount(int value) {
     setState(() {
-      _participantCount = value.clamp(_minParticipantCount, _maxParticipantCount);
+      _participantCount = _clampInt(
+        value,
+        _minParticipantCount,
+        _maxParticipantCount,
+      );
       _syncDependentValues();
     });
   }
@@ -115,10 +118,7 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
 
   void _submitMock() {
     final l10n = AppLocalizations.of(context);
-    final draft = _draft;
-
-    debugPrint(draft.toString());
-
+    debugPrint(_draft.toString());
     final messenger = ScaffoldMessenger.of(context);
     messenger.hideCurrentSnackBar();
     messenger.showSnackBar(
@@ -217,24 +217,7 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
     final l10n = AppLocalizations.of(context);
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n.teamSetupTitle),
-        actions: [
-          PopupMenuButton<String>(
-            onSelected: (value) {
-              if (value == 'top') {
-                openUrlInCurrentTab(_topPagePath);
-              }
-            },
-            itemBuilder: (context) => [
-              PopupMenuItem(
-                value: 'top',
-                child: Text(l10n.topPageMenu),
-              ),
-            ],
-          ),
-        ],
-      ),
+      appBar: AppBar(title: Text(l10n.teamSetupTitle)),
       body: SafeArea(
         child: ListView(
           padding: const EdgeInsets.all(12),

--- a/lib/features/team_scheduler/presentation/widgets/team_setup_number_field.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_setup_number_field.dart
@@ -63,7 +63,7 @@ class TeamSetupNumberField extends StatelessWidget {
                 ),
                 Expanded(
                   child: DropdownButtonFormField<int>(
-                    value: value,
+                    initialValue: value,
                     items: values
                         .map(
                           (item) => DropdownMenuItem<int>(

--- a/lib/features/team_scheduler/presentation/widgets/team_setup_number_field.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_setup_number_field.dart
@@ -26,8 +26,12 @@ class TeamSetupNumberField extends StatelessWidget {
   bool get _canDecrement => value > minValue;
   bool get _canIncrement => value < maxValue;
 
+  int _clampValue(int nextValue) {
+    return nextValue.clamp(minValue, maxValue).toInt();
+  }
+
   void _setValue(int nextValue) {
-    onChanged(nextValue.clamp(minValue, maxValue));
+    onChanged(_clampValue(nextValue));
   }
 
   @override

--- a/lib/features/team_scheduler/presentation/widgets/team_setup_number_field.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_setup_number_field.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
+
+class TeamSetupNumberField extends StatelessWidget {
+  const TeamSetupNumberField({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.minValue,
+    required this.maxValue,
+    required this.onChanged,
+    required this.tooltipDecrement,
+    required this.tooltipIncrement,
+    this.helpText,
+  });
+
+  final String label;
+  final int value;
+  final int minValue;
+  final int maxValue;
+  final ValueChanged<int> onChanged;
+  final String tooltipDecrement;
+  final String tooltipIncrement;
+  final String? helpText;
+
+  bool get _canDecrement => value > minValue;
+  bool get _canIncrement => value < maxValue;
+
+  void _setValue(int nextValue) {
+    onChanged(nextValue.clamp(minValue, maxValue));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final values = List<int>.generate(
+      maxValue - minValue + 1,
+      (index) => minValue + index,
+    );
+
+    return Card(
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              label,
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                IconButton(
+                  onPressed: _canDecrement ? () => _setValue(value - 1) : null,
+                  tooltip: tooltipDecrement,
+                  icon: const Icon(Icons.remove_circle_outline),
+                ),
+                Expanded(
+                  child: DropdownButtonFormField<int>(
+                    value: value,
+                    items: values
+                        .map(
+                          (item) => DropdownMenuItem<int>(
+                            value: item,
+                            child: Text(item.toString()),
+                          ),
+                        )
+                        .toList(growable: false),
+                    onChanged: (nextValue) {
+                      if (nextValue == null) return;
+                      _setValue(nextValue);
+                    },
+                    decoration: InputDecoration(
+                      border: const OutlineInputBorder(),
+                      isDense: true,
+                      helperText: helpText ??
+                          l10n.teamSetupRangeHelp(minValue, maxValue),
+                    ),
+                  ),
+                ),
+                IconButton(
+                  onPressed: _canIncrement ? () => _setValue(value + 1) : null,
+                  tooltip: tooltipIncrement,
+                  icon: const Icon(Icons.add_circle_outline),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -1,1 +1,2 @@
 export 'app_localizations.dart';
+export 'team_l10n.dart';

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -12,50 +12,36 @@ extension TeamL10n on AppLocalizations {
   String get teamSetupTitle => _isJapanese ? 'らんすけ：チーム' : 'Lanske: Team';
 
   String get teamSetupInstruction => _isJapanese
-      ? 'チーム数・人数などを指定して、チーム用対戦表を作成します。'
-      : 'Set team and participant counts to create a team match table.';
+      ? '同時進行試合数・参加人数・チーム数を決めて、チーム用対戦表を作成します。'
+      : 'Set simultaneous matches, participants, and teams to create a team match table.';
 
   String get teamSetupSupportedConditions => _isJapanese
-      ? '初期MVPでは、1〜2コート / 10チーム程度までを主な確認範囲としています。'
-      : 'For the initial MVP, the main verification range is 1 to 2 courts and roughly up to 10 teams.';
+      ? '初期MVPでは、同時進行1〜2試合 / 10チーム程度までを主な確認範囲としています。'
+      : 'For the initial MVP, the main verification range is 1 to 2 simultaneous matches and roughly up to 10 teams.';
 
   String get teamSetupInputUpperLimitNote => _isJapanese
-      ? '入力上限: コート数5 / チーム数25 / 参加人数50 / チーム人数25 / 1ラウンドに出るチーム数25'
-      : 'Input limits: 5 courts / 25 teams / 50 participants / 25 members per team / 25 active teams per round';
+      ? '入力上限: 同時進行試合数5 / 参加人数50 / チーム数25 / 1試合で対戦するチーム数25'
+      : 'Input limits: 5 simultaneous matches / 50 participants / 25 teams / 25 teams per match';
 
-  String get teamCountLabel => _isJapanese ? 'チーム数' : 'Teams';
-
-  String get activeTeamCountPerRoundLabel => _isJapanese
-      ? '1ラウンドに出るチーム数'
-      : 'Active teams per round';
-
-  String get teamSizeLabel => _isJapanese ? 'チーム人数' : 'Members per team';
+  String get concurrentMatchCountLabel => _isJapanese
+      ? '同時進行試合数'
+      : 'Simultaneous matches';
 
   String get participantCountLabel => _isJapanese ? '参加人数' : 'Participants';
 
-  String get decrementTeamCountTooltip => _isJapanese
-      ? 'チーム数を減らす'
-      : 'Decrease team count';
+  String get teamCountLabel => _isJapanese ? 'チーム数' : 'Teams';
 
-  String get incrementTeamCountTooltip => _isJapanese
-      ? 'チーム数を増やす'
-      : 'Increase team count';
+  String get teamsPerMatchLabel => _isJapanese
+      ? '1試合で対戦するチーム数'
+      : 'Teams per match';
 
-  String get decrementActiveTeamCountPerRoundTooltip => _isJapanese
-      ? '1ラウンドに出るチーム数を減らす'
-      : 'Decrease active teams per round';
+  String get decrementConcurrentMatchCountTooltip => _isJapanese
+      ? '同時進行試合数を減らす'
+      : 'Decrease simultaneous match count';
 
-  String get incrementActiveTeamCountPerRoundTooltip => _isJapanese
-      ? '1ラウンドに出るチーム数を増やす'
-      : 'Increase active teams per round';
-
-  String get decrementTeamSizeTooltip => _isJapanese
-      ? 'チーム人数を減らす'
-      : 'Decrease members per team';
-
-  String get incrementTeamSizeTooltip => _isJapanese
-      ? 'チーム人数を増やす'
-      : 'Increase members per team';
+  String get incrementConcurrentMatchCountTooltip => _isJapanese
+      ? '同時進行試合数を増やす'
+      : 'Increase simultaneous match count';
 
   String get decrementParticipantCountTooltip => _isJapanese
       ? '参加人数を減らす'
@@ -65,15 +51,43 @@ extension TeamL10n on AppLocalizations {
       ? '参加人数を増やす'
       : 'Increase participant count';
 
+  String get decrementTeamCountTooltip => _isJapanese
+      ? 'チーム数を減らす'
+      : 'Decrease team count';
+
+  String get incrementTeamCountTooltip => _isJapanese
+      ? 'チーム数を増やす'
+      : 'Increase team count';
+
+  String get decrementTeamsPerMatchTooltip => _isJapanese
+      ? '1試合で対戦するチーム数を減らす'
+      : 'Decrease teams per match';
+
+  String get incrementTeamsPerMatchTooltip => _isJapanese
+      ? '1試合で対戦するチーム数を増やす'
+      : 'Increase teams per match';
+
   String teamSetupRangeHelp(int minValue, int maxValue) {
     return _isJapanese
         ? '$minValue〜$maxValue の範囲で選択できます。'
         : 'Select a value from $minValue to $maxValue.';
   }
 
-  String get teamSetupDerivedTeamSizeHelp => _isJapanese
-      ? 'チーム人数は目安です。余りがある場合は、一部チームが+1人になります。'
-      : 'Members per team is a guide. If the participants do not divide evenly, some teams will have one extra member.';
+  String teamMemberCountSummary(int minMemberCount, int maxMemberCount) {
+    if (minMemberCount == maxMemberCount) {
+      return _isJapanese
+          ? '1チーム$minMemberCount人'
+          : '$minMemberCount per team';
+    }
+
+    return _isJapanese
+        ? '1チーム$minMemberCount〜$maxMemberCount人'
+        : '$minMemberCount to $maxMemberCount per team';
+  }
+
+  String get teamMemberCountSummaryHelp => _isJapanese
+      ? '参加人数とチーム数から自動計算します。余りがある場合は、一部チームが+1人になります。'
+      : 'Calculated from participants and teams. If the participants do not divide evenly, some teams will have one extra member.';
 
   String get resetTeamSetupButton => _isJapanese ? '入力項目のリセット' : 'Reset inputs';
 

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -5,67 +5,57 @@ extension TeamL10n on AppLocalizations {
 
   String get teamSetupMenuTitle => _isJapanese ? 'らんすけ：チーム' : 'Lanske: Team';
 
-  String get teamSetupMenuSubtitle => _isJapanese
-      ? 'チーム用対戦表を作成'
-      : 'Create a team match table';
+  String get teamSetupMenuSubtitle =>
+      _isJapanese ? 'チーム用対戦表を作成' : 'Create a team match table';
 
   String get teamSetupTitle => _isJapanese ? 'らんすけ：チーム' : 'Lanske: Team';
 
   String get teamSetupInstruction => _isJapanese
-      ? '同時進行試合数・参加人数・チーム数を決めて、チーム用対戦表を作成します。'
-      : 'Set simultaneous matches, participants, and teams to create a team match table.';
+      ? '同時進行試合数・参加人数・1チームの目安人数を決めて、チーム用対戦表を作成します。'
+      : 'Set simultaneous matches, participants, and preferred team size to create a team match table.';
 
   String get teamSetupSupportedConditions => _isJapanese
       ? '初期MVPでは、同時進行1〜2試合 / 10チーム程度までを主な確認範囲としています。'
       : 'For the initial MVP, the main verification range is 1 to 2 simultaneous matches and roughly up to 10 teams.';
 
   String get teamSetupInputUpperLimitNote => _isJapanese
-      ? '入力上限: 同時進行試合数5 / 参加人数50 / チーム数25 / 1試合で対戦するチーム数25'
-      : 'Input limits: 5 simultaneous matches / 50 participants / 25 teams / 25 teams per match';
+      ? '入力上限: 同時進行試合数5 / 参加人数50 / 1チームの目安人数25 / 1試合で対戦するチーム数25'
+      : 'Input limits: 5 simultaneous matches / 50 participants / preferred team size 25 / 25 teams per match';
 
-  String get concurrentMatchCountLabel => _isJapanese
-      ? '同時進行試合数'
-      : 'Simultaneous matches';
+  String get concurrentMatchCountLabel =>
+      _isJapanese ? '同時進行試合数' : 'Simultaneous matches';
 
   String get participantCountLabel => _isJapanese ? '参加人数' : 'Participants';
 
-  String get teamCountLabel => _isJapanese ? 'チーム数' : 'Teams';
+  String get preferredTeamSizeLabel =>
+      _isJapanese ? '1チームの目安人数' : 'Preferred team size';
 
-  String get teamsPerMatchLabel => _isJapanese
-      ? '1試合で対戦するチーム数'
-      : 'Teams per match';
+  String get teamsPerMatchLabel =>
+      _isJapanese ? '1試合で対戦するチーム数' : 'Teams per match';
 
-  String get decrementConcurrentMatchCountTooltip => _isJapanese
-      ? '同時進行試合数を減らす'
-      : 'Decrease simultaneous match count';
+  String get decrementConcurrentMatchCountTooltip =>
+      _isJapanese ? '同時進行試合数を減らす' : 'Decrease simultaneous match count';
 
-  String get incrementConcurrentMatchCountTooltip => _isJapanese
-      ? '同時進行試合数を増やす'
-      : 'Increase simultaneous match count';
+  String get incrementConcurrentMatchCountTooltip =>
+      _isJapanese ? '同時進行試合数を増やす' : 'Increase simultaneous match count';
 
-  String get decrementParticipantCountTooltip => _isJapanese
-      ? '参加人数を減らす'
-      : 'Decrease participant count';
+  String get decrementParticipantCountTooltip =>
+      _isJapanese ? '参加人数を減らす' : 'Decrease participant count';
 
-  String get incrementParticipantCountTooltip => _isJapanese
-      ? '参加人数を増やす'
-      : 'Increase participant count';
+  String get incrementParticipantCountTooltip =>
+      _isJapanese ? '参加人数を増やす' : 'Increase participant count';
 
-  String get decrementTeamCountTooltip => _isJapanese
-      ? 'チーム数を減らす'
-      : 'Decrease team count';
+  String get decrementPreferredTeamSizeTooltip =>
+      _isJapanese ? '1チームの目安人数を減らす' : 'Decrease preferred team size';
 
-  String get incrementTeamCountTooltip => _isJapanese
-      ? 'チーム数を増やす'
-      : 'Increase team count';
+  String get incrementPreferredTeamSizeTooltip =>
+      _isJapanese ? '1チームの目安人数を増やす' : 'Increase preferred team size';
 
-  String get decrementTeamsPerMatchTooltip => _isJapanese
-      ? '1試合で対戦するチーム数を減らす'
-      : 'Decrease teams per match';
+  String get decrementTeamsPerMatchTooltip =>
+      _isJapanese ? '1試合で対戦するチーム数を減らす' : 'Decrease teams per match';
 
-  String get incrementTeamsPerMatchTooltip => _isJapanese
-      ? '1試合で対戦するチーム数を増やす'
-      : 'Increase teams per match';
+  String get incrementTeamsPerMatchTooltip =>
+      _isJapanese ? '1試合で対戦するチーム数を増やす' : 'Increase teams per match';
 
   String teamSetupRangeHelp(int minValue, int maxValue) {
     return _isJapanese
@@ -73,31 +63,28 @@ extension TeamL10n on AppLocalizations {
         : 'Select a value from $minValue to $maxValue.';
   }
 
-  String teamMemberCountSummary(int minMemberCount, int maxMemberCount) {
-    if (minMemberCount == maxMemberCount) {
-      return _isJapanese
-          ? '1チーム$minMemberCount人'
-          : '$minMemberCount per team';
-    }
-
-    return _isJapanese
-        ? '1チーム$minMemberCount〜$maxMemberCount人'
-        : '$minMemberCount to $maxMemberCount per team';
+  String teamCountSummary(int teamCount) {
+    return _isJapanese ? '$teamCountチーム' : '$teamCount teams';
   }
 
-  String get teamMemberCountSummaryHelp => _isJapanese
-      ? '参加人数とチーム数から自動計算します。余りがある場合は、一部チームが+1人になります。'
-      : 'Calculated from participants and teams. If the participants do not divide evenly, some teams will have one extra member.';
+  String get teamCountSummaryHelp => _isJapanese
+      ? '参加人数と1チームの目安人数から自動計算します。'
+      : 'Calculated automatically from participants and preferred team size.';
+
+  String teamDistributionSummary(String summary) {
+    return _isJapanese ? '内訳: $summary' : 'Distribution: $summary';
+  }
+
+  String get teamDistributionSummaryHelp => _isJapanese
+      ? '余りがある場合は、一部チームの人数が1人少なくなります。'
+      : 'If there is a remainder, some teams will have one fewer member.';
 
   String get resetTeamSetupButton => _isJapanese ? '入力項目のリセット' : 'Reset inputs';
 
-  String get generateTeamScheduleButton => _isJapanese
-      ? 'チーム対戦表を作成'
-      : 'Create team match table';
+  String get generateTeamScheduleButton =>
+      _isJapanese ? 'チーム対戦表を作成' : 'Create team match table';
 
-  String get teamSetupMockNoticeTitle => _isJapanese
-      ? 'モック確認中'
-      : 'Mock flow';
+  String get teamSetupMockNoticeTitle => _isJapanese ? 'モック確認中' : 'Mock flow';
 
   String get teamSetupMockNoticeBody => _isJapanese
       ? 'backend API 接続前のため、次の作業でチーム用対戦表画面へ接続します。'

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -1,0 +1,95 @@
+import 'app_localizations.dart';
+
+extension TeamL10n on AppLocalizations {
+  bool get _isJapanese => localeName.startsWith('ja');
+
+  String get teamSetupMenuTitle => _isJapanese ? 'らんすけ：チーム' : 'Lanske: Team';
+
+  String get teamSetupMenuSubtitle => _isJapanese
+      ? 'チーム用対戦表を作成'
+      : 'Create a team match table';
+
+  String get teamSetupTitle => _isJapanese ? 'らんすけ：チーム' : 'Lanske: Team';
+
+  String get teamSetupInstruction => _isJapanese
+      ? 'チーム数・人数などを指定して、チーム用対戦表を作成します。'
+      : 'Set team and participant counts to create a team match table.';
+
+  String get teamSetupSupportedConditions => _isJapanese
+      ? '初期MVPでは、1〜2コート / 10チーム程度までを主な確認範囲としています。'
+      : 'For the initial MVP, the main verification range is 1 to 2 courts and roughly up to 10 teams.';
+
+  String get teamSetupInputUpperLimitNote => _isJapanese
+      ? '入力上限: コート数5 / チーム数25 / 参加人数50 / チーム人数25 / 1ラウンドに出るチーム数25'
+      : 'Input limits: 5 courts / 25 teams / 50 participants / 25 members per team / 25 active teams per round';
+
+  String get teamCountLabel => _isJapanese ? 'チーム数' : 'Teams';
+
+  String get activeTeamCountPerRoundLabel => _isJapanese
+      ? '1ラウンドに出るチーム数'
+      : 'Active teams per round';
+
+  String get teamSizeLabel => _isJapanese ? 'チーム人数' : 'Members per team';
+
+  String get participantCountLabel => _isJapanese ? '参加人数' : 'Participants';
+
+  String get decrementTeamCountTooltip => _isJapanese
+      ? 'チーム数を減らす'
+      : 'Decrease team count';
+
+  String get incrementTeamCountTooltip => _isJapanese
+      ? 'チーム数を増やす'
+      : 'Increase team count';
+
+  String get decrementActiveTeamCountPerRoundTooltip => _isJapanese
+      ? '1ラウンドに出るチーム数を減らす'
+      : 'Decrease active teams per round';
+
+  String get incrementActiveTeamCountPerRoundTooltip => _isJapanese
+      ? '1ラウンドに出るチーム数を増やす'
+      : 'Increase active teams per round';
+
+  String get decrementTeamSizeTooltip => _isJapanese
+      ? 'チーム人数を減らす'
+      : 'Decrease members per team';
+
+  String get incrementTeamSizeTooltip => _isJapanese
+      ? 'チーム人数を増やす'
+      : 'Increase members per team';
+
+  String get decrementParticipantCountTooltip => _isJapanese
+      ? '参加人数を減らす'
+      : 'Decrease participant count';
+
+  String get incrementParticipantCountTooltip => _isJapanese
+      ? '参加人数を増やす'
+      : 'Increase participant count';
+
+  String teamSetupRangeHelp(int minValue, int maxValue) {
+    return _isJapanese
+        ? '$minValue〜$maxValue の範囲で選択できます。'
+        : 'Select a value from $minValue to $maxValue.';
+  }
+
+  String get teamSetupDerivedTeamSizeHelp => _isJapanese
+      ? 'チーム人数は目安です。余りがある場合は、一部チームが+1人になります。'
+      : 'Members per team is a guide. If the participants do not divide evenly, some teams will have one extra member.';
+
+  String get resetTeamSetupButton => _isJapanese ? '入力項目のリセット' : 'Reset inputs';
+
+  String get generateTeamScheduleButton => _isJapanese
+      ? 'チーム対戦表を作成'
+      : 'Create team match table';
+
+  String get teamSetupMockNoticeTitle => _isJapanese
+      ? 'モック確認中'
+      : 'Mock flow';
+
+  String get teamSetupMockNoticeBody => _isJapanese
+      ? 'backend API 接続前のため、次の作業でチーム用対戦表画面へ接続します。'
+      : 'The backend API is not connected yet. The next work item will connect this to the team match table screen.';
+
+  String get teamSetupCreatedMessage => _isJapanese
+      ? 'チーム用セットアップ条件を作成しました'
+      : 'Team setup conditions were created.';
+}


### PR DESCRIPTION
## Summary

Closes #96

チーム用対戦表を作成するためのセットアップ画面を追加しました。

初期 MVP では backend API への本接続は行わず、まずは `/team` からチーム用セットアップ条件を入力できる状態にしています。

## Changes

* `/team` 直アクセス時にチーム用セットアップ画面を表示する route を追加
* チーム用セットアップ画面を追加
* 入力項目を以下の順番に整理

  * 同時進行試合数
  * 参加人数
  * 1チームの目安人数
  * 1試合で対戦するチーム数
* `- / +` ボタンと select box を併用するチーム用 number field を追加
* 参加人数と1チームの目安人数から、作成されるチーム数と人数配分を自動表示
* backend API 接続前のモック用 `TeamSetupDraft` を追加
* チーム用画面の l10n 文言を追加
* らんすけ：チーム用に薄い青系テーマを適用

## Deferred

* TOP / 既存メニューから `/team` への公開導線追加は、公開判断を含むため今回は入れない
* `/team` 導線の本格追加は、dev 環境から prod 環境への誘導対応と同じタイミングで行う
* backend API 接続は後続 Issue で対応する

## Checks

* [x] `dart format lib/`
* [x] `flutter analyze`
* [x] `flutter test`

## Docs / OpenAPI

* Docs 更新なし
* OpenAPI 更新なし

理由: 今回は web 側のチーム用セットアップ UI とモック draft 追加が中心で、backend API shape / OpenAPI はまだ確定・接続対象外のため。
