### PR TITLE
🔗 feat: save team schedules with share IDs refs #113

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -3,6 +3,7 @@ import 'package:srp_lanske/l10n/l10n.dart';
 
 import '../features/doubles_scheduler/presentation/event_setup_page.dart';
 import '../features/doubles_scheduler/presentation/restored_schedule_page.dart';
+import '../features/team_scheduler/presentation/team_schedule_page.dart';
 import '../features/team_scheduler/presentation/team_setup_page.dart';
 import 'theme/app_theme.dart';
 
@@ -32,6 +33,14 @@ class App extends StatelessWidget {
   Widget _homeForPath(String path) {
     if (path == '/team') {
       return const TeamSetupPage();
+    }
+
+    final teamScheduleMatch =
+        RegExp(r'^/team/schedules/([^/]+)$').firstMatch(path);
+    if (teamScheduleMatch != null) {
+      return TeamSchedulePage.restore(
+        shareId: teamScheduleMatch.group(1)!.trim().toUpperCase(),
+      );
     }
 
     return const EventSetupPage();

--- a/lib/features/team_scheduler/application/team_schedule_repository.dart
+++ b/lib/features/team_scheduler/application/team_schedule_repository.dart
@@ -1,0 +1,20 @@
+import '../domain/saved_team_schedule.dart';
+import '../domain/team_generated_schedule.dart';
+import '../presentation/models/team_setup_draft.dart';
+
+abstract class TeamScheduleRepository {
+  Future<SavedTeamSchedule> createFromGenerated({
+    required TeamSetupDraft draft,
+    required TeamGeneratedSchedule generated,
+    required String eventTitle,
+    required Map<int, String> teamNames,
+    required Map<int, String> memberNames,
+  });
+
+  Future<SavedTeamSchedule?> findByShareId(String shareId);
+
+  Future<SavedTeamSchedule> updateDisplay({
+    required String shareId,
+    required SavedTeamScheduleDisplay display,
+  });
+}

--- a/lib/features/team_scheduler/data/firestore_team_schedule_repository.dart
+++ b/lib/features/team_scheduler/data/firestore_team_schedule_repository.dart
@@ -1,0 +1,113 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:srp_lanske/features/doubles_scheduler/domain/public_id.dart';
+
+import '../application/team_schedule_repository.dart';
+import '../domain/saved_team_schedule.dart';
+import '../domain/team_generated_schedule.dart';
+import '../presentation/models/team_setup_draft.dart';
+
+class FirestoreTeamScheduleRepository implements TeamScheduleRepository {
+  FirestoreTeamScheduleRepository({
+    FirebaseFirestore? firestore,
+    String collectionPath = 'team_schedules',
+    String Function()? shareIdGenerator,
+  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+        _collectionPath = collectionPath,
+        _shareIdGenerator = shareIdGenerator ?? generatePublicId;
+
+  final FirebaseFirestore _firestore;
+  final String _collectionPath;
+  final String Function() _shareIdGenerator;
+
+  CollectionReference<Map<String, dynamic>> get _collection {
+    return _firestore.collection(_collectionPath);
+  }
+
+  @override
+  Future<SavedTeamSchedule> createFromGenerated({
+    required TeamSetupDraft draft,
+    required TeamGeneratedSchedule generated,
+    required String eventTitle,
+    required Map<int, String> teamNames,
+    required Map<int, String> memberNames,
+  }) async {
+    final now = DateTime.now();
+    final shareId = await _generateUniqueShareId();
+
+    final saved = SavedTeamSchedule(
+      schemaVersion: SavedTeamSchedule.currentSchemaVersion,
+      shareId: shareId,
+      status: 'active',
+      scheduleType: SavedTeamSchedule.teamScheduleType,
+      createdAt: now,
+      updatedAt: now,
+      setup: SavedTeamScheduleSetup(
+        concurrentMatchCount: draft.concurrentMatchCount,
+        participantCount: draft.participantCount,
+        preferredTeamSize: draft.preferredTeamSize,
+        teamsPerMatch: draft.teamsPerMatch,
+        roundCount: generated.roundCount,
+      ),
+      display: SavedTeamScheduleDisplay(
+        eventTitle: eventTitle,
+        teamNames: Map<int, String>.unmodifiable(teamNames),
+        memberNames: Map<int, String>.unmodifiable(memberNames),
+      ),
+      snapshot: generated.rawJson,
+      scores: const <String, dynamic>{},
+    );
+
+    await _collection.doc(shareId).set(saved.toJson());
+
+    return saved;
+  }
+
+  @override
+  Future<SavedTeamSchedule?> findByShareId(String shareId) async {
+    final snapshot = await _collection.doc(shareId).get();
+    final data = snapshot.data();
+
+    if (!snapshot.exists || data == null) {
+      return null;
+    }
+
+    return SavedTeamSchedule.fromJson(data);
+  }
+
+  @override
+  Future<SavedTeamSchedule> updateDisplay({
+    required String shareId,
+    required SavedTeamScheduleDisplay display,
+  }) async {
+    final current = await findByShareId(shareId);
+    if (current == null) {
+      throw StateError('team schedule not found: $shareId');
+    }
+
+    final updated = current.copyWith(
+      display: display,
+      updatedAt: DateTime.now(),
+    );
+
+    await _collection.doc(shareId).set(updated.toJson());
+
+    return updated;
+  }
+
+  Future<String> _generateUniqueShareId() async {
+    for (var attempt = 0; attempt < 10; attempt += 1) {
+      final candidate = _shareIdGenerator();
+
+      if (!isValidPublicId(candidate)) {
+        throw StateError('invalid share_id generated: $candidate');
+      }
+
+      final existing = await _collection.doc(candidate).get();
+      if (!existing.exists) {
+        return candidate;
+      }
+    }
+
+    throw StateError('failed to generate unique share_id');
+  }
+}

--- a/lib/features/team_scheduler/data/in_memory_team_schedule_repository.dart
+++ b/lib/features/team_scheduler/data/in_memory_team_schedule_repository.dart
@@ -1,0 +1,93 @@
+import 'package:srp_lanske/features/doubles_scheduler/domain/public_id.dart';
+
+import '../application/team_schedule_repository.dart';
+import '../domain/saved_team_schedule.dart';
+import '../domain/team_generated_schedule.dart';
+import '../presentation/models/team_setup_draft.dart';
+
+class InMemoryTeamScheduleRepository implements TeamScheduleRepository {
+  InMemoryTeamScheduleRepository({
+    String Function()? shareIdGenerator,
+  }) : _shareIdGenerator = shareIdGenerator ?? generatePublicId;
+
+  final String Function() _shareIdGenerator;
+  final Map<String, SavedTeamSchedule> _schedulesByShareId = {};
+
+  @override
+  Future<SavedTeamSchedule> createFromGenerated({
+    required TeamSetupDraft draft,
+    required TeamGeneratedSchedule generated,
+    required String eventTitle,
+    required Map<int, String> teamNames,
+    required Map<int, String> memberNames,
+  }) async {
+    final now = DateTime.now();
+    final shareId = _generateUniqueShareId();
+
+    final saved = SavedTeamSchedule(
+      schemaVersion: SavedTeamSchedule.currentSchemaVersion,
+      shareId: shareId,
+      status: 'active',
+      scheduleType: SavedTeamSchedule.teamScheduleType,
+      createdAt: now,
+      updatedAt: now,
+      setup: SavedTeamScheduleSetup(
+        concurrentMatchCount: draft.concurrentMatchCount,
+        participantCount: draft.participantCount,
+        preferredTeamSize: draft.preferredTeamSize,
+        teamsPerMatch: draft.teamsPerMatch,
+        roundCount: generated.roundCount,
+      ),
+      display: SavedTeamScheduleDisplay(
+        eventTitle: eventTitle,
+        teamNames: Map<int, String>.unmodifiable(teamNames),
+        memberNames: Map<int, String>.unmodifiable(memberNames),
+      ),
+      snapshot: generated.rawJson,
+      scores: const <String, dynamic>{},
+    );
+
+    _schedulesByShareId[shareId] = saved;
+    return saved;
+  }
+
+  @override
+  Future<SavedTeamSchedule?> findByShareId(String shareId) async {
+    return _schedulesByShareId[shareId];
+  }
+
+  @override
+  Future<SavedTeamSchedule> updateDisplay({
+    required String shareId,
+    required SavedTeamScheduleDisplay display,
+  }) async {
+    final current = _schedulesByShareId[shareId];
+    if (current == null) {
+      throw StateError('team schedule not found: $shareId');
+    }
+
+    final updated = current.copyWith(
+      display: display,
+      updatedAt: DateTime.now(),
+    );
+
+    _schedulesByShareId[shareId] = updated;
+    return updated;
+  }
+
+  String _generateUniqueShareId() {
+    for (var attempt = 0; attempt < 10; attempt += 1) {
+      final candidate = _shareIdGenerator();
+
+      if (!isValidPublicId(candidate)) {
+        throw StateError('invalid share_id generated: $candidate');
+      }
+
+      if (!_schedulesByShareId.containsKey(candidate)) {
+        return candidate;
+      }
+    }
+
+    throw StateError('failed to generate unique share_id');
+  }
+}

--- a/lib/features/team_scheduler/domain/saved_team_schedule.dart
+++ b/lib/features/team_scheduler/domain/saved_team_schedule.dart
@@ -1,0 +1,251 @@
+import 'dart:convert';
+
+class SavedTeamSchedule {
+  const SavedTeamSchedule({
+    required this.schemaVersion,
+    required this.shareId,
+    required this.status,
+    required this.scheduleType,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.setup,
+    required this.display,
+    required this.snapshot,
+    required this.scores,
+  });
+
+  static const int currentSchemaVersion = 1;
+  static const String teamScheduleType = 'team';
+
+  factory SavedTeamSchedule.fromJson(Map<String, dynamic> json) {
+    return SavedTeamSchedule(
+      schemaVersion: _readInt(json, 'schema_version', defaultValue: 1),
+      shareId: _readString(json, 'share_id'),
+      status: _readString(json, 'status', defaultValue: 'active'),
+      scheduleType: _readString(
+        json,
+        'schedule_type',
+        defaultValue: teamScheduleType,
+      ),
+      createdAt: _readDateTime(json, 'created_at'),
+      updatedAt: _readDateTime(json, 'updated_at'),
+      setup: SavedTeamScheduleSetup.fromJson(_readObject(json, 'setup')),
+      display: SavedTeamScheduleDisplay.fromJson(_readObject(json, 'display')),
+      snapshot: _readObject(json, 'snapshot'),
+      scores: _readObject(json, 'scores'),
+    );
+  }
+
+  final int schemaVersion;
+  final String shareId;
+  final String status;
+  final String scheduleType;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final SavedTeamScheduleSetup setup;
+  final SavedTeamScheduleDisplay display;
+  final Map<String, dynamic> snapshot;
+  final Map<String, dynamic> scores;
+
+  SavedTeamSchedule copyWith({
+    int? schemaVersion,
+    String? shareId,
+    String? status,
+    String? scheduleType,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    SavedTeamScheduleSetup? setup,
+    SavedTeamScheduleDisplay? display,
+    Map<String, dynamic>? snapshot,
+    Map<String, dynamic>? scores,
+  }) {
+    return SavedTeamSchedule(
+      schemaVersion: schemaVersion ?? this.schemaVersion,
+      shareId: shareId ?? this.shareId,
+      status: status ?? this.status,
+      scheduleType: scheduleType ?? this.scheduleType,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      setup: setup ?? this.setup,
+      display: display ?? this.display,
+      snapshot: snapshot ?? this.snapshot,
+      scores: scores ?? this.scores,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'schema_version': schemaVersion,
+      'share_id': shareId,
+      'status': status,
+      'schedule_type': scheduleType,
+      'created_at': createdAt.toIso8601String(),
+      'updated_at': updatedAt.toIso8601String(),
+      'setup': setup.toJson(),
+      'display': display.toJson(),
+      'snapshot': _copyObject(snapshot),
+      'scores': _copyObject(scores),
+    };
+  }
+}
+
+class SavedTeamScheduleSetup {
+  const SavedTeamScheduleSetup({
+    required this.concurrentMatchCount,
+    required this.participantCount,
+    required this.preferredTeamSize,
+    required this.teamsPerMatch,
+    required this.roundCount,
+  });
+
+  factory SavedTeamScheduleSetup.fromJson(Map<String, dynamic> json) {
+    return SavedTeamScheduleSetup(
+      concurrentMatchCount: _readInt(json, 'concurrent_match_count'),
+      participantCount: _readInt(json, 'participant_count'),
+      preferredTeamSize: _readInt(json, 'preferred_team_size'),
+      teamsPerMatch: _readInt(json, 'teams_per_match'),
+      roundCount: _readInt(json, 'round_count'),
+    );
+  }
+
+  final int concurrentMatchCount;
+  final int participantCount;
+  final int preferredTeamSize;
+  final int teamsPerMatch;
+  final int roundCount;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'concurrent_match_count': concurrentMatchCount,
+      'participant_count': participantCount,
+      'preferred_team_size': preferredTeamSize,
+      'teams_per_match': teamsPerMatch,
+      'round_count': roundCount,
+    };
+  }
+}
+
+class SavedTeamScheduleDisplay {
+  const SavedTeamScheduleDisplay({
+    required this.eventTitle,
+    required this.teamNames,
+    required this.memberNames,
+  });
+
+  factory SavedTeamScheduleDisplay.fromJson(Map<String, dynamic> json) {
+    return SavedTeamScheduleDisplay(
+      eventTitle: _readString(json, 'event_title'),
+      teamNames: _readIntStringMap(json, 'team_names'),
+      memberNames: _readIntStringMap(json, 'member_names'),
+    );
+  }
+
+  final String eventTitle;
+  final Map<int, String> teamNames;
+  final Map<int, String> memberNames;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'event_title': eventTitle,
+      'team_names': _writeIntStringMap(teamNames),
+      'member_names': _writeIntStringMap(memberNames),
+    };
+  }
+}
+
+String _readString(
+  Map<String, dynamic> json,
+  String key, {
+  String defaultValue = '',
+}) {
+  final value = json[key];
+  if (value == null) {
+    return defaultValue;
+  }
+
+  return value.toString();
+}
+
+int _readInt(
+  Map<String, dynamic> json,
+  String key, {
+  int defaultValue = 0,
+}) {
+  return _tryReadInt(json[key]) ?? defaultValue;
+}
+
+int? _tryReadInt(dynamic value) {
+  if (value is int) {
+    return value;
+  }
+
+  if (value is num) {
+    return value.toInt();
+  }
+
+  if (value is String) {
+    return int.tryParse(value);
+  }
+
+  return null;
+}
+
+DateTime _readDateTime(Map<String, dynamic> json, String key) {
+  final value = json[key];
+
+  if (value is DateTime) {
+    return value;
+  }
+
+  if (value is String && value.isNotEmpty) {
+    return DateTime.parse(value);
+  }
+
+  try {
+    final dynamic converted = value.toDate();
+    if (converted is DateTime) {
+      return converted;
+    }
+  } catch (_) {
+    // Ignore non-Firestore timestamp-like values.
+  }
+
+  throw FormatException('invalid datetime: $key');
+}
+
+Map<String, dynamic> _readObject(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value is Map) {
+    return _copyObject(Map<String, dynamic>.from(value));
+  }
+
+  return const <String, dynamic>{};
+}
+
+Map<int, String> _readIntStringMap(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value is! Map) {
+    return const <int, String>{};
+  }
+
+  final result = <int, String>{};
+  for (final entry in value.entries) {
+    final parsedKey = _tryReadInt(entry.key);
+    final rawValue = entry.value;
+    if (parsedKey != null && rawValue != null) {
+      result[parsedKey] = rawValue.toString();
+    }
+  }
+
+  return Map<int, String>.unmodifiable(result);
+}
+
+Map<String, String> _writeIntStringMap(Map<int, String> source) {
+  return Map<String, String>.unmodifiable(
+    source.map((key, value) => MapEntry(key.toString(), value)),
+  );
+}
+
+Map<String, dynamic> _copyObject(Map<String, dynamic> source) {
+  return jsonDecode(jsonEncode(source)) as Map<String, dynamic>;
+}

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -1,19 +1,39 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:srp_lanske/app/config/app_config.dart';
+import 'package:srp_lanske/features/doubles_scheduler/domain/public_id.dart';
 import 'package:srp_lanske/features/doubles_scheduler/infrastructure/generated_schedule_api_client.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
