### PR TITLE
🔌 feat: Connect team schedule page to backend API refs #102

### DIFF
--- a/lib/features/team_scheduler/application/team_generated_schedule_service.dart
+++ b/lib/features/team_scheduler/application/team_generated_schedule_service.dart
@@ -1,0 +1,60 @@
+import 'package:srp_lanske/features/doubles_scheduler/infrastructure/generated_schedule_api_client.dart';
+
+import '../domain/team_generated_schedule.dart';
+import '../presentation/models/team_setup_draft.dart';
+
+class TeamGeneratedScheduleService {
+  TeamGeneratedScheduleService(this._apiClient);
+
+  static const int fixedRoundCount = 5;
+
+  final GeneratedScheduleApiClient _apiClient;
+
+  Future<TeamGeneratedSchedule> generateFromDraft(TeamSetupDraft draft) async {
+    final response = await _apiClient.generate(
+      body: buildGenerateRequest(draft),
+    );
+
+    return TeamGeneratedSchedule.fromJson(response);
+  }
+
+  Map<String, dynamic> buildGenerateRequest(TeamSetupDraft draft) {
+    final participantCount = draft.participantCount.clamp(2, 50).toInt();
+    final maxTargetTeamSize = (participantCount - 1).clamp(1, participantCount);
+    final targetTeamSize =
+        draft.preferredTeamSize.clamp(1, maxTargetTeamSize).toInt();
+    final teamCount = (participantCount / targetTeamSize)
+        .ceil()
+        .clamp(2, participantCount)
+        .toInt();
+    final teamsPerMatch = draft.teamsPerMatch.clamp(2, teamCount).toInt();
+    final maxConcurrentMatchCount =
+        (teamCount ~/ teamsPerMatch).clamp(1, teamCount).toInt();
+    final concurrentMatchCount =
+        draft.concurrentMatchCount.clamp(1, maxConcurrentMatchCount).toInt();
+    final activeTeamCountPerRound = concurrentMatchCount * teamsPerMatch;
+
+    return <String, dynamic>{
+      'schedule_type': 'team',
+      'courts': concurrentMatchCount,
+      'round_count': fixedRoundCount,
+      'players': List<Map<String, dynamic>>.generate(
+        participantCount,
+        (index) => <String, dynamic>{
+          'player_slot': index + 1,
+          'pot_number': 1,
+        },
+        growable: false,
+      ),
+      'team_schedule': <String, dynamic>{
+        'team_count': teamCount,
+        'target_team_size': targetTeamSize,
+        'teams_per_match': teamsPerMatch,
+        'active_team_count_per_round': activeTeamCountPerRound,
+      },
+      'constraints': const <String, dynamic>{
+        'randomize': true,
+      },
+    };
+  }
+}

