### PR TITLE
📝 feat: add team participant name input refs #97

### DIFF
--- a/lib/features/team_scheduler/presentation/models/team_setup_draft.dart
+++ b/lib/features/team_scheduler/presentation/models/team_setup_draft.dart
@@ -6,12 +6,14 @@ class TeamSetupDraft {
     required this.participantCount,
     required this.preferredTeamSize,
     required this.teamsPerMatch,
+    required this.participantNames,
   });
 
   final int concurrentMatchCount;
   final int participantCount;
   final int preferredTeamSize;
   final int teamsPerMatch;
+  final List<String> participantNames;
 
   Map<String, dynamic> toJson() {
     return {
@@ -20,6 +22,7 @@ class TeamSetupDraft {
       'participantCount': participantCount,
       'preferredTeamSize': preferredTeamSize,
       'teamsPerMatch': teamsPerMatch,
+      'participantNames': participantNames,
     };
   }
 

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
 
 import 'models/team_setup_draft.dart';
+import 'widgets/team_participant_name_input_card.dart';
 import 'widgets/team_setup_number_field.dart';
 
 class TeamSetupPage extends StatefulWidget {
@@ -25,6 +26,7 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
   int _participantCount = 8;
   int _preferredTeamSize = 2;
   int _teamsPerMatch = 2;
+  List<String> _participantNames = const [];
 
   int _clampInt(int value, int minValue, int maxValue) =>
       value.clamp(minValue, maxValue).toInt();
@@ -79,6 +81,7 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
         participantCount: _participantCount,
         preferredTeamSize: _preferredTeamSize,
         teamsPerMatch: _teamsPerMatch,
+        participantNames: _participantNames,
       );
 
   void _syncDependentValues() {
@@ -136,12 +139,25 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
     });
   }
 
+  void _applyParticipantNames(List<String> names) {
+    setState(() {
+      _participantNames = names;
+      _participantCount = _clampInt(
+        names.length,
+        _minParticipantCount,
+        _maxParticipantCount,
+      );
+      _syncDependentValues();
+    });
+  }
+
   void _resetInputs() {
     setState(() {
       _concurrentMatchCount = 1;
       _participantCount = 8;
       _preferredTeamSize = 2;
       _teamsPerMatch = 2;
+      _participantNames = const [];
     });
   }
 
@@ -316,6 +332,13 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
               ),
               const SizedBox(height: 16),
               _buildNumberFields(context),
+              const SizedBox(height: 16),
+              TeamParticipantNameInputCard(
+                participantNames: _participantNames,
+                participantCount: _participantCount,
+                maxParticipantCount: _maxParticipantCount,
+                onApply: _applyParticipantNames,
+              ),
               const SizedBox(height: 16),
               _buildSummaryCards(context),
               const SizedBox(height: 16),