+import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 
 import '../application/team_generated_schedule_service.dart';
+import '../domain/saved_team_schedule.dart';
 import '../domain/team_generated_schedule.dart';
 import 'models/team_setup_draft.dart';
 
-class TeamSchedulePage extends StatefulWidget {
-  const TeamSchedulePage({
-    required this.draft,
-    super.key,
-  });
+enum _TeamSchedulePageMode {
+  create,
+  restore,
+}
 
-  final TeamSetupDraft draft;
+class TeamSchedulePage extends StatefulWidget {
+  const TeamSchedulePage.create({
+    required TeamSetupDraft draft,
+    super.key,
+  })  : _mode = _TeamSchedulePageMode.create,
+        _draft = draft,
+        _shareId = null;
+
+  const TeamSchedulePage.restore({
+    required String shareId,
+    super.key,
+  })  : _mode = _TeamSchedulePageMode.restore,
+        _draft = null,
+        _shareId = shareId;
+
+  final _TeamSchedulePageMode _mode;
+  final TeamSetupDraft? _draft;
+  final String? _shareId;
 
   @override
   State<TeamSchedulePage> createState() => _TeamSchedulePageState();
@@ -25,11 +45,17 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
   _TeamScheduleViewData? _schedule;
   String? _errorMessage;
   bool _isLoading = true;
+  bool _isSavingDisplay = false;
+  String? _displaySaveErrorMessage;
 
   String _eventTitle = '';
   Map<int, String> _teamDisplayNames = const {};
   Map<int, String> _memberDisplayNames = const {};
   int? _selectedTeamSlot;
+  String? _shareId;
+  String? _shareUrl;
+
+  bool get _isRestoreMode => widget._mode == _TeamSchedulePageMode.restore;
 
   @override
   void initState() {
@@ -42,7 +68,13 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     );
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
+      if (!mounted) {
+        return;
+      }
+
+      if (_isRestoreMode) {
+        _restoreSchedule();
+      } else {
         _generateSchedule();
       }
     });