--- a/lib/features/team_scheduler/domain/team_generated_schedule.dart
+++ b/lib/features/team_scheduler/domain/team_generated_schedule.dart
@@ -1,0 +1,255 @@
+class TeamGeneratedSchedule {
+  const TeamGeneratedSchedule({
+    required this.generatedScheduleId,
+    required this.scheduleType,
+    required this.status,
+    required this.algorithmVersion,
+    required this.courts,
+    required this.roundCount,
+    required this.playerCount,
+    required this.teamCount,
+    required this.teamsPerMatch,
+    required this.activeTeamCountPerRound,
+    required this.players,
+    required this.teams,
+    required this.assignments,
+    required this.rounds,
+    required this.inspection,
+    required this.score,
+    required this.warnings,
+    required this.rawJson,
+  });
+
+  factory TeamGeneratedSchedule.fromJson(Map<String, dynamic> json) {
+    return TeamGeneratedSchedule(
+      generatedScheduleId: _readString(json, 'generated_schedule_id'),
+      scheduleType: _readString(json, 'schedule_type'),
+      status: _readString(json, 'status'),
+      algorithmVersion: _readString(json, 'algorithm_version'),
+      courts: _readInt(json, 'courts'),
+      roundCount: _readInt(json, 'round_count'),
+      playerCount: _readInt(json, 'player_count'),
+      teamCount: _readInt(json, 'team_count'),
+      teamsPerMatch: _readInt(json, 'teams_per_match'),
+      activeTeamCountPerRound: _readInt(
+        json,
+        'active_team_count_per_round',
+      ),
+      players: _readObjectList(json, 'players')
+          .map(TeamGeneratedPlayer.fromJson)
+          .toList(growable: false),
+      teams: _readObjectList(json, 'teams')
+          .map(TeamGeneratedTeam.fromJson)
+          .toList(growable: false),
+      assignments: _readObjectList(json, 'assignments')
+          .map(TeamGeneratedAssignment.fromJson)
+          .toList(growable: false),
+      rounds: _readObjectList(json, 'rounds')
+          .map(TeamGeneratedRound.fromJson)
+          .toList(growable: false),
+      inspection: _readObject(json, 'inspection'),
+      score: _readObject(json, 'score'),
+      warnings: _readStringList(json, 'warnings'),
+      rawJson: Map<String, dynamic>.unmodifiable(json),
+    );
+  }
+
+  final String generatedScheduleId;
+  final String scheduleType;
+  final String status;
+  final String algorithmVersion;
+  final int courts;
+  final int roundCount;
+  final int playerCount;
+  final int teamCount;
+  final int teamsPerMatch;
+  final int activeTeamCountPerRound;
+  final List<TeamGeneratedPlayer> players;
+  final List<TeamGeneratedTeam> teams;
+  final List<TeamGeneratedAssignment> assignments;
+  final List<TeamGeneratedRound> rounds;
+  final Map<String, dynamic> inspection;
+  final Map<String, dynamic> score;
+  final List<String> warnings;
+  final Map<String, dynamic> rawJson;
+}
+
+class TeamGeneratedPlayer {
+  const TeamGeneratedPlayer({
+    required this.playerSlot,
+    required this.potNumber,
+  });
+
+  factory TeamGeneratedPlayer.fromJson(Map<String, dynamic> json) {
+    return TeamGeneratedPlayer(
+      playerSlot: _readInt(json, 'player_slot'),
+      potNumber: _readInt(json, 'pot_number'),
+    );
+  }
+
+  final int playerSlot;
+  final int potNumber;
+}
+
+class TeamGeneratedTeam {
+  const TeamGeneratedTeam({
+    required this.teamSlot,
+    required this.memberPlayerSlots,
+  });
+
+  factory TeamGeneratedTeam.fromJson(Map<String, dynamic> json) {
+    return TeamGeneratedTeam(
+      teamSlot: _readInt(json, 'team_slot'),
+      memberPlayerSlots: _readIntList(json, 'member_player_slots'),
+    );
+  }
+
+  final int teamSlot;
+  final List<int> memberPlayerSlots;
+}
+
+class TeamGeneratedAssignment {
+  const TeamGeneratedAssignment({
+    required this.playerSlot,
+    required this.teamSlot,
+  });
+
+  factory TeamGeneratedAssignment.fromJson(Map<String, dynamic> json) {
+    return TeamGeneratedAssignment(
+      playerSlot: _readInt(json, 'player_slot'),
+      teamSlot: _readInt(json, 'team_slot'),
+    );
+  }
+
+  final int playerSlot;
+  final int teamSlot;
+}
+
+class TeamGeneratedRound {
+  const TeamGeneratedRound({
+    required this.roundNo,
+    required this.courts,
+  });
+
+  factory TeamGeneratedRound.fromJson(Map<String, dynamic> json) {
+    final courts = _readObjectList(json, 'courts');
+    final fallbackMatches =
+        courts.isEmpty ? _readObjectList(json, 'matches') : courts;
+
+    return TeamGeneratedRound(
+      roundNo: _readInt(json, 'round_no'),
+      courts: fallbackMatches
+          .map(TeamGeneratedRoundCourt.fromJson)
+          .toList(growable: false),
+    );
+  }
+
+  final int roundNo;
+  final List<TeamGeneratedRoundCourt> courts;
+}
+
+class TeamGeneratedRoundCourt {
+  const TeamGeneratedRoundCourt({
+    required this.courtNo,
+    required this.matchNo,
+    required this.teamSlots,
+  });
+
+  factory TeamGeneratedRoundCourt.fromJson(Map<String, dynamic> json) {
+    return TeamGeneratedRoundCourt(
+      courtNo: _readInt(json, 'court_no'),
+      matchNo: _readInt(json, 'match_no'),
+      teamSlots: _readIntList(json, 'team_slots'),
+    );
+  }
+
+  final int courtNo;
+  final int matchNo;
+  final List<int> teamSlots;
+}
+
+String _readString(
+  Map<String, dynamic> json,
+  String key, {
+  String defaultValue = '',
+}) {
+  final value = json[key];
+  if (value == null) {
+    return defaultValue;
+  }
+
+  return value.toString();
+}
+
+int _readInt(
+  Map<String, dynamic> json,
+  String key, {
+  int defaultValue = 0,
+}) {
+  return _tryReadInt(json[key]) ?? defaultValue;
+}
+
+int? _tryReadInt(dynamic value) {
+  if (value is int) {
+    return value;
+  }
+
+  if (value is num) {
+    return value.toInt();
+  }
+
+  if (value is String) {
+    return int.tryParse(value);
+  }
+
+  return null;
+}
+
+List<int> _readIntList(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value is! List) {
+    return const [];
+  }
+
+  final result = <int>[];
+  for (final item in value) {
+    final parsed = _tryReadInt(item);
+    if (parsed != null) {
+      result.add(parsed);
+    }
+  }
+
+  return List<int>.unmodifiable(result);
+}
+
+List<String> _readStringList(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value is! List) {
+    return const [];
+  }
+
+  return List<String>.unmodifiable(value.map((item) => item.toString()));
+}
+
+Map<String, dynamic> _readObject(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value is Map) {
+    return Map<String, dynamic>.from(value);
+  }
+
+  return const <String, dynamic>{};
+}
+
+List<Map<String, dynamic>> _readObjectList(
+  Map<String, dynamic> json,
+  String key,
+) {
+  final value = json[key];
+  if (value is! List) {
+    return const [];
+  }
+
+  return value.whereType<Map>().map((item) {
+    return Map<String, dynamic>.from(item);
+  }).toList(growable: false);
+}

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:srp_lanske/app/config/app_config.dart';
+import 'package:srp_lanske/features/doubles_scheduler/infrastructure/generated_schedule_api_client.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
 
