### PR TITLE
📋 feat: add mock team schedule page and display name editing refs #98 refs #99

### DIFF
--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -18,6 +18,9 @@ class TeamSchedulePage extends StatefulWidget {
 
 class _TeamSchedulePageState extends State<TeamSchedulePage> {
   late final _MockTeamSchedule _schedule;
+  late String _eventTitle;
+  late Map<String, String> _teamDisplayNames;
+  late Map<String, String> _memberDisplayNames;
   late String _selectedTeamId;
   bool _initialized = false;
 
@@ -31,6 +34,13 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
 
     final l10n = AppLocalizations.of(context);
     _schedule = _buildMockSchedule(widget.draft, l10n);
+    _eventTitle = _schedule.eventTitle;
+    _teamDisplayNames = {
+      for (final team in _schedule.teams) team.id: team.displayName,
+    };
+    _memberDisplayNames = {
+      for (final member in _schedule.members) member.id: member.displayName,
+    };
     _selectedTeamId = _schedule.teams.first.id;
     _initialized = true;
   }
@@ -144,11 +154,15 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
   _MockTeam get _selectedTeam => _teamById[_selectedTeamId]!;
 
   String _teamName(String teamId) {
-    return _teamById[teamId]?.displayName ?? teamId;
+    return _teamDisplayNames[teamId] ??
+        _teamById[teamId]?.displayName ??
+        teamId;
   }
 
   String _memberName(String memberId) {
-    return _memberById[memberId]?.displayName ?? memberId;
+    return _memberDisplayNames[memberId] ??
+        _memberById[memberId]?.displayName ??
+        memberId;
   }
 
   String _matchTitle(BuildContext context, _MockTeamMatch match) {
@@ -168,6 +182,92 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     });
   }
 
+  Future<void> _editDisplayName({
+    required String dialogTitle,
+    required String initialValue,
+    required ValueChanged<String> onSaved,
+  }) async {
+    final l10n = AppLocalizations.of(context);
+    final controller = TextEditingController(text: initialValue);
+
+    final result = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(dialogTitle),
+          content: TextField(
+            controller: controller,
+            autofocus: true,
+            decoration: InputDecoration(
+              labelText: l10n.displayNameInputLabel,
+            ),
+            textInputAction: TextInputAction.done,
+            onSubmitted: (value) {
+              Navigator.of(context).pop(value);
+            },
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: Text(l10n.cancelDisplayNameEditButton),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(controller.text),
+              child: Text(l10n.saveDisplayNameEditButton),
+            ),
+          ],
+        );
+      },
+    );
+
+    controller.dispose();
+
+    final trimmed = result?.trim();
+    if (trimmed == null || trimmed.isEmpty) {
+      return;
+    }
+
+    setState(() {
+      onSaved(trimmed);
+    });
+  }
+
+  Future<void> _editEventTitle() async {
+    final l10n = AppLocalizations.of(context);
+
+    await _editDisplayName(
+      dialogTitle: l10n.editTeamScheduleEventTitleDialogTitle,
+      initialValue: _eventTitle,
+      onSaved: (value) {
+        _eventTitle = value;
+      },
+    );
+  }
+
+  Future<void> _editTeamName(String teamId) async {
+    final l10n = AppLocalizations.of(context);
+
+    await _editDisplayName(
+      dialogTitle: l10n.editTeamNameDialogTitle(_teamName(teamId)),
+      initialValue: _teamName(teamId),
+      onSaved: (value) {
+        _teamDisplayNames[teamId] = value;
+      },
+    );
+  }
+
+  Future<void> _editMemberName(String memberId) async {
+    final l10n = AppLocalizations.of(context);
+
+    await _editDisplayName(
+      dialogTitle: l10n.editTeamMemberNameDialogTitle(_memberName(memberId)),
+      initialValue: _memberName(memberId),
+      onSaved: (value) {
+        _memberDisplayNames[memberId] = value;
+      },
+    );
+  }
+
   Widget _buildHeaderCard(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
@@ -180,11 +280,23 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              _schedule.eventTitle,
-              style: theme.textTheme.headlineSmall?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Text(
+                    _eventTitle,
+                    style: theme.textTheme.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  tooltip: l10n.editTeamScheduleEventTitleTooltip,
+                  onPressed: _editEventTitle,
+                  icon: const Icon(Icons.edit_outlined),
+                ),
+              ],
             ),
             const SizedBox(height: 8),
             Text(
@@ -276,19 +388,57 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
               runSpacing: 8,
               children: [
                 for (final team in _schedule.teams)
-                  ChoiceChip(
-                    label: Text(
-                      l10n.teamChoiceLabel(
-                        teamName: _teamName(team.id),
-                        memberCount: team.memberIds.length,
-                      ),
-                    ),
-                    selected: team.id == _selectedTeamId,
-                    onSelected: (_) => _selectTeam(team.id),
-                  ),
+                  _buildTeamSelectionChip(context, team),
               ],
             ),
           ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTeamSelectionChip(BuildContext context, _MockTeam team) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final isSelected = team.id == _selectedTeamId;