@@ -82,32 +114,128 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
   }
 
   Future<void> _generateSchedule() async {
+    final draft = widget._draft;
+    if (draft == null) {
+      setState(() {
+        _errorMessage = 'missing team setup draft';
+        _isLoading = false;
+      });
+      return;
+    }
+
     setState(() {
       _isLoading = true;
       _errorMessage = null;
+      _displaySaveErrorMessage = null;
     });
 
     try {
-      final generated = await _service.generateFromDraft(widget.draft);
+      final generated = await _service.generateFromDraft(draft);
 
       if (!mounted) {
         return;
       }
 
       final l10n = AppLocalizations.of(context);
-      final schedule = _buildViewData(generated, l10n);
+      final schedule = _buildViewData(
+        generated: generated,
+        l10n: l10n,
+        draft: draft,
+      );
+
+      final teamNames = {
+        for (final team in schedule.teams) team.teamSlot: team.displayName,
+      };
+      final memberNames = {
+        for (final member in schedule.members)
+          member.playerSlot: member.displayName,
+      };
+
+      final saved = await appTeamScheduleRepository.createFromGenerated(
+        draft: draft,
+        generated: generated,
+        eventTitle: schedule.eventTitle,
+        teamNames: teamNames,
+        memberNames: memberNames,
+      );
+
+      if (!mounted) {
+        return;
+      }
 
       setState(() {
         _schedule = schedule;
-        _eventTitle = schedule.eventTitle;
-        _teamDisplayNames = {
-          for (final team in schedule.teams) team.teamSlot: team.displayName,
-        };
-        _memberDisplayNames = {
-          for (final member in schedule.members)
-            member.playerSlot: member.displayName,
-        };
+        _eventTitle = saved.display.eventTitle;
+        _teamDisplayNames = saved.display.teamNames;
+        _memberDisplayNames = saved.display.memberNames;
         _selectedTeamSlot = schedule.teams.first.teamSlot;
+        _shareId = saved.shareId;
+        _shareUrl = _buildShareUrl(saved.shareId);
+        _isLoading = false;
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _errorMessage = _formatError(error);
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _restoreSchedule() async {
+    final rawShareId = widget._shareId?.trim().toUpperCase() ?? '';
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+      _displaySaveErrorMessage = null;
+    });
+
+    try {
+      if (!isValidPublicId(rawShareId)) {
+        throw FormatException('invalid share id: $rawShareId');
+      }
+
+      final saved = await appTeamScheduleRepository.findByShareId(rawShareId);
+      if (saved == null) {
+        throw StateError('team schedule not found: $rawShareId');
+      }
+
+      final generated = TeamGeneratedSchedule.fromJson(saved.snapshot);
+
+      if (!mounted) {
+        return;
+      }
+
+      final schedule = _buildViewData(
+        generated: generated,
+        l10n: AppLocalizations.of(context),
+        savedSetup: saved.setup,
+      );
+
+      setState(() {
+        _schedule = schedule;
+        _eventTitle = saved.display.eventTitle.isEmpty
+            ? schedule.eventTitle
+            : saved.display.eventTitle;
+        _teamDisplayNames = saved.display.teamNames.isEmpty
+            ? {
+                for (final team in schedule.teams)
+                  team.teamSlot: team.displayName,
+              }
+            : saved.display.teamNames;
+        _memberDisplayNames = saved.display.memberNames.isEmpty
+            ? {
+                for (final member in schedule.members)
+                  member.playerSlot: member.displayName,
+              }
+            : saved.display.memberNames;
+        _selectedTeamSlot = schedule.teams.first.teamSlot;
+        _shareId = saved.shareId;
+        _shareUrl = _buildShareUrl(saved.shareId);
         _isLoading = false;
       });
     } catch (error) {
@@ -130,10 +258,24 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     return error.toString();
   }
 
-  _TeamScheduleViewData _buildViewData(
-    TeamGeneratedSchedule generated,
-    AppLocalizations l10n,
-  ) {
+  String _buildShareUrl(String shareId) {
+    final base = Uri.base;
+
+    return base
+        .replace(
+          path: '/team/schedules/$shareId',
+          queryParameters: const <String, String>{},
+          fragment: '',
+        )
+        .toString();
+  }
+
+  _TeamScheduleViewData _buildViewData({
+    required TeamGeneratedSchedule generated,
+    required AppLocalizations l10n,
+    TeamSetupDraft? draft,
+    SavedTeamScheduleSetup? savedSetup,
+  }) {
     final sortedGeneratedTeams = generated.teams.toList(growable: false)
       ..sort((a, b) => a.teamSlot.compareTo(b.teamSlot));
 
@@ -150,7 +292,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
 
     final fallbackPlayerCount = generated.playerCount > 0
         ? generated.playerCount
-        : widget.draft.participantCount;
+        : draft?.participantCount ?? savedSetup?.participantCount ?? 0;
 
     final effectivePlayerSlots = playerSlots.isEmpty
         ? List<int>.generate(
@@ -163,7 +305,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     final members = effectivePlayerSlots.map((playerSlot) {
       return _TeamMemberViewData(
         playerSlot: playerSlot,
-        displayName: _initialMemberName(playerSlot, l10n),
+        displayName: _initialMemberName(playerSlot, l10n, draft),
       );
     }).toList(growable: false);
 
@@ -229,14 +371,21 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       nextRoundNo: rounds.first.roundNo,
       concurrentMatchCount: generated.courts > 0
           ? generated.courts
-          : widget.draft.concurrentMatchCount,
+          : draft?.concurrentMatchCount ??
+              savedSetup?.concurrentMatchCount ??
+              1,
     );
   }
 
-  String _initialMemberName(int playerSlot, AppLocalizations l10n) {
+  String _initialMemberName(
+    int playerSlot,
+    AppLocalizations l10n,
+    TeamSetupDraft? draft,
+  ) {
+    final names = draft?.participantNames ?? const <String>[];
     final index = playerSlot - 1;
-    if (index >= 0 && index < widget.draft.participantNames.length) {
-      final name = widget.draft.participantNames[index].trim();
+    if (index >= 0 && index < names.length) {
+      final name = names[index].trim();
       if (name.isNotEmpty) {
         return name;
       }
@@ -257,6 +406,53 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         'Participant $playerSlot';
   }
 
+  SavedTeamScheduleDisplay _currentDisplay() {
+    return SavedTeamScheduleDisplay(
+      eventTitle: _eventTitle,
+      teamNames: Map<int, String>.unmodifiable(_teamDisplayNames),
+      memberNames: Map<int, String>.unmodifiable(_memberDisplayNames),
+    );
+  }
+
+  Future<void> _saveCurrentDisplay() async {
+    final shareId = _shareId;
+    if (shareId == null || shareId.isEmpty) {
+      return;
+    }
+
+    setState(() {
+      _isSavingDisplay = true;
+      _displaySaveErrorMessage = null;
+    });
+
+    try {
+      final saved = await appTeamScheduleRepository.updateDisplay(
+        shareId: shareId,
+        display: _currentDisplay(),
+      );
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _eventTitle = saved.display.eventTitle;
+        _teamDisplayNames = saved.display.teamNames;
+        _memberDisplayNames = saved.display.memberNames;
+        _isSavingDisplay = false;
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _displaySaveErrorMessage = _formatError(error);
+        _isSavingDisplay = false;
+      });
+    }
+  }
+
   String _matchTitle(BuildContext context, _TeamMatchViewData match) {
     final l10n = AppLocalizations.of(context);
     final teamNames = match.teamSlots.map(_teamName).toList(growable: false);
@@ -272,6 +468,24 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     setState(() {
       _selectedTeamSlot = teamSlot;
     });
+  }
+
+  Future<void> _copyShareUrl() async {
+    final l10n = AppLocalizations.of(context);
+    final shareUrl = _shareUrl;
+    if (shareUrl == null || shareUrl.isEmpty) {
+      return;
+    }
+
+    await Clipboard.setData(ClipboardData(text: shareUrl));
+
+    if (!mounted) {
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(l10n.teamScheduleShareUrlCopiedMessage)),
+    );
   }
 
   Future<void> _editDisplayName({
@@ -322,6 +536,8 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     setState(() {
       onSaved(trimmed);
     });
+
+    await _saveCurrentDisplay();
   }
 
   Future<void> _editEventTitle() async {
@@ -410,6 +626,91 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
             Text(
               l10n.teamScheduleBackendDataNotice,
               style: theme.textTheme.bodySmall,
+            ),
+            if (_isSavingDisplay || _displaySaveErrorMessage != null) ...[
+              const SizedBox(height: 8),
+              _buildDisplaySaveStatus(context),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDisplaySaveStatus(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final error = _displaySaveErrorMessage;
+
+    if (_isSavingDisplay) {
+      return Row(
+        children: [
+          const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            l10n.savingTeamScheduleDisplayMessage,
+            style: theme.textTheme.bodySmall,
+          ),
+        ],
+      );
+    }
+
+    if (error != null && error.isNotEmpty) {
+      return Text(
+        l10n.teamScheduleDisplaySaveFailedMessage(error),
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+
+  Widget _buildShareCard(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final shareId = _shareId;
+    final shareUrl = _shareUrl;
+
+    if (shareId == null || shareUrl == null) {
+      return const SizedBox.shrink();
+    }
+
+    return Card(
+      elevation: 0,
+      color: Colors.white,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.teamScheduleShareTitle,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(l10n.teamScheduleShareDescription),
+            const SizedBox(height: 12),
+            SelectableText(
+              l10n.teamScheduleShareIdLabel(shareId),
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            SelectableText(shareUrl),
+            const SizedBox(height: 12),
+            FilledButton.icon(
+              onPressed: _copyShareUrl,
+              icon: const Icon(Icons.copy),
+              label: Text(l10n.copyTeamScheduleShareUrlButton),
             ),
           ],
         ),
@@ -684,6 +985,9 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
 
   Widget _buildLoadingBody(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final message = _isRestoreMode
+        ? l10n.restoringTeamScheduleMessage
+        : l10n.creatingTeamScheduleMessage;
 
     return Center(
       child: Padding(
@@ -693,7 +997,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           children: [
             const CircularProgressIndicator(),
             const SizedBox(height: 16),
-            Text(l10n.creatingTeamScheduleMessage),
+            Text(message),
           ],
         ),
       ),
@@ -717,18 +1021,29 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  l10n.teamScheduleGenerateFailedTitle,
+                  _isRestoreMode
+                      ? l10n.teamScheduleRestoreFailedTitle
+                      : l10n.teamScheduleGenerateFailedTitle,
                   style: theme.textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),
                 ),
                 const SizedBox(height: 8),
-                Text(l10n.teamScheduleGenerateFailedBody(message)),
+                Text(
+                  _isRestoreMode
+                      ? l10n.teamScheduleRestoreFailedBody(message)
+                      : l10n.teamScheduleGenerateFailedBody(message),
+                ),
                 const SizedBox(height: 16),
                 FilledButton.icon(
-                  onPressed: _generateSchedule,
+                  onPressed:
+                      _isRestoreMode ? _restoreSchedule : _generateSchedule,
                   icon: const Icon(Icons.refresh),
-                  label: Text(l10n.retryTeamScheduleGenerateButton),
+                  label: Text(
+                    _isRestoreMode
+                        ? l10n.retryTeamScheduleRestoreButton
+                        : l10n.retryTeamScheduleGenerateButton,
+                  ),
                 ),
               ],
             ),
@@ -743,6 +1058,8 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       padding: const EdgeInsets.all(12),
       children: [
         _buildHeaderCard(context),
+        const SizedBox(height: 12),
+        _buildShareCard(context),
         const SizedBox(height: 12),
         _buildNextRoundCard(context),
         const SizedBox(height: 12),

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
 
-import 'team_schedule_page.dart';
 import 'models/team_setup_draft.dart';
+import 'team_schedule_page.dart';
 import 'widgets/team_participant_name_input_card.dart';
 import 'widgets/team_setup_number_field.dart';
 
@@ -180,7 +180,7 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
   void _submit() {
     Navigator.of(context).push(
       MaterialPageRoute<void>(
-        builder: (context) => TeamSchedulePage(draft: _draft),
+        builder: (context) => TeamSchedulePage.create(draft: _draft),
       ),
     );
   }

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -129,8 +129,8 @@ extension TeamL10n on AppLocalizations {
       _isJapanese ? 'alpha確認中' : 'Alpha flow';
 
   String get teamSetupAlphaNoticeBody => _isJapanese
-      ? '作成後、backend API の生成結果を表示します。チーム変更・スコア入力・共有URLはまだ未実装です。'
-      : 'After creation, this screen shows the backend API result. Team changes, score input, and share URLs are not implemented yet.';
+      ? '作成後、backend API の生成結果を保存し、共有URLから再表示できます。チーム変更・スコア入力はまだ未実装です。'
+      : 'After creation, the backend API result is saved and can be reopened from a share URL. Team changes and score input are not implemented yet.';
 
   String get teamSetupMockNoticeTitle => teamSetupAlphaNoticeTitle;
 
@@ -166,11 +166,19 @@ extension TeamL10n on AppLocalizations {
   String get teamScheduleMockDataNotice => teamScheduleBackendDataNotice;
 
   String get teamScheduleBackendDataNotice => _isJapanese
-      ? 'backend API の生成結果を表示しています。表示名はこの画面内で編集できます。'
-      : 'Showing the backend API result. Display names can be edited on this screen.';
+      ? 'backend API の生成結果を保存して表示しています。表示名はこの画面内で編集できます。'
+      : 'Showing the saved backend API result. Display names can be edited on this screen.';
 
-  String get creatingTeamScheduleMessage =>
-      _isJapanese ? 'チーム対戦表を作成中です…' : 'Creating team match table...';
+  String get creatingTeamScheduleMessage => _isJapanese
+      ? 'チーム対戦表を作成・保存中です…'
+      : 'Creating and saving team match table...';
+
+  String get restoringTeamScheduleMessage => _isJapanese
+      ? '保存済みのチーム対戦表を読み込み中です…'
+      : 'Loading saved team match table...';
+
+  String get savingTeamScheduleDisplayMessage =>
+      _isJapanese ? '表示名を保存中です…' : 'Saving display names...';
 
   String get teamScheduleGenerateFailedTitle =>
       _isJapanese ? 'チーム対戦表の作成に失敗しました' : 'Failed to create team match table';
@@ -178,17 +186,57 @@ extension TeamL10n on AppLocalizations {
   String teamScheduleGenerateFailedBody(String detail) {
     if (detail.isEmpty) {
       return _isJapanese
-          ? 'backend API の応答を確認してください。'
-          : 'Check the backend API response.';
+          ? 'backend API または Firestore 保存の応答を確認してください。'
+          : 'Check the backend API or Firestore save response.';
     }
 
     return _isJapanese
-        ? 'backend API の応答を確認してください。\n\n$detail'
-        : 'Check the backend API response.\n\n$detail';
+        ? 'backend API または Firestore 保存の応答を確認してください。\n\n$detail'
+        : 'Check the backend API or Firestore save response.\n\n$detail';
+  }
+
+  String get teamScheduleRestoreFailedTitle =>
+      _isJapanese ? 'チーム対戦表の読み込みに失敗しました' : 'Failed to load team match table';
+
+  String teamScheduleRestoreFailedBody(String detail) {
+    if (detail.isEmpty) {
+      return _isJapanese
+          ? '共有IDまたは保存済みデータを確認してください。'
+          : 'Check the share ID or saved data.';
+    }
+
+    return _isJapanese
+        ? '共有IDまたは保存済みデータを確認してください。\n\n$detail'
+        : 'Check the share ID or saved data.\n\n$detail';
+  }
+
+  String teamScheduleDisplaySaveFailedMessage(String detail) {
+    return _isJapanese
+        ? '表示名の保存に失敗しました: $detail'
+        : 'Failed to save display names: $detail';
   }
 
   String get retryTeamScheduleGenerateButton =>
       _isJapanese ? 'もう一度作成' : 'Try again';
+
+  String get retryTeamScheduleRestoreButton =>
+      _isJapanese ? 'もう一度読み込む' : 'Reload';
+
+  String get teamScheduleShareTitle => _isJapanese ? '共有URL' : 'Share URL';
+
+  String get teamScheduleShareDescription => _isJapanese
+      ? 'このURLを共有すると、保存済みのチーム対戦表を開き直せます。'
+      : 'Share this URL to reopen the saved team match table.';
+
+  String teamScheduleShareIdLabel(String shareId) {
+    return _isJapanese ? '共有ID: $shareId' : 'Share ID: $shareId';
+  }
+
+  String get copyTeamScheduleShareUrlButton =>
+      _isJapanese ? '共有URLをコピー' : 'Copy share URL';
+
+  String get teamScheduleShareUrlCopiedMessage =>
+      _isJapanese ? '共有URLをコピーしました' : 'Copied share URL.';
 
   String get nextTeamMatchTitle => _isJapanese ? '次の対戦' : 'Next match';
 

--- a/lib/shared/repositories/app_repositories.dart
+++ b/lib/shared/repositories/app_repositories.dart
@@ -4,8 +4,14 @@ import 'package:srp_lanske/app/config/app_config.dart';
 import 'package:srp_lanske/features/doubles_scheduler/application/event_repository.dart';
 import 'package:srp_lanske/features/doubles_scheduler/data/firestore_event_repository.dart';
 import 'package:srp_lanske/features/doubles_scheduler/data/in_memory_event_repository.dart';
+import 'package:srp_lanske/features/team_scheduler/application/team_schedule_repository.dart';
+import 'package:srp_lanske/features/team_scheduler/data/firestore_team_schedule_repository.dart';
+import 'package:srp_lanske/features/team_scheduler/data/in_memory_team_schedule_repository.dart';
 
 final EventRepository appEventRepository = _createEventRepository();
+
+final TeamScheduleRepository appTeamScheduleRepository =
+    _createTeamScheduleRepository();
 
 EventRepository _createEventRepository() {
   if (AppConfig.usesFirestoreEventRepository) {
@@ -13,4 +19,12 @@ EventRepository _createEventRepository() {
   }
 
   return InMemoryEventRepository();
+}
+
+TeamScheduleRepository _createTeamScheduleRepository() {
+  if (AppConfig.usesFirestoreEventRepository) {
+    return FirestoreTeamScheduleRepository();
+  }
+
+  return InMemoryTeamScheduleRepository();
 }


### PR DESCRIPTION
## Summary

- チーム用対戦表を `team_schedules/{shareId}` として Firestore に保存
- 保存時に共有IDを生成し、共有URLを表示
- `/team/schedules/{shareId}` から保存済みチーム対戦表を復元
- core get API には依存せず、Firestore document の `snapshot` から復元
- event title / team display names / member display names の保存・復元に対応
- 生成直後保存、表示名編集時の即時保存に対応

## Not included

- core 側の team schedule 保存
- core get API 前提の復元
- ログイン / owner / 権限管理
- 公開期限 / visibility 本設計
- チーム用対戦表一覧画面
- score 入力
- ボッチャ用スコアシート
- prod / preview deploy

## Verification

- `/team` から生成できることを確認
- Firestore `team_schedules/{shareId}` に保存されることを確認
- 共有URLを別タブで開けることを確認
- core 停止中でも保存済み snapshot から復元できることを確認
- event title / team names / member names の編集内容が再読み込み後も復元されることを確認
- `dart format lib/`
- `flutter analyze`
- `flutter test`

closes #113