-import '../../../l10n/app_localizations.dart';
-import '../../../l10n/team_l10n.dart';
+import '../application/team_generated_schedule_service.dart';
+import '../domain/team_generated_schedule.dart';
 import 'models/team_setup_draft.dart';
 
 class TeamSchedulePage extends StatefulWidget {
@@ -17,157 +20,246 @@ class TeamSchedulePage extends StatefulWidget {
 }
 
 class _TeamSchedulePageState extends State<TeamSchedulePage> {
-  late final _MockTeamSchedule _schedule;
-  late String _eventTitle;
-  late Map<String, String> _teamDisplayNames;
-  late Map<String, String> _memberDisplayNames;
-  late String _selectedTeamId;
-  bool _initialized = false;
+  late final TeamGeneratedScheduleService _service;
+
+  _TeamScheduleViewData? _schedule;
+  String? _errorMessage;
+  bool _isLoading = true;
+
+  String _eventTitle = '';
+  Map<int, String> _teamDisplayNames = const {};
+  Map<int, String> _memberDisplayNames = const {};
+  int? _selectedTeamSlot;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void initState() {
+    super.initState();
 
-    if (_initialized) {
-      return;
-    }
-
-    final l10n = AppLocalizations.of(context);
-    _schedule = _buildMockSchedule(widget.draft, l10n);
-    _eventTitle = _schedule.eventTitle;
-    _teamDisplayNames = {
-      for (final team in _schedule.teams) team.id: team.displayName,
-    };
-    _memberDisplayNames = {
-      for (final member in _schedule.members) member.id: member.displayName,
-    };
-    _selectedTeamId = _schedule.teams.first.id;
-    _initialized = true;
-  }
-
-  _MockTeamSchedule _buildMockSchedule(
-    TeamSetupDraft draft,
-    AppLocalizations l10n,
-  ) {
-    final participantCount = draft.participantCount;
-    final preferredTeamSize =
-        draft.preferredTeamSize.clamp(1, participantCount);
-    final teamCount = (participantCount / preferredTeamSize)
-        .ceil()
-        .clamp(1, participantCount)
-        .toInt();
-
-    final memberNames = List<String>.generate(participantCount, (index) {
-      if (index < draft.participantNames.length) {
-        final name = draft.participantNames[index].trim();
-        if (name.isNotEmpty) {
-          return name;
-        }
-      }
-
-      return l10n.defaultTeamMemberName(index + 1);
-    }, growable: false);
-
-    final members = List<_MockTeamMember>.generate(
-      participantCount,
-      (index) => _MockTeamMember(
-        id: 'member-${index + 1}',
-        displayName: memberNames[index],
+    _service = TeamGeneratedScheduleService(
+      GeneratedScheduleApiClient(
+        baseUrl: AppConfig.coreApiBaseUrl,
       ),
-      growable: false,
     );
 
-    final baseMemberCount = participantCount ~/ teamCount;
-    final remainder = participantCount % teamCount;
-    var memberIndex = 0;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _generateSchedule();
+      }
+    });
+  }
 
-    final teams = List<_MockTeam>.generate(teamCount, (teamIndex) {
-      final memberCount =
-          teamIndex < remainder ? baseMemberCount + 1 : baseMemberCount;
-      final memberIds = members
-          .skip(memberIndex)
-          .take(memberCount)
-          .map((member) => member.id)
-          .toList(growable: false);
+  Map<int, _TeamViewData> get _teamBySlot {
+    final schedule = _schedule;
+    if (schedule == null) {
+      return const {};
+    }
 
-      memberIndex += memberCount;
+    return {
+      for (final team in schedule.teams) team.teamSlot: team,
+    };
+  }
 
-      return _MockTeam(
-        id: 'team-${teamIndex + 1}',
-        displayName: l10n.defaultTeamName(teamIndex + 1),
-        memberIds: memberIds,
-      );
-    }, growable: false);
+  Map<int, _TeamMemberViewData> get _memberBySlot {
+    final schedule = _schedule;
+    if (schedule == null) {
+      return const {};
+    }
 
-    final effectiveTeamsPerMatch =
-        teamCount <= 1 ? 1 : draft.teamsPerMatch.clamp(2, teamCount).toInt();
-    final effectiveConcurrentMatchCount =
-        draft.concurrentMatchCount.clamp(1, teamCount).toInt();
+    return {
+      for (final member in schedule.members) member.playerSlot: member,
+    };
+  }
 
-    final rounds = List<_MockTeamRound>.generate(6, (roundIndex) {
-      final matches = List<_MockTeamMatch>.generate(
-        effectiveConcurrentMatchCount,
-        (matchIndex) {
-          final startTeamIndex = (roundIndex *
-                      effectiveConcurrentMatchCount *
-                      effectiveTeamsPerMatch +
-                  matchIndex * effectiveTeamsPerMatch) %
-              teamCount;
+  _TeamViewData get _selectedTeam {
+    final schedule = _schedule!;
+    final selectedTeamSlot = _selectedTeamSlot;
 
-          final teamIds = List<String>.generate(
-            effectiveTeamsPerMatch,
-            (offset) => teams[(startTeamIndex + offset) % teamCount].id,
+    if (selectedTeamSlot == null) {
+      return schedule.teams.first;
+    }
+
+    return _teamBySlot[selectedTeamSlot] ?? schedule.teams.first;
+  }
+
+  Future<void> _generateSchedule() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final generated = await _service.generateFromDraft(widget.draft);
+
+      if (!mounted) {
+        return;
+      }
+
+      final l10n = AppLocalizations.of(context);
+      final schedule = _buildViewData(generated, l10n);
+
+      setState(() {
+        _schedule = schedule;
+        _eventTitle = schedule.eventTitle;
+        _teamDisplayNames = {
+          for (final team in schedule.teams) team.teamSlot: team.displayName,
+        };
+        _memberDisplayNames = {
+          for (final member in schedule.members)
+            member.playerSlot: member.displayName,
+        };
+        _selectedTeamSlot = schedule.teams.first.teamSlot;
+        _isLoading = false;
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _errorMessage = _formatError(error);
+        _isLoading = false;
+      });
+    }
+  }
+
+  String _formatError(Object error) {
+    if (error is CoreApiException) {
+      return 'HTTP ${error.statusCode}: ${error.message}';
+    }
+
+    return error.toString();
+  }
+
+  _TeamScheduleViewData _buildViewData(
+    TeamGeneratedSchedule generated,
+    AppLocalizations l10n,
+  ) {
+    final sortedGeneratedTeams = generated.teams.toList(growable: false)
+      ..sort((a, b) => a.teamSlot.compareTo(b.teamSlot));
+
+    if (sortedGeneratedTeams.isEmpty) {
+      throw const FormatException('team generate response has no teams');
+    }
+
+    final playerSlots = generated.players
+        .map((player) => player.playerSlot)
+        .where((slot) => slot > 0)
+        .toSet()
+        .toList(growable: false)
+      ..sort();
+
+    final fallbackPlayerCount = generated.playerCount > 0
+        ? generated.playerCount
+        : widget.draft.participantCount;
+
+    final effectivePlayerSlots = playerSlots.isEmpty
+        ? List<int>.generate(
+            fallbackPlayerCount,
+            (index) => index + 1,
             growable: false,
-          );
+          )
+        : playerSlots;
 
-          return _MockTeamMatch(
-            courtNo: matchIndex + 1,
-            teamIds: teamIds,
-          );
-        },
-        growable: false,
+    final members = effectivePlayerSlots.map((playerSlot) {
+      return _TeamMemberViewData(
+        playerSlot: playerSlot,
+        displayName: _initialMemberName(playerSlot, l10n),
       );
+    }).toList(growable: false);
 
-      return _MockTeamRound(
-        roundNo: roundIndex + 1,
-        matches: matches,
+    final assignmentMemberSlotsByTeam = <int, List<int>>{};
+    for (final assignment in generated.assignments) {
+      assignmentMemberSlotsByTeam
+          .putIfAbsent(assignment.teamSlot, () => <int>[])
+          .add(assignment.playerSlot);
+    }
+
+    for (final memberSlots in assignmentMemberSlotsByTeam.values) {
+      memberSlots.sort();
+    }
+
+    final teams = sortedGeneratedTeams.map((team) {
+      final memberPlayerSlots = team.memberPlayerSlots.isNotEmpty
+          ? team.memberPlayerSlots.toList(growable: false)
+          : assignmentMemberSlotsByTeam[team.teamSlot] ?? const <int>[];
+
+      return _TeamViewData(
+        teamSlot: team.teamSlot,
+        displayName: l10n.defaultTeamName(team.teamSlot),
+        memberPlayerSlots: memberPlayerSlots,
       );
-    }, growable: false);
+    }).toList(growable: false);
 
-    return _MockTeamSchedule(
+    final sortedGeneratedRounds = generated.rounds.toList(growable: false)
+      ..sort((a, b) => a.roundNo.compareTo(b.roundNo));
+
+    final rounds = sortedGeneratedRounds.map((round) {
+      final sortedCourts = round.courts.toList(growable: false)
+        ..sort((a, b) {
+          final courtCompare = a.courtNo.compareTo(b.courtNo);
+          if (courtCompare != 0) {
+            return courtCompare;
+          }
+
+          return a.matchNo.compareTo(b.matchNo);
+        });
+
+      return _TeamRoundViewData(
+        roundNo: round.roundNo,
+        matches: sortedCourts.map((court) {
+          return _TeamMatchViewData(
+            courtNo: court.courtNo,
+            matchNo: court.matchNo,
+            teamSlots: court.teamSlots,
+          );
+        }).toList(growable: false),
+      );
+    }).toList(growable: false);
+
+    if (rounds.isEmpty) {
+      throw const FormatException('team generate response has no rounds');
+    }
+
+    return _TeamScheduleViewData(
+      generatedScheduleId: generated.generatedScheduleId,
       eventTitle: l10n.defaultTeamScheduleEventTitle,
       members: members,
       teams: teams,
       rounds: rounds,
-      nextRoundNo: 1,
+      nextRoundNo: rounds.first.roundNo,
+      concurrentMatchCount: generated.courts > 0
+          ? generated.courts
+          : widget.draft.concurrentMatchCount,
     );
   }
 
-  Map<String, _MockTeam> get _teamById => {
-        for (final team in _schedule.teams) team.id: team,
-      };
+  String _initialMemberName(int playerSlot, AppLocalizations l10n) {
+    final index = playerSlot - 1;
+    if (index >= 0 && index < widget.draft.participantNames.length) {
+      final name = widget.draft.participantNames[index].trim();
+      if (name.isNotEmpty) {
+        return name;
+      }
+    }
 
-  Map<String, _MockTeamMember> get _memberById => {
-        for (final member in _schedule.members) member.id: member,
-      };
-
-  _MockTeam get _selectedTeam => _teamById[_selectedTeamId]!;
-
-  String _teamName(String teamId) {
-    return _teamDisplayNames[teamId] ??
-        _teamById[teamId]?.displayName ??
-        teamId;
+    return l10n.defaultTeamMemberName(playerSlot);
   }
 
-  String _memberName(String memberId) {
-    return _memberDisplayNames[memberId] ??
-        _memberById[memberId]?.displayName ??
-        memberId;
+  String _teamName(int teamSlot) {
+    return _teamDisplayNames[teamSlot] ??
+        _teamBySlot[teamSlot]?.displayName ??
+        'Team $teamSlot';
   }
 
-  String _matchTitle(BuildContext context, _MockTeamMatch match) {
+  String _memberName(int playerSlot) {
+    return _memberDisplayNames[playerSlot] ??
+        _memberBySlot[playerSlot]?.displayName ??
+        'Participant $playerSlot';
+  }
+
+  String _matchTitle(BuildContext context, _TeamMatchViewData match) {
     final l10n = AppLocalizations.of(context);
-    final teamNames = match.teamIds.map(_teamName).toList(growable: false);
+    final teamNames = match.teamSlots.map(_teamName).toList(growable: false);
 
     if (teamNames.length == 2) {
       return teamNames.join(l10n.teamMatchVsSeparator);
@@ -176,9 +268,9 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     return teamNames.join(l10n.teamMatchGroupSeparator);
   }
 
-  void _selectTeam(String teamId) {
+  void _selectTeam(int teamSlot) {
     setState(() {
-      _selectedTeamId = teamId;
+      _selectedTeamSlot = teamSlot;
     });
   }
 
@@ -244,31 +336,38 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     );
   }
 
-  Future<void> _editTeamName(String teamId) async {
+  Future<void> _editTeamName(int teamSlot) async {
     final l10n = AppLocalizations.of(context);
 
     await _editDisplayName(
-      dialogTitle: l10n.editTeamNameDialogTitle(_teamName(teamId)),
-      initialValue: _teamName(teamId),
+      dialogTitle: l10n.editTeamNameDialogTitle(_teamName(teamSlot)),
+      initialValue: _teamName(teamSlot),
       onSaved: (value) {
-        _teamDisplayNames[teamId] = value;
+        _teamDisplayNames = {
+          ..._teamDisplayNames,
+          teamSlot: value,
+        };
       },
     );
   }
 
-  Future<void> _editMemberName(String memberId) async {
+  Future<void> _editMemberName(int playerSlot) async {
     final l10n = AppLocalizations.of(context);
 
     await _editDisplayName(
-      dialogTitle: l10n.editTeamMemberNameDialogTitle(_memberName(memberId)),
-      initialValue: _memberName(memberId),
+      dialogTitle: l10n.editTeamMemberNameDialogTitle(_memberName(playerSlot)),
+      initialValue: _memberName(playerSlot),
       onSaved: (value) {
-        _memberDisplayNames[memberId] = value;
+        _memberDisplayNames = {
+          ..._memberDisplayNames,
+          playerSlot: value,
+        };
       },
     );
   }
 
   Widget _buildHeaderCard(BuildContext context) {
+    final schedule = _schedule!;
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
@@ -301,15 +400,15 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
             const SizedBox(height: 8),
             Text(
               l10n.teamScheduleSummary(
-                teamCount: _schedule.teams.length,
-                memberCount: _schedule.members.length,
-                concurrentMatchCount: widget.draft.concurrentMatchCount,
+                teamCount: schedule.teams.length,
+                memberCount: schedule.members.length,
+                concurrentMatchCount: schedule.concurrentMatchCount,
               ),
               style: theme.textTheme.bodyMedium,
             ),
             const SizedBox(height: 8),
             Text(
-              l10n.teamScheduleMockDataNotice,
+              l10n.teamScheduleBackendDataNotice,
               style: theme.textTheme.bodySmall,
             ),
           ],
@@ -319,11 +418,12 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
   }
 
   Widget _buildNextRoundCard(BuildContext context) {
+    final schedule = _schedule!;
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
-    final nextRound = _schedule.rounds.firstWhere(
-      (round) => round.roundNo == _schedule.nextRoundNo,
-      orElse: () => _schedule.rounds.first,
+    final nextRound = schedule.rounds.firstWhere(
+      (round) => round.roundNo == schedule.nextRoundNo,
+      orElse: () => schedule.rounds.first,
     );
 
     return Card(
@@ -365,6 +465,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
   }
 
   Widget _buildTeamListCard(BuildContext context) {
+    final schedule = _schedule!;
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
@@ -387,7 +488,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
               spacing: 8,
               runSpacing: 8,
               children: [
-                for (final team in _schedule.teams)
+                for (final team in schedule.teams)
                   _buildTeamSelectionChip(context, team),
               ],
             ),
@@ -397,10 +498,10 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     );
   }
 
-  Widget _buildTeamSelectionChip(BuildContext context, _MockTeam team) {
+  Widget _buildTeamSelectionChip(BuildContext context, _TeamViewData team) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
-    final isSelected = team.id == _selectedTeamId;
+    final isSelected = team.teamSlot == _selectedTeamSlot;
 
     return Card(
       margin: EdgeInsets.zero,
@@ -414,7 +515,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       ),
       child: InkWell(
         borderRadius: BorderRadius.circular(20),
-        onTap: () => _selectTeam(team.id),
+        onTap: () => _selectTeam(team.teamSlot),
         child: Padding(
           padding: const EdgeInsets.only(left: 12, right: 4),
           child: Row(
@@ -426,15 +527,15 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
               ],
               Text(
                 l10n.teamChoiceLabel(
-                  teamName: _teamName(team.id),
-                  memberCount: team.memberIds.length,
+                  teamName: _teamName(team.teamSlot),
+                  memberCount: team.memberPlayerSlots.length,
                 ),
                 style: theme.textTheme.bodyMedium,
               ),
               IconButton(
                 tooltip: l10n.editTeamNameTooltip,
                 visualDensity: VisualDensity.compact,
-                onPressed: () => _editTeamName(team.id),
+                onPressed: () => _editTeamName(team.teamSlot),
                 icon: const Icon(Icons.edit_outlined, size: 18),
               ),
             ],
@@ -458,21 +559,21 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l10n.selectedTeamMembersTitle(_teamName(team.id)),
+              l10n.selectedTeamMembersTitle(_teamName(team.teamSlot)),
               style: theme.textTheme.titleMedium?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
             ),
             const SizedBox(height: 12),
-            for (final memberId in team.memberIds)
+            for (final playerSlot in team.memberPlayerSlots)
               ListTile(
                 dense: true,
                 contentPadding: EdgeInsets.zero,
                 leading: const Icon(Icons.person_outline),
-                title: Text(_memberName(memberId)),
+                title: Text(_memberName(playerSlot)),
                 trailing: IconButton(
                   tooltip: l10n.editTeamMemberNameTooltip,
-                  onPressed: () => _editMemberName(memberId),
+                  onPressed: () => _editMemberName(playerSlot),
                   icon: const Icon(Icons.edit_outlined),
                 ),
               ),
@@ -483,20 +584,23 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
   }
 
   Widget _buildRoundList(BuildContext context) {
+    final schedule = _schedule!;
+
     return Column(
       children: [
-        for (final round in _schedule.rounds) ...[
+        for (final round in schedule.rounds) ...[
           _buildRoundCard(context, round),
-          if (round != _schedule.rounds.last) const SizedBox(height: 12),
+          if (round != schedule.rounds.last) const SizedBox(height: 12),
         ],
       ],
     );
   }
 
-  Widget _buildRoundCard(BuildContext context, _MockTeamRound round) {
+  Widget _buildRoundCard(BuildContext context, _TeamRoundViewData round) {
+    final schedule = _schedule!;
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
-    final isNextRound = round.roundNo == _schedule.nextRoundNo;
+    final isNextRound = round.roundNo == schedule.nextRoundNo;
 
     return Card(
       elevation: 0,
@@ -541,7 +645,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     );
   }
 
-  Widget _buildMatchRow(BuildContext context, _MockTeamMatch match) {
+  Widget _buildMatchRow(BuildContext context, _TeamMatchViewData match) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
@@ -564,18 +668,104 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           spacing: 8,
           runSpacing: 8,
           children: [
-            for (final teamId in match.teamIds)
+            for (final teamSlot in match.teamSlots)
               ActionChip(
-                label: Text(_teamName(teamId)),
-                avatar: teamId == _selectedTeamId
+                label: Text(_teamName(teamSlot)),
+                avatar: teamSlot == _selectedTeamSlot
                     ? const Icon(Icons.check, size: 18)
                     : null,
-                onPressed: () => _selectTeam(teamId),
+                onPressed: () => _selectTeam(teamSlot),
               ),
           ],
         ),
       ],
     );
+  }
+
+  Widget _buildLoadingBody(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const CircularProgressIndicator(),
+            const SizedBox(height: 16),
+            Text(l10n.creatingTeamScheduleMessage),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildErrorBody(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final message = _errorMessage ?? '';
+
+    return ListView(
+      padding: const EdgeInsets.all(12),
+      children: [
+        Card(
+          elevation: 0,
+          color: Colors.white,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l10n.teamScheduleGenerateFailedTitle,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(l10n.teamScheduleGenerateFailedBody(message)),
+                const SizedBox(height: 16),
+                FilledButton.icon(
+                  onPressed: _generateSchedule,
+                  icon: const Icon(Icons.refresh),
+                  label: Text(l10n.retryTeamScheduleGenerateButton),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildScheduleBody(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(12),
+      children: [
+        _buildHeaderCard(context),
+        const SizedBox(height: 12),
+        _buildNextRoundCard(context),
+        const SizedBox(height: 12),
+        _buildTeamListCard(context),
+        const SizedBox(height: 12),
+        _buildSelectedTeamMembersCard(context),
+        const SizedBox(height: 16),
+        _buildRoundList(context),
+        const SizedBox(height: 80),
+      ],
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    if (_isLoading) {
+      return _buildLoadingBody(context);
+    }
+
+    if (_errorMessage != null || _schedule == null) {
+      return _buildErrorBody(context);
+    }
+
+    return _buildScheduleBody(context);
   }
 
   @override
@@ -596,81 +786,73 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           elevation: 0,
         ),
         body: SafeArea(
-          child: ListView(
-            padding: const EdgeInsets.all(12),
-            children: [
-              _buildHeaderCard(context),
-              const SizedBox(height: 12),
-              _buildNextRoundCard(context),
-              const SizedBox(height: 12),
-              _buildTeamListCard(context),
-              const SizedBox(height: 12),
-              _buildSelectedTeamMembersCard(context),
-              const SizedBox(height: 16),
-              _buildRoundList(context),
-              const SizedBox(height: 80),
-            ],
-          ),
+          child: _buildBody(context),
         ),
       ),
     );
   }
 }
 
-class _MockTeamSchedule {
-  const _MockTeamSchedule({
+class _TeamScheduleViewData {
+  const _TeamScheduleViewData({
+    required this.generatedScheduleId,
     required this.eventTitle,
     required this.members,
     required this.teams,
     required this.rounds,
     required this.nextRoundNo,
+    required this.concurrentMatchCount,
   });
 
+  final String generatedScheduleId;
   final String eventTitle;
-  final List<_MockTeamMember> members;
-  final List<_MockTeam> teams;
-  final List<_MockTeamRound> rounds;
+  final List<_TeamMemberViewData> members;
+  final List<_TeamViewData> teams;
+  final List<_TeamRoundViewData> rounds;
   final int nextRoundNo;
+  final int concurrentMatchCount;
 }
 
-class _MockTeamMember {
-  const _MockTeamMember({
-    required this.id,
+class _TeamMemberViewData {
+  const _TeamMemberViewData({
+    required this.playerSlot,
     required this.displayName,
   });
 
-  final String id;
+  final int playerSlot;
   final String displayName;
 }
 
-class _MockTeam {
-  const _MockTeam({
-    required this.id,
+class _TeamViewData {
+  const _TeamViewData({
+    required this.teamSlot,
     required this.displayName,
-    required this.memberIds,
+    required this.memberPlayerSlots,
   });
 
-  final String id;
+  final int teamSlot;
   final String displayName;
-  final List<String> memberIds;
+  final List<int> memberPlayerSlots;
 }
 
-class _MockTeamRound {
-  const _MockTeamRound({
+class _TeamRoundViewData {
+  const _TeamRoundViewData({
     required this.roundNo,
     required this.matches,
   });
 
   final int roundNo;
-  final List<_MockTeamMatch> matches;
+  final List<_TeamMatchViewData> matches;
 }
 
-class _MockTeamMatch {
-  const _MockTeamMatch({
+class _TeamMatchViewData {
+  const _TeamMatchViewData({
     required this.courtNo,
-    required this.teamIds,
+    required this.matchNo,
+    required this.teamSlots,
   });
 
   final int courtNo;
-  final List<String> teamIds;
+  final int matchNo;
+  final List<int> teamSlots;
 }

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -49,6 +49,15 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
         _derivedTeamCount,
       );
 
+  int get _effectiveMaxConcurrentMatchCount {
+    final maxByTeams = _derivedTeamCount ~/ _teamsPerMatch;
+    return _clampInt(
+      maxByTeams,
+      _minConcurrentMatchCount,
+      _maxConcurrentMatchCount,
+    );
+  }
+
   List<int> get _teamMemberCounts {
     final teamCount = _derivedTeamCount;
     final base = _participantCount ~/ teamCount;
@@ -96,6 +105,11 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
       _minTeamsPerMatch,
       _effectiveMaxTeamsPerMatch,
     );
+    _concurrentMatchCount = _clampInt(
+      _concurrentMatchCount,
+      _minConcurrentMatchCount,
+      _effectiveMaxConcurrentMatchCount,
+    );
   }
 
   void _setConcurrentMatchCount(int value) {
@@ -103,7 +117,7 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
       _concurrentMatchCount = _clampInt(
         value,
         _minConcurrentMatchCount,
-        _maxConcurrentMatchCount,
+        _effectiveMaxConcurrentMatchCount,
       );
     });
   }
@@ -137,6 +151,7 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
         _minTeamsPerMatch,
         _effectiveMaxTeamsPerMatch,
       );
+      _syncDependentValues();
     });
   }
 
@@ -162,9 +177,7 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
     });
   }
 
-  void _submitMock() {
-    debugPrint(_draft.toString());
-
+  void _submit() {
     Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (context) => TeamSchedulePage(draft: _draft),
@@ -192,7 +205,7 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
                 label: l10n.concurrentMatchCountLabel,
                 value: _concurrentMatchCount,
                 minValue: _minConcurrentMatchCount,
-                maxValue: _maxConcurrentMatchCount,
+                maxValue: _effectiveMaxConcurrentMatchCount,
                 onChanged: _setConcurrentMatchCount,
                 tooltipDecrement: l10n.decrementConcurrentMatchCountTooltip,
                 tooltipIncrement: l10n.incrementConcurrentMatchCountTooltip,
@@ -348,14 +361,14 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        l10n.teamSetupMockNoticeTitle,
+                        l10n.teamSetupAlphaNoticeTitle,
                         style: const TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.bold,
                         ),
                       ),
                       const SizedBox(height: 8),
-                      Text(l10n.teamSetupMockNoticeBody),
+                      Text(l10n.teamSetupAlphaNoticeBody),
                     ],
                   ),
                 ),
@@ -378,7 +391,7 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
                   ),
                   const SizedBox(width: 12),
                   FilledButton(
-                    onPressed: _submitMock,
+                    onPressed: _submit,
                     style: FilledButton.styleFrom(
                       minimumSize: Size.zero,
                       padding: const EdgeInsets.symmetric(

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -15,12 +15,12 @@ extension TeamL10n on AppLocalizations {
       : 'Set simultaneous matches, participants, and preferred team size to create a team match table.';
 
   String get teamSetupSupportedConditions => _isJapanese
-      ? '初期MVPでは、同時進行1〜2試合 / 10チーム程度までを主な確認範囲としています。'
-      : 'For the initial MVP, the main verification range is 1 to 2 simultaneous matches and roughly up to 10 teams.';
+      ? '初期alphaでは、backend APIで5ラウンド分のチーム対戦表を作成します。'
+      : 'For the initial alpha, the backend API creates a 5-round team match table.';
 
   String get teamSetupInputUpperLimitNote => _isJapanese
-      ? '入力上限: 同時進行試合数5 / 参加人数50 / 1チームの目安人数25 / 1試合で対戦するチーム数25'
-      : 'Input limits: 5 simultaneous matches / 50 participants / preferred team size 25 / 25 teams per match';
+      ? '入力上限: 同時進行試合数5 / 参加人数50 / 1チームの目安人数25 / 1試合で対戦するチーム数25。条件により同時進行数は安全範囲に丸めます。'
+      : 'Input limits: 5 simultaneous matches / 50 participants / preferred team size 25 / 25 teams per match. Simultaneous matches are clamped to a safe range when needed.';
 
   String get concurrentMatchCountLabel =>
       _isJapanese ? '同時進行試合数' : 'Simultaneous matches';
@@ -125,11 +125,16 @@ extension TeamL10n on AppLocalizations {
   String get generateTeamScheduleButton =>
       _isJapanese ? 'チーム対戦表を作成' : 'Create team match table';
 
-  String get teamSetupMockNoticeTitle => _isJapanese ? 'モック確認中' : 'Mock flow';
+  String get teamSetupAlphaNoticeTitle =>
+      _isJapanese ? 'alpha確認中' : 'Alpha flow';
 
-  String get teamSetupMockNoticeBody => _isJapanese
-      ? 'backend API 接続前のため、次の作業でチーム用対戦表画面へ接続します。'
-      : 'The backend API is not connected yet. The next work item will connect this to the team match table screen.';
+  String get teamSetupAlphaNoticeBody => _isJapanese
+      ? '作成後、backend API の生成結果を表示します。チーム変更・スコア入力・共有URLはまだ未実装です。'
+      : 'After creation, this screen shows the backend API result. Team changes, score input, and share URLs are not implemented yet.';
+
+  String get teamSetupMockNoticeTitle => teamSetupAlphaNoticeTitle;
+
+  String get teamSetupMockNoticeBody => teamSetupAlphaNoticeBody;
 
   String get teamSetupCreatedMessage => _isJapanese
       ? 'チーム用セットアップ条件を作成しました'
@@ -158,9 +163,32 @@ extension TeamL10n on AppLocalizations {
         : '$teamCount teams / $memberCount members / $concurrentMatchCount simultaneous matches';
   }
 
-  String get teamScheduleMockDataNotice => _isJapanese
-      ? 'backend API 接続前のため、表示内容はセットアップ条件から作成したモックデータです。'
-      : 'The backend API is not connected yet, so this screen shows mock data created from the setup conditions.';
+  String get teamScheduleMockDataNotice => teamScheduleBackendDataNotice;
+
+  String get teamScheduleBackendDataNotice => _isJapanese
+      ? 'backend API の生成結果を表示しています。表示名はこの画面内で編集できます。'
+      : 'Showing the backend API result. Display names can be edited on this screen.';
+
+  String get creatingTeamScheduleMessage =>
+      _isJapanese ? 'チーム対戦表を作成中です…' : 'Creating team match table...';
+
+  String get teamScheduleGenerateFailedTitle =>
+      _isJapanese ? 'チーム対戦表の作成に失敗しました' : 'Failed to create team match table';
+
+  String teamScheduleGenerateFailedBody(String detail) {
+    if (detail.isEmpty) {
+      return _isJapanese
+          ? 'backend API の応答を確認してください。'
+          : 'Check the backend API response.';
+    }
+
+    return _isJapanese
+        ? 'backend API の応答を確認してください。\n\n$detail'
+        : 'Check the backend API response.\n\n$detail';
+  }
+
+  String get retryTeamScheduleGenerateButton =>
+      _isJapanese ? 'もう一度作成' : 'Try again';
 
   String get nextTeamMatchTitle => _isJapanese ? '次の対戦' : 'Next match';
 


### PR DESCRIPTION
## Summary

* チーム用対戦表画面を mock 生成から backend team generate API 接続へ差し替え
* `/team` セットアップ条件から `schedule_type: "team"` の generate request を組み立てるように変更
* core response の `teams / assignments / rounds` をチーム用対戦表画面へ反映
* `player_slot -> 表示名`、`team_slot -> チーム表示名` を web 側 state で対応
* イベントタイトル、チーム名、メンバー表示名の画面内編集を維持
* team generate response 用 model / service を追加
* 生成中 loading / 生成失敗時 error / retry 表示を追加
* alpha 用に round_count は固定 5 として送信
* 同時進行試合数は core validation に合うよう、team count / teams per match から安全範囲に丸める

## Background

web #102「🔌 チーム用対戦表画面を backend API 接続へ切り替える」の対応。

これまでのチーム用対戦表画面は、セットアップ条件から web 側で作成した mock data を表示していた。
今回、core team generate API の response を表示する形に差し替えた。

使用 endpoint は以下。

```text
POST /api/v1/generated-schedules:generate
```

`/api/v1/schedules:generate` ではない。

request は `schedule_type: "team"` で送信する。

## Implementation notes

### Request

`TeamSetupDraft` から以下の request を組み立てる。

* `schedule_type: "team"`
* `courts`
  * 同時進行試合数
* `round_count`
  * alpha 用に固定 5
* `players`
  * `player_slot` は 1 始まり
  * `pot_number` は MVP では全員 1
* `team_schedule`
  * `team_count`
  * `target_team_size`
  * `teams_per_match`
  * `active_team_count_per_round`
* `constraints.randomize: true`

### Response

core response のうち、主に以下を画面表示へ利用する。

* `generated_schedule_id`
* `players`
* `teams`
* `assignments`
* `rounds`

core は `display_name` / `team_name` を扱わないため、表示名は web 側 state で保持する。

### UI

* backend API 生成中は loading を表示
* 生成失敗時は error card と retry button を表示
* 生成成功時は既存の team schedule UI に表示
* event title / team name / member display name の編集機能は維持
* setup 画面の alpha notice を backend API 接続前提の文言へ更新

## Deferred

この PR では以下を対応しない。

* web #100 チーム用対戦表一覧画面
* Firestore 保存
* 共有 URL
* score 入力
* ボッチャ用スコアシート
* チーム所属変更
* 手動再シャッフル
* ラウンドごとのチーム再編成
* ログイン機能
* prod / preview deploy
* Cloud Run tagged revision の実作業
* generated schedule API client の共通配置化

generated schedule API client は、今回は既存実装を暫定利用する。
共通配置化は別 Issue で対応する。

Deferred tasks are tracked in #110.

## Verification

* [x] `dart format lib/`
* [x] `flutter analyze`
* [x] `flutter test`
* [x] local core API 接続で `/team` からチーム用対戦表を生成できること
* [x] 20 players / 2 courts / 10 teams / 5 rounds の表示確認
* [x] event title を編集できること
* [x] team name を編集できること
* [x] member display name を編集できること
* [x] backend API 停止時に error 表示と retry button が出ること

## Notes

明日の alpha 利用に向けて、まずは「backend API で生成したチーム対戦表を画面に表示できる」ことを優先した。

実運用では 2〜3 ゲームごとにチーム替えする想定のため、round_count は当面固定 5 で進める。

Closes #102