+
+    return Card(
+      margin: EdgeInsets.zero,
+      elevation: 0,
+      color: isSelected ? Colors.blue.shade50 : Colors.white,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+        side: BorderSide(
+          color: isSelected ? Colors.blue.shade300 : Colors.grey.shade300,
+        ),
+      ),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(20),
+        onTap: () => _selectTeam(team.id),
+        child: Padding(
+          padding: const EdgeInsets.only(left: 12, right: 4),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (isSelected) ...[
+                const Icon(Icons.check, size: 18),
+                const SizedBox(width: 4),
+              ],
+              Text(
+                l10n.teamChoiceLabel(
+                  teamName: _teamName(team.id),
+                  memberCount: team.memberIds.length,
+                ),
+                style: theme.textTheme.bodyMedium,
+              ),
+              IconButton(
+                tooltip: l10n.editTeamNameTooltip,
+                visualDensity: VisualDensity.compact,
+                onPressed: () => _editTeamName(team.id),
+                icon: const Icon(Icons.edit_outlined, size: 18),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -320,6 +470,11 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
                 contentPadding: EdgeInsets.zero,
                 leading: const Icon(Icons.person_outline),
                 title: Text(_memberName(memberId)),
+                trailing: IconButton(
+                  tooltip: l10n.editTeamMemberNameTooltip,
+                  onPressed: () => _editMemberName(memberId),
+                  icon: const Icon(Icons.edit_outlined),
+                ),
               ),
           ],
         ),

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -1,0 +1,492 @@
+import 'package:flutter/material.dart';
+
+import 'models/team_setup_draft.dart';
+
+class TeamSchedulePage extends StatefulWidget {
+  const TeamSchedulePage({
+    required this.draft,
+    super.key,
+  });
+
+  final TeamSetupDraft draft;
+
+  @override
+  State<TeamSchedulePage> createState() => _TeamSchedulePageState();
+}
+
+class _TeamSchedulePageState extends State<TeamSchedulePage> {
+  late final _MockTeamSchedule _schedule;
+  late String _selectedTeamId;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _schedule = _buildMockSchedule(widget.draft);
+    _selectedTeamId = _schedule.teams.first.id;
+  }
+
+  _MockTeamSchedule _buildMockSchedule(TeamSetupDraft draft) {
+    final participantCount = draft.participantCount;
+    final preferredTeamSize =
+        draft.preferredTeamSize.clamp(1, participantCount);
+    final teamCount = (participantCount / preferredTeamSize)
+        .ceil()
+        .clamp(1, participantCount)
+        .toInt();
+
+    final memberNames = List<String>.generate(participantCount, (index) {
+      if (index < draft.participantNames.length) {
+        final name = draft.participantNames[index].trim();
+        if (name.isNotEmpty) {
+          return name;
+        }
+      }
+
+      return '参加者${index + 1}';
+    }, growable: false);
+
+    final members = List<_MockTeamMember>.generate(
+      participantCount,
+      (index) => _MockTeamMember(
+        id: 'member-${index + 1}',
+        displayName: memberNames[index],
+      ),
+      growable: false,
+    );
+
+    final baseMemberCount = participantCount ~/ teamCount;
+    final remainder = participantCount % teamCount;
+    var memberIndex = 0;
+
+    final teams = List<_MockTeam>.generate(teamCount, (teamIndex) {
+      final memberCount =
+          teamIndex < remainder ? baseMemberCount + 1 : baseMemberCount;
+      final memberIds = members
+          .skip(memberIndex)
+          .take(memberCount)
+          .map((member) => member.id)
+          .toList(growable: false);
+
+      memberIndex += memberCount;
+
+      return _MockTeam(
+        id: 'team-${teamIndex + 1}',
+        displayName: 'チーム${teamIndex + 1}',
+        memberIds: memberIds,
+      );
+    }, growable: false);
+
+    final effectiveTeamsPerMatch =
+        teamCount <= 1 ? 1 : draft.teamsPerMatch.clamp(2, teamCount).toInt();
+    final effectiveConcurrentMatchCount =
+        draft.concurrentMatchCount.clamp(1, teamCount).toInt();
+
+    final rounds = List<_MockTeamRound>.generate(6, (roundIndex) {
+      final matches = List<_MockTeamMatch>.generate(
+        effectiveConcurrentMatchCount,
+        (matchIndex) {
+          final startTeamIndex = (roundIndex *
+                      effectiveConcurrentMatchCount *
+                      effectiveTeamsPerMatch +
+                  matchIndex * effectiveTeamsPerMatch) %
+              teamCount;
+
+          final teamIds = List<String>.generate(
+            effectiveTeamsPerMatch,
+            (offset) => teams[(startTeamIndex + offset) % teamCount].id,
+            growable: false,
+          );
+
+          return _MockTeamMatch(
+            courtNo: matchIndex + 1,
+            teamIds: teamIds,
+          );
+        },
+        growable: false,
+      );
+
+      return _MockTeamRound(
+        roundNo: roundIndex + 1,
+        matches: matches,
+      );
+    }, growable: false);
+
+    return _MockTeamSchedule(
+      eventTitle: 'チーム練習会',
+      members: members,
+      teams: teams,
+      rounds: rounds,
+      nextRoundNo: 1,
+    );
+  }
+
+  Map<String, _MockTeam> get _teamById => {
+        for (final team in _schedule.teams) team.id: team,
+      };
+
+  Map<String, _MockTeamMember> get _memberById => {
+        for (final member in _schedule.members) member.id: member,
+      };
+
+  _MockTeam get _selectedTeam => _teamById[_selectedTeamId]!;
+
+  String _teamName(String teamId) {
+    return _teamById[teamId]?.displayName ?? teamId;
+  }
+
+  String _memberName(String memberId) {
+    return _memberById[memberId]?.displayName ?? memberId;
+  }
+
+  String _matchTitle(_MockTeamMatch match) {
+    final teamNames = match.teamIds.map(_teamName).toList(growable: false);
+
+    if (teamNames.length == 2) {
+      return '${teamNames[0]} vs ${teamNames[1]}';
+    }
+
+    return teamNames.join(' / ');
+  }
+
+  void _selectTeam(String teamId) {
+    setState(() {
+      _selectedTeamId = teamId;
+    });
+  }
+
+  Widget _buildHeaderCard(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      elevation: 0,
+      color: Colors.white,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              _schedule.eventTitle,
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '${_schedule.teams.length}チーム / '
+              '${_schedule.members.length}人 / '
+              '${widget.draft.concurrentMatchCount}同時進行',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'backend API 接続前のため、表示内容はセットアップ条件から作成したモックデータです。',
+              style: theme.textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNextRoundCard(BuildContext context) {
+    final theme = Theme.of(context);
+    final nextRound = _schedule.rounds.firstWhere(
+      (round) => round.roundNo == _schedule.nextRoundNo,
+      orElse: () => _schedule.rounds.first,
+    );
+
+    return Card(
+      elevation: 0,
+      color: Colors.blue.shade100,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '次の対戦',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '第${nextRound.roundNo}ラウンド',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 8),
+            for (final match in nextRound.matches) ...[
+              Text(
+                'コート${match.courtNo}: ${_matchTitle(match)}',
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              if (match != nextRound.matches.last) const SizedBox(height: 4),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTeamListCard(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      elevation: 0,
+      color: Colors.white,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'チーム一覧',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final team in _schedule.teams)
+                  ChoiceChip(
+                    label: Text(
+                      '${team.displayName} (${team.memberIds.length}人)',
+                    ),
+                    selected: team.id == _selectedTeamId,
+                    onSelected: (_) => _selectTeam(team.id),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSelectedTeamMembersCard(BuildContext context) {
+    final theme = Theme.of(context);
+    final team = _selectedTeam;
+
+    return Card(
+      elevation: 0,
+      color: Colors.white,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '${team.displayName} のメンバー',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 12),
+            for (final memberId in team.memberIds)
+              ListTile(
+                dense: true,
+                contentPadding: EdgeInsets.zero,
+                leading: const Icon(Icons.person_outline),
+                title: Text(_memberName(memberId)),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRoundList(BuildContext context) {
+    return Column(
+      children: [
+        for (final round in _schedule.rounds) ...[
+          _buildRoundCard(context, round),
+          if (round != _schedule.rounds.last) const SizedBox(height: 12),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildRoundCard(BuildContext context, _MockTeamRound round) {
+    final theme = Theme.of(context);
+    final isNextRound = round.roundNo == _schedule.nextRoundNo;
+
+    return Card(
+      elevation: 0,
+      color: isNextRound ? Colors.blue.shade50 : Colors.white,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(
+          color: isNextRound ? Colors.blue.shade300 : Colors.transparent,
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text(
+                  '第${round.roundNo}ラウンド',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                if (isNextRound) ...[
+                  const SizedBox(width: 8),
+                  Chip(
+                    label: const Text('次の対戦'),
+                    visualDensity: VisualDensity.compact,
+                    backgroundColor: Colors.blue.shade100,
+                  ),
+                ],
+              ],
+            ),
+            const SizedBox(height: 12),
+            for (final match in round.matches) ...[
+              _buildMatchRow(context, match),
+              if (match != round.matches.last) const Divider(height: 24),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMatchRow(BuildContext context, _MockTeamMatch match) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'コート${match.courtNo}',
+          style: theme.textTheme.labelLarge,
+        ),
+        const SizedBox(height: 6),
+        Text(
+          _matchTitle(match),
+          style: theme.textTheme.bodyLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            for (final teamId in match.teamIds)
+              ActionChip(
+                label: Text(_teamName(teamId)),
+                avatar: teamId == _selectedTeamId
+                    ? const Icon(Icons.check, size: 18)
+                    : null,
+                onPressed: () => _selectTeam(teamId),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: Theme.of(context).copyWith(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        scaffoldBackgroundColor: Colors.blue.shade50,
+      ),
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('チーム対戦表'),
+          backgroundColor: Colors.blue.shade100,
+          foregroundColor: Colors.black87,
+          surfaceTintColor: Colors.transparent,
+          elevation: 0,
+        ),
+        body: SafeArea(
+          child: ListView(
+            padding: const EdgeInsets.all(12),
+            children: [
+              _buildHeaderCard(context),
+              const SizedBox(height: 12),
+              _buildNextRoundCard(context),
+              const SizedBox(height: 12),
+              _buildTeamListCard(context),
+              const SizedBox(height: 12),
+              _buildSelectedTeamMembersCard(context),
+              const SizedBox(height: 16),
+              _buildRoundList(context),
+              const SizedBox(height: 80),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MockTeamSchedule {
+  const _MockTeamSchedule({
+    required this.eventTitle,
+    required this.members,
+    required this.teams,
+    required this.rounds,
+    required this.nextRoundNo,
+  });
+
+  final String eventTitle;
+  final List<_MockTeamMember> members;
+  final List<_MockTeam> teams;
+  final List<_MockTeamRound> rounds;
+  final int nextRoundNo;
+}
+
+class _MockTeamMember {
+  const _MockTeamMember({
+    required this.id,
+    required this.displayName,
+  });
+
+  final String id;
+  final String displayName;
+}
+
+class _MockTeam {
+  const _MockTeam({
+    required this.id,
+    required this.displayName,
+    required this.memberIds,
+  });
+
+  final String id;
+  final String displayName;
+  final List<String> memberIds;
+}
+
+class _MockTeamRound {
+  const _MockTeamRound({
+    required this.roundNo,
+    required this.matches,
+  });
+
+  final int roundNo;
+  final List<_MockTeamMatch> matches;
+}
+
+class _MockTeamMatch {
+  const _MockTeamMatch({
+    required this.courtNo,
+    required this.teamIds,
+  });
+
+  final int courtNo;
+  final List<String> teamIds;
+}

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../../l10n/app_localizations.dart';
+import '../../../l10n/team_l10n.dart';
 import 'models/team_setup_draft.dart';
 
 class TeamSchedulePage extends StatefulWidget {
@@ -17,16 +19,26 @@ class TeamSchedulePage extends StatefulWidget {
 class _TeamSchedulePageState extends State<TeamSchedulePage> {
   late final _MockTeamSchedule _schedule;
   late String _selectedTeamId;
+  bool _initialized = false;
 
   @override
-  void initState() {
-    super.initState();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
 
-    _schedule = _buildMockSchedule(widget.draft);
+    if (_initialized) {
+      return;
+    }
+
+    final l10n = AppLocalizations.of(context);
+    _schedule = _buildMockSchedule(widget.draft, l10n);
     _selectedTeamId = _schedule.teams.first.id;
+    _initialized = true;
   }
 
-  _MockTeamSchedule _buildMockSchedule(TeamSetupDraft draft) {
+  _MockTeamSchedule _buildMockSchedule(
+    TeamSetupDraft draft,
+    AppLocalizations l10n,
+  ) {
     final participantCount = draft.participantCount;
     final preferredTeamSize =
         draft.preferredTeamSize.clamp(1, participantCount);
@@ -43,7 +55,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         }
       }
 
-      return '参加者${index + 1}';
+      return l10n.defaultTeamMemberName(index + 1);
     }, growable: false);
 
     final members = List<_MockTeamMember>.generate(
@@ -72,7 +84,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
 
       return _MockTeam(
         id: 'team-${teamIndex + 1}',
-        displayName: 'チーム${teamIndex + 1}',
+        displayName: l10n.defaultTeamName(teamIndex + 1),
         memberIds: memberIds,
       );
     }, growable: false);
@@ -113,7 +125,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     }, growable: false);
 
     return _MockTeamSchedule(
-      eventTitle: 'チーム練習会',
+      eventTitle: l10n.defaultTeamScheduleEventTitle,
       members: members,
       teams: teams,
       rounds: rounds,
@@ -139,14 +151,15 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     return _memberById[memberId]?.displayName ?? memberId;
   }
 
-  String _matchTitle(_MockTeamMatch match) {
+  String _matchTitle(BuildContext context, _MockTeamMatch match) {
+    final l10n = AppLocalizations.of(context);
     final teamNames = match.teamIds.map(_teamName).toList(growable: false);
 
     if (teamNames.length == 2) {
-      return '${teamNames[0]} vs ${teamNames[1]}';
+      return teamNames.join(l10n.teamMatchVsSeparator);
     }
 
-    return teamNames.join(' / ');
+    return teamNames.join(l10n.teamMatchGroupSeparator);
   }
 
   void _selectTeam(String teamId) {
@@ -157,6 +170,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
 
   Widget _buildHeaderCard(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
 
     return Card(
       elevation: 0,
@@ -174,14 +188,16 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
             ),
             const SizedBox(height: 8),
             Text(
-              '${_schedule.teams.length}チーム / '
-              '${_schedule.members.length}人 / '
-              '${widget.draft.concurrentMatchCount}同時進行',
+              l10n.teamScheduleSummary(
+                teamCount: _schedule.teams.length,
+                memberCount: _schedule.members.length,
+                concurrentMatchCount: widget.draft.concurrentMatchCount,
+              ),
               style: theme.textTheme.bodyMedium,
             ),
             const SizedBox(height: 8),
             Text(
-              'backend API 接続前のため、表示内容はセットアップ条件から作成したモックデータです。',
+              l10n.teamScheduleMockDataNotice,
               style: theme.textTheme.bodySmall,
             ),
           ],
@@ -192,6 +208,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
 
   Widget _buildNextRoundCard(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
     final nextRound = _schedule.rounds.firstWhere(
       (round) => round.roundNo == _schedule.nextRoundNo,
       orElse: () => _schedule.rounds.first,
@@ -206,20 +223,23 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              '次の対戦',
+              l10n.nextTeamMatchTitle,
               style: theme.textTheme.titleMedium?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
             ),
             const SizedBox(height: 8),
             Text(
-              '第${nextRound.roundNo}ラウンド',
+              l10n.teamRoundTitle(nextRound.roundNo),
               style: theme.textTheme.bodyMedium,
             ),
             const SizedBox(height: 8),
             for (final match in nextRound.matches) ...[
               Text(
-                'コート${match.courtNo}: ${_matchTitle(match)}',
+                l10n.teamCourtMatchTitle(
+                  courtNo: match.courtNo,
+                  matchTitle: _matchTitle(context, match),
+                ),
                 style: theme.textTheme.bodyLarge?.copyWith(
                   fontWeight: FontWeight.w600,
                 ),
@@ -234,6 +254,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
 
   Widget _buildTeamListCard(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
 
     return Card(
       elevation: 0,
@@ -244,7 +265,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'チーム一覧',
+              l10n.teamListTitle,
               style: theme.textTheme.titleMedium?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
@@ -257,7 +278,10 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
                 for (final team in _schedule.teams)
                   ChoiceChip(
                     label: Text(
-                      '${team.displayName} (${team.memberIds.length}人)',
+                      l10n.teamChoiceLabel(
+                        teamName: _teamName(team.id),
+                        memberCount: team.memberIds.length,
+                      ),
                     ),
                     selected: team.id == _selectedTeamId,
                     onSelected: (_) => _selectTeam(team.id),
@@ -272,6 +296,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
 
   Widget _buildSelectedTeamMembersCard(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
     final team = _selectedTeam;
 
     return Card(
@@ -283,7 +308,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              '${team.displayName} のメンバー',
+              l10n.selectedTeamMembersTitle(_teamName(team.id)),
               style: theme.textTheme.titleMedium?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
@@ -315,6 +340,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
 
   Widget _buildRoundCard(BuildContext context, _MockTeamRound round) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
     final isNextRound = round.roundNo == _schedule.nextRoundNo;
 
     return Card(
@@ -334,7 +360,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
             Row(
               children: [
                 Text(
-                  '第${round.roundNo}ラウンド',
+                  l10n.teamRoundTitle(round.roundNo),
                   style: theme.textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),
@@ -342,7 +368,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
                 if (isNextRound) ...[
                   const SizedBox(width: 8),
                   Chip(
-                    label: const Text('次の対戦'),
+                    label: Text(l10n.nextTeamMatchTitle),
                     visualDensity: VisualDensity.compact,
                     backgroundColor: Colors.blue.shade100,
                   ),
@@ -362,17 +388,18 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
 
   Widget _buildMatchRow(BuildContext context, _MockTeamMatch match) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'コート${match.courtNo}',
+          l10n.teamCourtTitle(match.courtNo),
           style: theme.textTheme.labelLarge,
         ),
         const SizedBox(height: 6),
         Text(
-          _matchTitle(match),
+          _matchTitle(context, match),
           style: theme.textTheme.bodyLarge?.copyWith(
             fontWeight: FontWeight.w600,
           ),
@@ -398,6 +425,8 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return Theme(
       data: Theme.of(context).copyWith(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
@@ -405,7 +434,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       ),
       child: Scaffold(
         appBar: AppBar(
-          title: const Text('チーム対戦表'),
+          title: Text(l10n.teamScheduleTitle),
           backgroundColor: Colors.blue.shade100,
           foregroundColor: Colors.black87,
           surfaceTintColor: Colors.transparent,

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
 
+import 'team_schedule_page.dart';
 import 'models/team_setup_draft.dart';
 import 'widgets/team_participant_name_input_card.dart';
 import 'widgets/team_setup_number_field.dart';
@@ -162,15 +163,11 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
   }
 
   void _submitMock() {
-    final l10n = AppLocalizations.of(context);
     debugPrint(_draft.toString());
 
-    final messenger = ScaffoldMessenger.of(context);
-    messenger.hideCurrentSnackBar();
-    messenger.showSnackBar(
-      SnackBar(
-        content: Text(l10n.teamSetupCreatedMessage),
-        duration: const Duration(seconds: 2),
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (context) => TeamSchedulePage(draft: _draft),
       ),
     );
   }

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -197,4 +197,29 @@ extension TeamL10n on AppLocalizations {
   String get teamMatchVsSeparator => ' vs ';
 
   String get teamMatchGroupSeparator => ' / ';
+
+  String get editTeamScheduleEventTitleTooltip =>
+      _isJapanese ? 'イベントタイトルを編集' : 'Edit event title';
+
+  String get editTeamNameTooltip => _isJapanese ? 'チーム名を編集' : 'Edit team name';
+
+  String get editTeamMemberNameTooltip =>
+      _isJapanese ? 'メンバー表示名を編集' : 'Edit member display name';
+
+  String get editTeamScheduleEventTitleDialogTitle =>
+      _isJapanese ? 'イベントタイトルを編集' : 'Edit event title';
+
+  String editTeamNameDialogTitle(String teamName) {
+    return _isJapanese ? '$teamName を編集' : 'Edit $teamName';
+  }
+
+  String editTeamMemberNameDialogTitle(String memberName) {
+    return _isJapanese ? '$memberName を編集' : 'Edit $memberName';
+  }
+
+  String get displayNameInputLabel => _isJapanese ? '表示名' : 'Display name';
+
+  String get cancelDisplayNameEditButton => _isJapanese ? 'キャンセル' : 'Cancel';
+
+  String get saveDisplayNameEditButton => _isJapanese ? '保存' : 'Save';
 }

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -134,4 +134,67 @@ extension TeamL10n on AppLocalizations {
   String get teamSetupCreatedMessage => _isJapanese
       ? 'チーム用セットアップ条件を作成しました'
       : 'Team setup conditions were created.';
+
+  String get teamScheduleTitle => _isJapanese ? 'チーム対戦表' : 'Team match table';
+
+  String get defaultTeamScheduleEventTitle =>
+      _isJapanese ? 'チーム練習会' : 'Team practice';
+
+  String defaultTeamMemberName(int memberNo) {
+    return _isJapanese ? '参加者$memberNo' : 'Participant $memberNo';
+  }
+
+  String defaultTeamName(int teamNo) {
+    return _isJapanese ? 'チーム$teamNo' : 'Team $teamNo';
+  }
+
+  String teamScheduleSummary({
+    required int teamCount,
+    required int memberCount,
+    required int concurrentMatchCount,
+  }) {
+    return _isJapanese
+        ? '$teamCountチーム / $memberCount人 / $concurrentMatchCount同時進行'
+        : '$teamCount teams / $memberCount members / $concurrentMatchCount simultaneous matches';
+  }
+
+  String get teamScheduleMockDataNotice => _isJapanese
+      ? 'backend API 接続前のため、表示内容はセットアップ条件から作成したモックデータです。'
+      : 'The backend API is not connected yet, so this screen shows mock data created from the setup conditions.';
+
+  String get nextTeamMatchTitle => _isJapanese ? '次の対戦' : 'Next match';
+
+  String teamRoundTitle(int roundNo) {
+    return _isJapanese ? '第$roundNoラウンド' : 'Round $roundNo';
+  }
+
+  String teamCourtTitle(int courtNo) {
+    return _isJapanese ? 'コート$courtNo' : 'Court $courtNo';
+  }
+
+  String teamCourtMatchTitle({
+    required int courtNo,
+    required String matchTitle,
+  }) {
+    return '${teamCourtTitle(courtNo)}: $matchTitle';
+  }
+
+  String get teamListTitle => _isJapanese ? 'チーム一覧' : 'Teams';
+
+  String teamChoiceLabel({
+    required String teamName,
+    required int memberCount,
+  }) {
+    return _isJapanese
+        ? '$teamName ($memberCount人)'
+        : '$teamName ($memberCount members)';
+  }
+
+  String selectedTeamMembersTitle(String teamName) {
+    return _isJapanese ? '$teamName のメンバー' : '$teamName members';
+  }
+
+  String get teamMatchVsSeparator => ' vs ';
+
+  String get teamMatchGroupSeparator => ' / ';
 }


### PR DESCRIPTION
## 概要

チーム用セットアップ画面から遷移できる、チーム用対戦表画面を追加しました。

現時点では backend API 接続前のため、セットアップ条件から作成したモックデータを表示します。
また、チーム用対戦表画面上で、イベントタイトル・チーム名・メンバー表示名を編集できるようにしました。

## 対応 Issue

Closes #98
Closes #99

## 変更内容

* チーム用対戦表画面を追加
* `/team` のセットアップ画面からチーム用対戦表画面へ遷移
* セットアップ条件をもとにしたモックチーム対戦表を生成
* チームカード一覧を表示
* チーム選択状態を追加
* 選択チームの所属メンバー一覧を表示
* ラウンドカード一覧を表示
* 2チーム対戦は `A vs B` 形式で表示
* 複数チーム対戦は `A / B / C` 形式で表示
* 次対戦ラウンドをハイライト表示
* イベントタイトルを編集できるように追加
* チーム名を編集できるように追加
* メンバー表示名を編集できるように追加
* チーム用対戦表画面の文言を `team_l10n.dart` に追加

## やらないこと

以下は今回の PR では扱いません。

* backend API 接続
* Firestore 保存
* 共有 URL
* TOP / メニューから `/team` への公開導線追加
* チーム所属変更
* チーム再シャッフル
* ラウンドごとのチーム再編成
* 対戦結果入力
* チーム用対戦表一覧画面
* ARB 管理への移行

## 実装メモ

表示名編集では、イベントタイトル・チーム名・メンバー表示名のみを state として更新します。

チーム所属は `memberIds` の関係を固定したままにしており、編集 UI からチームへの追加・削除・移動はできないようにしています。

## 確認内容

* [x] `/team` を開ける
* [x] セットアップ画面からチーム用対戦表画面へ進める
* [x] チーム一覧が表示される
* [x] チームを選択すると所属メンバー一覧が切り替わる
* [x] ラウンドカード内のチームを選択しても選択チームが切り替わる
* [x] 次対戦がハイライト表示される
* [x] イベントタイトルを編集できる
* [x] チーム名を編集できる
* [x] メンバー表示名を編集できる
* [x] チーム所属変更 UI がない
* [x] `dart format lib/`
* [x] `flutter analyze`
* [x] `flutter test`

## 補足

チーム用対戦表一覧画面は #100 として作成済みですが、生成済みチーム対戦表の保存・取得 shape が固まってから着手する方針のため、今回は保留します。