--- a/lib/features/team_scheduler/presentation/widgets/team_participant_name_input_card.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_participant_name_input_card.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
+
+class TeamParticipantNameInputCard extends StatefulWidget {
+  const TeamParticipantNameInputCard({
+    super.key,
+    required this.participantNames,
+    required this.participantCount,
+    required this.maxParticipantCount,
+    required this.onApply,
+  });
+
+  final List<String> participantNames;
+  final int participantCount;
+  final int maxParticipantCount;
+  final ValueChanged<List<String>> onApply;
+
+  @override
+  State<TeamParticipantNameInputCard> createState() =>
+      _TeamParticipantNameInputCardState();
+}
+
+class _TeamParticipantNameInputCardState
+    extends State<TeamParticipantNameInputCard> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(
+      text: widget.participantNames.join('\n'),
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant TeamParticipantNameInputCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.participantNames != widget.participantNames) {
+      final nextText = widget.participantNames.join('\n');
+      if (_controller.text != nextText) {
+        _controller.text = nextText;
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  List<String> _parseParticipantNames(String rawText) {
+    final normalizedText = rawText.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+    final hasNewLine = normalizedText.contains('\n');
+    final hasComma = normalizedText.contains(',') || normalizedText.contains('、');
+    final hasTab = normalizedText.contains('\t');
+
+    final separator = hasNewLine
+        ? RegExp(r'\n+')
+        : hasComma
+            ? RegExp(r'[,、]+')
+            : hasTab
+                ? RegExp(r'\t+')
+                : RegExp(r'\n+');
+
+    return normalizedText
+        .split(separator)
+        .map((name) => name.trim())
+        .where((name) => name.isNotEmpty)
+        .take(widget.maxParticipantCount)
+        .toList(growable: false);
+  }
+
+  int _parsedCountBeforeLimit(String rawText) {
+    final normalizedText = rawText.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+    final hasNewLine = normalizedText.contains('\n');
+    final hasComma = normalizedText.contains(',') || normalizedText.contains('、');
+    final hasTab = normalizedText.contains('\t');
+
+    final separator = hasNewLine
+        ? RegExp(r'\n+')
+        : hasComma
+            ? RegExp(r'[,、]+')
+            : hasTab
+                ? RegExp(r'\t+')
+                : RegExp(r'\n+');
+
+    return normalizedText
+        .split(separator)
+        .map((name) => name.trim())
+        .where((name) => name.isNotEmpty)
+        .length;
+  }
+
+  void _applyParticipantNames() {
+    final l10n = AppLocalizations.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    final rawText = _controller.text;
+    final parsedCountBeforeLimit = _parsedCountBeforeLimit(rawText);
+    final names = _parseParticipantNames(rawText);
+
+    messenger.hideCurrentSnackBar();
+
+    if (rawText.trim().isEmpty) {
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.participantNamesEmptyMessage)),
+      );
+      return;
+    }
+
+    if (names.length < 2) {
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.participantNamesTooFewMessage)),
+      );
+      return;
+    }
+
+    widget.onApply(names);
+
+    final message = parsedCountBeforeLimit > widget.maxParticipantCount
+        ? l10n.participantNamesTrimmedMessage(widget.maxParticipantCount)
+        : l10n.participantNamesAppliedMessage(names.length);
+
+    messenger.showSnackBar(
+      SnackBar(content: Text(message), duration: const Duration(seconds: 2)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return Card(
+      elevation: 0,
+      color: Colors.white,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.teamParticipantInputTitle,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Text(l10n.teamParticipantInputDescription),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _controller,
+              keyboardType: TextInputType.multiline,
+              minLines: 4,
+              maxLines: 8,
+              decoration: InputDecoration(
+                border: const OutlineInputBorder(),
+                labelText: l10n.teamParticipantInputLabel,
+                hintText: l10n.teamParticipantInputHint,
+                alignLabelWithHint: true,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.participantNameCountStatus(
+                widget.participantNames.length,
+                widget.participantCount,
+              ),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton.tonal(
+                onPressed: _applyParticipantNames,
+                child: Text(l10n.applyParticipantNamesButton),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/team_scheduler/presentation/widgets/team_participant_name_input_card.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_participant_name_input_card.dart
@@ -51,9 +51,11 @@ class _TeamParticipantNameInputCardState
   }
 
   List<String> _parseParticipantNames(String rawText) {
-    final normalizedText = rawText.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+    final normalizedText =
+        rawText.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
     final hasNewLine = normalizedText.contains('\n');
-    final hasComma = normalizedText.contains(',') || normalizedText.contains('、');
+    final hasComma =
+        normalizedText.contains(',') || normalizedText.contains('、');
     final hasTab = normalizedText.contains('\t');
 
     final separator = hasNewLine
@@ -73,9 +75,11 @@ class _TeamParticipantNameInputCardState
   }
 
   int _parsedCountBeforeLimit(String rawText) {
-    final normalizedText = rawText.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+    final normalizedText =
+        rawText.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
     final hasNewLine = normalizedText.contains('\n');
-    final hasComma = normalizedText.contains(',') || normalizedText.contains('、');
+    final hasComma =
+        normalizedText.contains(',') || normalizedText.contains('、');
     final hasTab = normalizedText.contains('\t');
 
     final separator = hasNewLine

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -89,9 +89,8 @@ extension TeamL10n on AppLocalizations {
   String get teamParticipantInputLabel =>
       _isJapanese ? '参加者名' : 'Participant names';
 
-  String get teamParticipantInputHint => _isJapanese
-      ? '例:\n田中\n佐藤\n鈴木'
-      : 'Example:\nAlex\nBlair\nCasey';
+  String get teamParticipantInputHint =>
+      _isJapanese ? '例:\n田中\n佐藤\n鈴木' : 'Example:\nAlex\nBlair\nCasey';
 
   String get applyParticipantNamesButton =>
       _isJapanese ? '参加者名を反映' : 'Apply participant names';
@@ -118,9 +117,8 @@ extension TeamL10n on AppLocalizations {
       ? '参加者名は2人以上入力してください。'
       : 'Enter at least two participant names.';
 
-  String get participantNamesEmptyMessage => _isJapanese
-      ? '参加者名を入力してください。'
-      : 'Enter participant names.';
+  String get participantNamesEmptyMessage =>
+      _isJapanese ? '参加者名を入力してください。' : 'Enter participant names.';
 
   String get resetTeamSetupButton => _isJapanese ? '入力項目のリセット' : 'Reset inputs';
 

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -79,6 +79,49 @@ extension TeamL10n on AppLocalizations {
       ? '余りがある場合は、一部チームの人数が1人少なくなります。'
       : 'If there is a remainder, some teams will have one fewer member.';
 
+  String get teamParticipantInputTitle =>
+      _isJapanese ? '参加者名の取り込み' : 'Participant names';
+
+  String get teamParticipantInputDescription => _isJapanese
+      ? '改行区切りで参加者名を貼り付けて反映できます。カンマ・読点・タブ区切りも簡易対応します。'
+      : 'Paste participant names separated by new lines. Commas and tabs are also supported in a simple form.';
+
+  String get teamParticipantInputLabel =>
+      _isJapanese ? '参加者名' : 'Participant names';
+
+  String get teamParticipantInputHint => _isJapanese
+      ? '例:\n田中\n佐藤\n鈴木'
+      : 'Example:\nAlex\nBlair\nCasey';
+
+  String get applyParticipantNamesButton =>
+      _isJapanese ? '参加者名を反映' : 'Apply participant names';
+
+  String participantNameCountStatus(int nameCount, int participantCount) {
+    return _isJapanese
+        ? '入力済み: $nameCount人 / 参加人数: $participantCount人'
+        : 'Names: $nameCount / Participants: $participantCount';
+  }
+
+  String participantNamesAppliedMessage(int nameCount) {
+    return _isJapanese
+        ? '$nameCount人の参加者名を反映しました'
+        : 'Applied $nameCount participant names.';
+  }
+
+  String participantNamesTrimmedMessage(int maxCount) {
+    return _isJapanese
+        ? '$maxCount人まで取り込みました。超過分は省略しました。'
+        : 'Applied up to $maxCount participant names. Extra names were omitted.';
+  }
+
+  String get participantNamesTooFewMessage => _isJapanese
+      ? '参加者名は2人以上入力してください。'
+      : 'Enter at least two participant names.';
+
+  String get participantNamesEmptyMessage => _isJapanese
+      ? '参加者名を入力してください。'
+      : 'Enter participant names.';
+
   String get resetTeamSetupButton => _isJapanese ? '入力項目のリセット' : 'Reset inputs';
 
   String get generateTeamScheduleButton =>


### PR DESCRIPTION
## Summary

Closes #97

チーム用セットアップ画面に、参加者名をまとめて入力・反映するためのテキスト入力欄を追加しました。

まずは必要最小限の取り込み機能に限定し、詳細な個別編集 UI や参加者一覧コピーは後続で扱います。

## Changes

* チーム用セットアップ画面に参加者名入力カードを追加
* 参加者名入力カードを `TeamParticipantNameInputCard` として widget 分離
* 参加者名の簡易パースに対応

  * 改行区切り
  * カンマ区切り
  * 読点区切り
  * タブ区切り
* 参加者名を反映したとき、参加人数を取り込み人数に同期
* 参加者名が50件を超える場合は先頭50件に丸める
* 2人未満の場合は反映しない
* `TeamSetupDraft` に `participantNames` を追加
* #97 用のチーム画面文言を `team_l10n.dart` に追加

## Deferred

* 参加者名の個別入力欄
* 参加者名の個別編集 UI
* 参加者名の削除 / 追加 UI
* 参加者一覧コピー
* 高度な CSV parser
* 外部ファイル import
* チーム所属の編集
* 採用後の再シャッフル

## Notes

参加者一覧コピーは、対戦表作成後に同じ参加者で再作成するときの導線として扱うため、今回のセットアップページには入れていません。

チーム用 l10n 文言は現在 `team_l10n.dart` の extension に追加しています。ARB 管理への移行は #105 で対応予定です。

## Checks

* [x] `dart format lib/`
* [x] `flutter analyze`
* [x] `flutter test`
* [x] 画面確認

## Docs / OpenAPI

* Docs 更新なし
* OpenAPI 更新なし

理由: 今回は web 側のチーム用セットアップ UI の参加者名入力追加のみで、backend API shape / OpenAPI はまだ接続対象外のため。
