### PR TITLE
🎯 feat: add boccia score sheet input refs #111

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,18 +154,18 @@ flutter run -d web-server --web-hostname 0.0.0.0 --web-port 3000 \
 
 ### Codespaces で core API と接続して起動する
 
-`srp-lanske-web` を Codespaces で起動し、別 Codespace で起動している `srp-lanske-core` に接続する場合は、core 側の forwarded URL を `LANSKE_API_BASE_URL` に指定する。
+`srp-lanske-web` を Codespaces で起動し、別 Codespace で起動している `srp-lanske-core` に接続する場合は、core 側の forwarded URL を `LANSKE_CORE_API_BASE_URL` に指定する。
 
 ```bash
 flutter run -d chrome \
-  --dart-define=LANSKE_API_BASE_URL=https://<core-codespace-name>-8080.app.github.dev
+  --dart-define=LANSKE_CORE_API_BASE_URL=https://<core-codespace-name>-8080.app.github.dev
 ```
 
 Firestore event repository を使う場合は、必要に応じて以下も指定する。
 
 ```bash
 flutter run -d chrome \
-  --dart-define=LANSKE_API_BASE_URL=https://<core-codespace-name>-8080.app.github.dev \
+  --dart-define=LANSKE_CORE_API_BASE_URL=https://<core-codespace-name>-8080.app.github.dev \
   --dart-define=LANSKE_EVENT_REPOSITORY=firestore
 ```
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,30 @@ flutter run -d web-server --web-hostname 0.0.0.0 --web-port 3000 \
 
 `<core-api-url>` には Cloud Run などの公開 core API URL を指定します。
 
+### Codespaces で core API と接続して起動する
+
+`srp-lanske-web` を Codespaces で起動し、別 Codespace で起動している `srp-lanske-core` に接続する場合は、core 側の forwarded URL を `LANSKE_API_BASE_URL` に指定する。
+
+```bash
+flutter run -d chrome \
+  --dart-define=LANSKE_API_BASE_URL=https://<core-codespace-name>-8080.app.github.dev
+```
+
+Firestore event repository を使う場合は、必要に応じて以下も指定する。
+
+```bash
+flutter run -d chrome \
+  --dart-define=LANSKE_API_BASE_URL=https://<core-codespace-name>-8080.app.github.dev \
+  --dart-define=LANSKE_EVENT_REPOSITORY=firestore
+```
+
+注意:
+
+* web から core を叩く場合、基本的に `localhost` ではなく core Codespace の forwarded URL を使う
+* core の `8080` port が Private の場合、別 Codespace / ブラウザからのアクセスで `302 pf-signin` にリダイレクトされることがある
+* core の forwarded URL で `/health` が通ることを確認してから web を起動する
+* 詳細な起動・確認手順は `lee-esys/worklog/lanske/codespaces-web-core-runbook.md` を参照する
+
 ---
 
 ## 📚 ドキュメント

--- a/lib/features/team_scheduler/application/team_schedule_repository.dart
+++ b/lib/features/team_scheduler/application/team_schedule_repository.dart
@@ -17,4 +17,9 @@ abstract class TeamScheduleRepository {
     required String shareId,
     required SavedTeamScheduleDisplay display,
   });
+
+  Future<SavedTeamSchedule> updateScores({
+    required String shareId,
+    required Map<String, dynamic> scores,
+  });
 }

--- a/lib/features/team_scheduler/data/firestore_team_schedule_repository.dart
+++ b/lib/features/team_scheduler/data/firestore_team_schedule_repository.dart
@@ -79,10 +79,7 @@ class FirestoreTeamScheduleRepository implements TeamScheduleRepository {
     required String shareId,
     required SavedTeamScheduleDisplay display,
   }) async {
-    final current = await findByShareId(shareId);
-    if (current == null) {
-      throw StateError('team schedule not found: $shareId');
-    }
+    final current = await _readExisting(shareId);
 
     final updated = current.copyWith(
       display: display,
@@ -92,6 +89,32 @@ class FirestoreTeamScheduleRepository implements TeamScheduleRepository {
     await _collection.doc(shareId).set(updated.toJson());
 
     return updated;
+  }
+
+  @override
+  Future<SavedTeamSchedule> updateScores({
+    required String shareId,
+    required Map<String, dynamic> scores,
+  }) async {
+    final current = await _readExisting(shareId);
+
+    final updated = current.copyWith(
+      scores: Map<String, dynamic>.unmodifiable(scores),
+      updatedAt: DateTime.now(),
+    );
+
+    await _collection.doc(shareId).set(updated.toJson());
+
+    return updated;
+  }
+
+  Future<SavedTeamSchedule> _readExisting(String shareId) async {
+    final current = await findByShareId(shareId);
+    if (current == null) {
+      throw StateError('team schedule not found: $shareId');
+    }
+
+    return current;
   }
 
   Future<String> _generateUniqueShareId() async {

--- a/lib/features/team_scheduler/data/in_memory_team_schedule_repository.dart
+++ b/lib/features/team_scheduler/data/in_memory_team_schedule_repository.dart
@@ -61,10 +61,7 @@ class InMemoryTeamScheduleRepository implements TeamScheduleRepository {
     required String shareId,
     required SavedTeamScheduleDisplay display,
   }) async {
-    final current = _schedulesByShareId[shareId];
-    if (current == null) {
-      throw StateError('team schedule not found: $shareId');
-    }
+    final current = _readExisting(shareId);
 
     final updated = current.copyWith(
       display: display,
@@ -73,6 +70,31 @@ class InMemoryTeamScheduleRepository implements TeamScheduleRepository {
 
     _schedulesByShareId[shareId] = updated;
     return updated;
+  }
+
+  @override
+  Future<SavedTeamSchedule> updateScores({
+    required String shareId,
+    required Map<String, dynamic> scores,
+  }) async {
+    final current = _readExisting(shareId);
+
+    final updated = current.copyWith(
+      scores: Map<String, dynamic>.unmodifiable(scores),
+      updatedAt: DateTime.now(),
+    );
+
+    _schedulesByShareId[shareId] = updated;
+    return updated;
+  }
+
+  SavedTeamSchedule _readExisting(String shareId) {
+    final current = _schedulesByShareId[shareId];
+    if (current == null) {
+      throw StateError('team schedule not found: $shareId');
+    }
+
+    return current;
   }
 
   String _generateUniqueShareId() {

--- a/lib/features/team_scheduler/domain/boccia_score.dart
+++ b/lib/features/team_scheduler/domain/boccia_score.dart
@@ -1,0 +1,414 @@
+enum TeamScheduleSport {
+  none,
+  boccia,
+}
+
+extension TeamScheduleSportJson on TeamScheduleSport {
+  String? toJsonValue() {
+    return switch (this) {
+      TeamScheduleSport.none => null,
+      TeamScheduleSport.boccia => 'boccia',
+    };
+  }
+
+  static TeamScheduleSport fromJsonValue(Object? value) {
+    return switch (value?.toString()) {
+      'boccia' => TeamScheduleSport.boccia,
+      _ => TeamScheduleSport.none,
+    };
+  }
+}
+
+class TeamScheduleScores {
+  const TeamScheduleScores({
+    required this.selectedSport,
+    required this.boccia,
+  });
+
+  const TeamScheduleScores.empty()
+      : selectedSport = TeamScheduleSport.none,
+        boccia = const BocciaScoreSheet.empty();
+
+  factory TeamScheduleScores.fromJson(Map<String, dynamic> json) {
+    return TeamScheduleScores(
+      selectedSport: TeamScheduleSportJson.fromJsonValue(
+        json['selected_sport'],
+      ),
+      boccia: BocciaScoreSheet.fromJson(_readObject(json['boccia'])),
+    );
+  }
+
+  final TeamScheduleSport selectedSport;
+  final BocciaScoreSheet boccia;
+
+  TeamScheduleScores copyWith({
+    TeamScheduleSport? selectedSport,
+    BocciaScoreSheet? boccia,
+  }) {
+    return TeamScheduleScores(
+      selectedSport: selectedSport ?? this.selectedSport,
+      boccia: boccia ?? this.boccia,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'selected_sport': selectedSport.toJsonValue(),
+      'boccia': boccia.toJson(),
+    };
+  }
+}
+
+class BocciaScoreSheet {
+  const BocciaScoreSheet({
+    required this.matches,
+  });
+
+  const BocciaScoreSheet.empty() : matches = const <int, BocciaMatchScore>{};
+
+  factory BocciaScoreSheet.fromJson(Map<String, dynamic> json) {
+    final matchesJson = json['matches'];
+    if (matchesJson is! Map) {
+      return const BocciaScoreSheet.empty();
+    }
+
+    final matches = <int, BocciaMatchScore>{};
+
+    for (final entry in matchesJson.entries) {
+      final value = entry.value;
+      if (value is! Map) {
+        continue;
+      }
+
+      final matchNoFromKey = _readInt(entry.key);
+      final parsed = BocciaMatchScore.fromJson(_readObject(value));
+      final matchNo = parsed.matchNo > 0 ? parsed.matchNo : matchNoFromKey;
+
+      if (matchNo <= 0) {
+        continue;
+      }
+
+      matches[matchNo] = parsed.copyWith(matchNo: matchNo);
+    }
+
+    return BocciaScoreSheet(
+      matches: Map<int, BocciaMatchScore>.unmodifiable(matches),
+    );
+  }
+
+  final Map<int, BocciaMatchScore> matches;
+
+  BocciaMatchScore? matchScore(int matchNo) {
+    return matches[matchNo];
+  }
+
+  BocciaMatchScore initialMatchScore({
+    required int matchNo,
+    required List<int> teamSlots,
+  }) {
+    if (teamSlots.length != 2) {
+      throw ArgumentError.value(
+        teamSlots,
+        'teamSlots',
+        'Boccia score input supports two-team matches only.',
+      );
+    }
+
+    return BocciaMatchScore.initial(
+      matchNo: matchNo,
+      redTeamSlot: teamSlots[0],
+      blueTeamSlot: teamSlots[1],
+    );
+  }
+
+  BocciaMatchScore matchScoreOrInitial({
+    required int matchNo,
+    required List<int> teamSlots,
+  }) {
+    return matchScore(matchNo) ??
+        initialMatchScore(
+          matchNo: matchNo,
+          teamSlots: teamSlots,
+        );
+  }
+
+  BocciaScoreSheet upsertMatch(BocciaMatchScore score) {
+    return BocciaScoreSheet(
+      matches: Map<int, BocciaMatchScore>.unmodifiable(
+        <int, BocciaMatchScore>{
+          ...matches,
+          score.matchNo: score,
+        },
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final sortedMatchNos = matches.keys.toList(growable: false)..sort();
+
+    return <String, dynamic>{
+      'matches': <String, dynamic>{
+        for (final matchNo in sortedMatchNos)
+          matchNo.toString(): matches[matchNo]!.toJson(),
+      },
+    };
+  }
+}
+
+class BocciaMatchScore {
+  const BocciaMatchScore({
+    required this.matchNo,
+    required this.redTeamSlot,
+    required this.blueTeamSlot,
+    required this.endScores,
+    required this.throwLogs,
+  });
+
+  factory BocciaMatchScore.initial({
+    required int matchNo,
+    required int redTeamSlot,
+    required int blueTeamSlot,
+    int endCount = 6,
+  }) {
+    return BocciaMatchScore(
+      matchNo: matchNo,
+      redTeamSlot: redTeamSlot,
+      blueTeamSlot: blueTeamSlot,
+      endScores: List<BocciaEndScore>.unmodifiable(
+        List<BocciaEndScore>.generate(
+          endCount,
+          (index) => BocciaEndScore.empty(endNo: index + 1),
+        ),
+      ),
+      throwLogs: const <Map<String, dynamic>>[],
+    );
+  }
+
+  factory BocciaMatchScore.fromJson(Map<String, dynamic> json) {
+    final parsedEndScores = _readEndScores(json['end_scores']);
+    final endCount = _readInt(
+      json['end_count'],
+      defaultValue: parsedEndScores.isEmpty ? 6 : parsedEndScores.length,
+    );
+
+    return BocciaMatchScore(
+      matchNo: _readInt(json['match_no']),
+      redTeamSlot: _readInt(json['red_team_slot']),
+      blueTeamSlot: _readInt(json['blue_team_slot']),
+      endScores: _normalizeEndScores(
+        parsedEndScores,
+        endCount: endCount,
+      ),
+      throwLogs: _readObjectList(json['throw_logs']),
+    );
+  }
+
+  final int matchNo;
+  final int redTeamSlot;
+  final int blueTeamSlot;
+  final List<BocciaEndScore> endScores;
+  final List<Map<String, dynamic>> throwLogs;
+
+  int get endCount => endScores.length;
+
+  int get totalRedScore {
+    return endScores.fold<int>(
+      0,
+      (sum, endScore) => sum + endScore.red,
+    );
+  }
+
+  int get totalBlueScore {
+    return endScores.fold<int>(
+      0,
+      (sum, endScore) => sum + endScore.blue,
+    );
+  }
+
+  bool get hasAnyScore {
+    return endScores.any((endScore) => endScore.red > 0 || endScore.blue > 0);
+  }
+
+  BocciaMatchScore copyWith({
+    int? matchNo,
+    int? redTeamSlot,
+    int? blueTeamSlot,
+    List<BocciaEndScore>? endScores,
+    List<Map<String, dynamic>>? throwLogs,
+  }) {
+    return BocciaMatchScore(
+      matchNo: matchNo ?? this.matchNo,
+      redTeamSlot: redTeamSlot ?? this.redTeamSlot,
+      blueTeamSlot: blueTeamSlot ?? this.blueTeamSlot,
+      endScores: List<BocciaEndScore>.unmodifiable(
+        endScores ?? this.endScores,
+      ),
+      throwLogs: List<Map<String, dynamic>>.unmodifiable(
+        throwLogs ?? this.throwLogs,
+      ),
+    );
+  }
+
+  BocciaMatchScore replaceEndScore({
+    required int endNo,
+    int? red,
+    int? blue,
+  }) {
+    return copyWith(
+      endScores: endScores.map((endScore) {
+        if (endScore.endNo != endNo) {
+          return endScore;
+        }
+
+        return endScore.copyWith(
+          red: red,
+          blue: blue,
+        );
+      }).toList(growable: false),
+    );
+  }
+
+  BocciaMatchScore swapped() {
+    return copyWith(
+      redTeamSlot: blueTeamSlot,
+      blueTeamSlot: redTeamSlot,
+      endScores: endScores
+          .map((endScore) => endScore.swapped())
+          .toList(growable: false),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'match_no': matchNo,
+      'red_team_slot': redTeamSlot,
+      'blue_team_slot': blueTeamSlot,
+      'end_count': endCount,
+      'end_scores': endScores.map((endScore) => endScore.toJson()).toList(),
+      'throw_logs': throwLogs,
+    };
+  }
+}
+
+class BocciaEndScore {
+  const BocciaEndScore({
+    required this.endNo,
+    required this.red,
+    required this.blue,
+  });
+
+  const BocciaEndScore.empty({
+    required this.endNo,
+  })  : red = 0,
+        blue = 0;
+
+  factory BocciaEndScore.fromJson(Map<String, dynamic> json) {
+    return BocciaEndScore(
+      endNo: _readInt(json['end_no']),
+      red: _clampScore(_readInt(json['red'])),
+      blue: _clampScore(_readInt(json['blue'])),
+    );
+  }
+
+  final int endNo;
+  final int red;
+  final int blue;
+
+  BocciaEndScore copyWith({
+    int? endNo,
+    int? red,
+    int? blue,
+  }) {
+    return BocciaEndScore(
+      endNo: endNo ?? this.endNo,
+      red: red == null ? this.red : _clampScore(red),
+      blue: blue == null ? this.blue : _clampScore(blue),
+    );
+  }
+
+  BocciaEndScore swapped() {
+    return copyWith(
+      red: blue,
+      blue: red,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'end_no': endNo,
+      'red': red,
+      'blue': blue,
+    };
+  }
+}
+
+List<BocciaEndScore> _readEndScores(Object? value) {
+  if (value is! List) {
+    return const <BocciaEndScore>[];
+  }
+
+  return value
+      .whereType<Map>()
+      .map((json) => BocciaEndScore.fromJson(_readObject(json)))
+      .where((endScore) => endScore.endNo > 0)
+      .toList(growable: false);
+}
+
+List<BocciaEndScore> _normalizeEndScores(
+  List<BocciaEndScore> source, {
+  required int endCount,
+}) {
+  final sourceByEndNo = <int, BocciaEndScore>{
+    for (final endScore in source) endScore.endNo: endScore,
+  };
+
+  return List<BocciaEndScore>.unmodifiable(
+    List<BocciaEndScore>.generate(
+      endCount,
+      (index) {
+        final endNo = index + 1;
+        return sourceByEndNo[endNo] ?? BocciaEndScore.empty(endNo: endNo);
+      },
+    ),
+  );
+}
+
+Map<String, dynamic> _readObject(Object? value) {
+  if (value is! Map) {
+    return const <String, dynamic>{};
+  }
+
+  return <String, dynamic>{
+    for (final entry in value.entries) entry.key.toString(): entry.value,
+  };
+}
+
+List<Map<String, dynamic>> _readObjectList(Object? value) {
+  if (value is! List) {
+    return const <Map<String, dynamic>>[];
+  }
+
+  return List<Map<String, dynamic>>.unmodifiable(
+    value.whereType<Map>().map(_readObject),
+  );
+}
+
+int _readInt(Object? value, {int defaultValue = 0}) {
+  if (value is int) {
+    return value;
+  }
+
+  if (value is num) {
+    return value.toInt();
+  }
+
+  if (value is String) {
+    return int.tryParse(value) ?? defaultValue;
+  }
+
+  return defaultValue;
+}
+
+int _clampScore(int value) {
+  return value.clamp(0, 6).toInt();
+}

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -7,9 +7,11 @@ import 'package:srp_lanske/l10n/l10n.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 
 import '../application/team_generated_schedule_service.dart';
+import '../domain/boccia_score.dart';
 import '../domain/saved_team_schedule.dart';
 import '../domain/team_generated_schedule.dart';
 import 'models/team_setup_draft.dart';
+import 'widgets/boccia_score_dialog.dart';
 
 enum _TeamSchedulePageMode {
   create,
@@ -47,6 +49,10 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
   bool _isLoading = true;
   bool _isSavingDisplay = false;
   String? _displaySaveErrorMessage;
+
+  TeamScheduleScores _scores = const TeamScheduleScores.empty();
+  bool _isSavingScores = false;
+  String? _scoresSaveErrorMessage;
 
   String _eventTitle = '';
   Map<int, String> _teamDisplayNames = const {};
@@ -171,6 +177,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         _selectedTeamSlot = schedule.teams.first.teamSlot;
         _shareId = saved.shareId;
         _shareUrl = _buildShareUrl(saved.shareId);
+        _scores = TeamScheduleScores.fromJson(saved.scores);
         _isLoading = false;
       });
     } catch (error) {
@@ -236,6 +243,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         _selectedTeamSlot = schedule.teams.first.teamSlot;
         _shareId = saved.shareId;
         _shareUrl = _buildShareUrl(saved.shareId);
+        _scores = TeamScheduleScores.fromJson(saved.scores);
         _isLoading = false;
       });
     } catch (error) {
@@ -453,6 +461,128 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     }
   }
 
+  Future<TeamScheduleScores> _saveScores(TeamScheduleScores scores) async {
+    final shareId = _shareId;
+    if (shareId == null || shareId.isEmpty) {
+      setState(() {
+        _scores = scores;
+        _scoresSaveErrorMessage = null;
+      });
+      return scores;
+    }
+
+    setState(() {
+      _isSavingScores = true;
+      _scoresSaveErrorMessage = null;
+    });
+
+    try {
+      final saved = await appTeamScheduleRepository.updateScores(
+        shareId: shareId,
+        scores: scores.toJson(),
+      );
+
+      final savedScores = TeamScheduleScores.fromJson(saved.scores);
+
+      if (!mounted) {
+        return savedScores;
+      }
+
+      setState(() {
+        _scores = savedScores;
+        _isSavingScores = false;
+      });
+
+      return savedScores;
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _scoresSaveErrorMessage = _formatError(error);
+          _isSavingScores = false;
+        });
+      }
+
+      rethrow;
+    }
+  }
+
+  Future<void> _selectSport(TeamScheduleSport? sport) async {
+    if (sport == null || sport == _scores.selectedSport || _isSavingScores) {
+      return;
+    }
+
+    try {
+      await _saveScores(_scores.copyWith(selectedSport: sport));
+    } catch (_) {
+      // Error message is shown in the header card.
+    }
+  }
+
+  Future<BocciaMatchScore> _saveBocciaMatchScore(
+    BocciaMatchScore score,
+  ) async {
+    final nextScores = _scores.copyWith(
+      selectedSport: TeamScheduleSport.boccia,
+      boccia: _scores.boccia.upsertMatch(score),
+    );
+
+    final savedScores = await _saveScores(nextScores);
+
+    return savedScores.boccia.matchScore(score.matchNo) ?? score;
+  }
+
+  Future<void> _openBocciaScoreDialog(_TeamMatchViewData match) async {
+    final l10n = AppLocalizations.of(context);
+
+    if (_scores.selectedSport == TeamScheduleSport.none) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.selectSportBeforeScoreInputMessage)),
+      );
+      return;
+    }
+
+    if (_scores.selectedSport != TeamScheduleSport.boccia) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.selectSportBeforeScoreInputMessage)),
+      );
+      return;
+    }
+
+    if (match.teamSlots.length != 2) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.unsupportedBocciaMatchMessage)),
+      );
+      return;
+    }
+
+    final initialScore = _scores.boccia.matchScoreOrInitial(
+      matchNo: match.matchNo,
+      teamSlots: match.teamSlots,
+    );
+
+    await showDialog<BocciaMatchScore>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return BocciaScoreDialog(
+          initialScore: initialScore,
+          redTeamName: _teamName(initialScore.redTeamSlot),
+          blueTeamName: _teamName(initialScore.blueTeamSlot),
+          onSave: _saveBocciaMatchScore,
+        );
+      },
+    );
+  }
+
+  String _sportLabel(TeamScheduleSport sport) {
+    final l10n = AppLocalizations.of(context);
+
+    return switch (sport) {
+      TeamScheduleSport.none => l10n.teamScheduleSportNoneLabel,
+      TeamScheduleSport.boccia => l10n.teamScheduleSportBocciaLabel,
+    };
+  }
+
   String _matchTitle(BuildContext context, _TeamMatchViewData match) {
     final l10n = AppLocalizations.of(context);
     final teamNames = match.teamSlots.map(_teamName).toList(growable: false);
@@ -627,6 +757,8 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
               l10n.teamScheduleBackendDataNotice,
               style: theme.textTheme.bodySmall,
             ),
+            const SizedBox(height: 16),
+            _buildSportSelector(context),
             if (_isSavingDisplay || _displaySaveErrorMessage != null) ...[
               const SizedBox(height: 8),
               _buildDisplaySaveStatus(context),
@@ -669,6 +801,85 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     }
 
     return const SizedBox.shrink();
+  }
+
+  Widget _buildScoreSaveStatus(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final error = _scoresSaveErrorMessage;
+
+    if (_isSavingScores) {
+      return Row(
+        children: [
+          const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            l10n.savingTeamScheduleScoresMessage,
+            style: theme.textTheme.bodySmall,
+          ),
+        ],
+      );
+    }
+
+    if (error != null && error.isNotEmpty) {
+      return Text(
+        l10n.teamScheduleScoresSaveFailedMessage(error),
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+
+  Widget _buildSportSelector(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n.teamScheduleSportSectionTitle,
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 8),
+        DropdownButtonFormField<TeamScheduleSport>(
+          initialValue: _scores.selectedSport,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            contentPadding: EdgeInsets.symmetric(
+              horizontal: 12,
+              vertical: 10,
+            ),
+          ),
+          onChanged: _isSavingScores ? null : _selectSport,
+          items: [
+            for (final sport in TeamScheduleSport.values)
+              DropdownMenuItem<TeamScheduleSport>(
+                value: sport,
+                child: Text(_sportLabel(sport)),
+              ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Text(
+          l10n.teamScheduleSportHelp,
+          style: theme.textTheme.bodySmall,
+        ),
+        if (_isSavingScores || _scoresSaveErrorMessage != null) ...[
+          const SizedBox(height: 8),
+          _buildScoreSaveStatus(context),
+        ],
+      ],
+    );
   }
 
   Widget _buildShareCard(BuildContext context) {
@@ -946,6 +1157,48 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     );
   }
 
+  Widget _buildMatchScoreAction(
+    BuildContext context,
+    _TeamMatchViewData match,
+  ) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final score = _scores.boccia.matchScore(match.matchNo);
+    final hasScore = score?.hasAnyScore ?? false;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (_scores.selectedSport == TeamScheduleSport.boccia &&
+            score != null) ...[
+          Text(
+            l10n.bocciaScoreSummary(
+              redTeamName: _teamName(score.redTeamSlot),
+              redScore: score.totalRedScore,
+              blueTeamName: _teamName(score.blueTeamSlot),
+              blueScore: score.totalBlueScore,
+            ),
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+        FilledButton.tonalIcon(
+          onPressed: _isSavingScores
+              ? null
+              : () {
+                  _openBocciaScoreDialog(match);
+                },
+          icon: const Icon(Icons.edit_note),
+          label: Text(
+            hasScore ? l10n.editBocciaScoreButton : l10n.inputBocciaScoreButton,
+          ),
+        ),
+      ],
+    );
+  }
+
   Widget _buildMatchRow(BuildContext context, _TeamMatchViewData match) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
@@ -979,6 +1232,8 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
               ),
           ],
         ),
+        const SizedBox(height: 12),
+        _buildMatchScoreAction(context, match),
       ],
     );
   }

--- a/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
+++ b/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
@@ -1,0 +1,474 @@
+import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
+
+import '../../domain/boccia_score.dart';
+
+class BocciaScoreDialog extends StatefulWidget {
+  const BocciaScoreDialog({
+    required this.initialScore,
+    required this.redTeamName,
+    required this.blueTeamName,
+    required this.onSave,
+    super.key,
+  });
+
+  final BocciaMatchScore initialScore;
+  final String redTeamName;
+  final String blueTeamName;
+  final Future<BocciaMatchScore> Function(BocciaMatchScore score) onSave;
+
+  @override
+  State<BocciaScoreDialog> createState() => _BocciaScoreDialogState();
+}
+
+class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
+  late BocciaMatchScore _draftScore;
+  late BocciaMatchScore _lastSavedScore;
+
+  bool _isSaving = false;
+  String? _statusMessage;
+  String? _errorMessage;
+
+  bool get _isDirty => !_scoreEquals(_draftScore, _lastSavedScore);
+
+  @override
+  void initState() {
+    super.initState();
+    _draftScore = widget.initialScore;
+    _lastSavedScore = widget.initialScore;
+  }
+
+  String _redTeamName(BocciaMatchScore score) {
+    if (score.redTeamSlot == widget.initialScore.redTeamSlot) {
+      return widget.redTeamName;
+    }
+
+    return widget.blueTeamName;
+  }
+
+  String _blueTeamName(BocciaMatchScore score) {
+    if (score.blueTeamSlot == widget.initialScore.blueTeamSlot) {
+      return widget.blueTeamName;
+    }
+
+    return widget.redTeamName;
+  }
+
+  Future<bool> _save() async {
+    if (_isSaving) {
+      return false;
+    }
+
+    setState(() {
+      _isSaving = true;
+      _statusMessage = null;
+      _errorMessage = null;
+    });
+
+    try {
+      final saved = await widget.onSave(_draftScore);
+
+      if (!mounted) {
+        return false;
+      }
+
+      setState(() {
+        _draftScore = saved;
+        _lastSavedScore = saved;
+        _statusMessage = AppLocalizations.of(context).bocciaScoreSavedMessage;
+        _isSaving = false;
+      });
+
+      return true;
+    } catch (error) {
+      if (!mounted) {
+        return false;
+      }
+
+      setState(() {
+        _errorMessage = error.toString();
+        _isSaving = false;
+      });
+
+      return false;
+    }
+  }
+
+  Future<void> _close() async {
+    if (!_isDirty) {
+      Navigator.of(context).pop(_lastSavedScore);
+      return;
+    }
+
+    final action = await showDialog<_UnsavedAction>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        final l10n = AppLocalizations.of(context);
+
+        return AlertDialog(
+          title: Text(l10n.bocciaScoreDiscardChangesTitle),
+          content: Text(l10n.bocciaScoreDiscardChangesBody),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(_UnsavedAction.returnToInput);
+              },
+              child: Text(l10n.returnToBocciaScoreInputButton),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(_UnsavedAction.discardAndClose);
+              },
+              child: Text(l10n.discardBocciaScoreChangesButton),
+            ),
+            FilledButton(
+              onPressed: () {
+                Navigator.of(context).pop(_UnsavedAction.saveAndClose);
+              },
+              child: Text(l10n.saveAndCloseBocciaScoreButton),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (!mounted || action == null || action == _UnsavedAction.returnToInput) {
+      return;
+    }
+
+    if (action == _UnsavedAction.discardAndClose) {
+      Navigator.of(context).pop(_lastSavedScore);
+      return;
+    }
+
+    final saved = await _save();
+    if (!mounted || !saved) {
+      return;
+    }
+
+    Navigator.of(context).pop(_lastSavedScore);
+  }
+
+  void _swapOrder() {
+    setState(() {
+      _draftScore = _draftScore.swapped();
+      _statusMessage = null;
+      _errorMessage = null;
+    });
+  }
+
+  void _setEndScore({
+    required int endNo,
+    int? red,
+    int? blue,
+  }) {
+    setState(() {
+      _draftScore = _draftScore.replaceEndScore(
+        endNo: endNo,
+        red: red,
+        blue: blue,
+      );
+      _statusMessage = null;
+      _errorMessage = null;
+    });
+  }
+
+  Widget _buildOrderHeader(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        FilledButton.tonalIcon(
+          onPressed: _isSaving ? null : _swapOrder,
+          icon: const Icon(Icons.swap_horiz),
+          label: Text(l10n.swapBocciaOrderButton),
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(
+              child: _buildTeamHeader(
+                context,
+                label: l10n.bocciaFirstTeamLabel,
+                teamName: _redTeamName(_draftScore),
+                backgroundColor: Colors.red.shade50,
+                borderColor: Colors.red.shade200,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: _buildTeamHeader(
+                context,
+                label: l10n.bocciaSecondTeamLabel,
+                teamName: _blueTeamName(_draftScore),
+                backgroundColor: Colors.blue.shade50,
+                borderColor: Colors.blue.shade200,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Text(
+          l10n.bocciaScoreDialogMatchTitle(
+            redTeamName: _redTeamName(_draftScore),
+            blueTeamName: _blueTeamName(_draftScore),
+          ),
+          textAlign: TextAlign.center,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTeamHeader(
+    BuildContext context, {
+    required String label,
+    required String teamName,
+    required Color backgroundColor,
+    required Color borderColor,
+  }) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        border: Border.all(color: borderColor),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.labelLarge,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            teamName,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildScoreTable(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: DataTable(
+        headingRowHeight: 44,
+        dataRowMinHeight: 52,
+        dataRowMaxHeight: 56,
+        columns: [
+          const DataColumn(label: SizedBox(width: 56)),
+          for (final endScore in _draftScore.endScores)
+            DataColumn(
+              label: Text(l10n.bocciaEndLabel(endScore.endNo)),
+            ),
+          DataColumn(
+            label: Text(l10n.bocciaTotalLabel),
+          ),
+        ],
+        rows: [
+          DataRow(
+            color: WidgetStatePropertyAll(Colors.red.shade50),
+            cells: [
+              DataCell(Text(l10n.bocciaFirstTeamLabel)),
+              for (final endScore in _draftScore.endScores)
+                DataCell(
+                  _buildScoreDropdown(
+                    value: endScore.red,
+                    onChanged: (value) {
+                      if (value == null) {
+                        return;
+                      }
+
+                      _setEndScore(
+                        endNo: endScore.endNo,
+                        red: value,
+                      );
+                    },
+                  ),
+                ),
+              DataCell(
+                Text(
+                  _draftScore.totalRedScore.toString(),
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              ),
+            ],
+          ),
+          DataRow(
+            color: WidgetStatePropertyAll(Colors.blue.shade50),
+            cells: [
+              DataCell(Text(l10n.bocciaSecondTeamLabel)),
+              for (final endScore in _draftScore.endScores)
+                DataCell(
+                  _buildScoreDropdown(
+                    value: endScore.blue,
+                    onChanged: (value) {
+                      if (value == null) {
+                        return;
+                      }
+
+                      _setEndScore(
+                        endNo: endScore.endNo,
+                        blue: value,
+                      );
+                    },
+                  ),
+                ),
+              DataCell(
+                Text(
+                  _draftScore.totalBlueScore.toString(),
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildScoreDropdown({
+    required int value,
+    required ValueChanged<int?> onChanged,
+  }) {
+    return DropdownButton<int>(
+      value: value,
+      onChanged: _isSaving ? null : onChanged,
+      items: [
+        for (var score = 0; score <= 6; score += 1)
+          DropdownMenuItem<int>(
+            value: score,
+            child: Text(score.toString()),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildStatus(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    if (_isSaving) {
+      return Row(
+        children: [
+          const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          const SizedBox(width: 8),
+          Text(l10n.savingTeamScheduleScoresMessage),
+        ],
+      );
+    }
+
+    final errorMessage = _errorMessage;
+    if (errorMessage != null && errorMessage.isNotEmpty) {
+      return Text(
+        l10n.teamScheduleScoresSaveFailedMessage(errorMessage),
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      );
+    }
+
+    final statusMessage = _statusMessage;
+    if (statusMessage != null && statusMessage.isNotEmpty) {
+      return Text(
+        statusMessage,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.primary,
+          fontWeight: FontWeight.bold,
+        ),
+      );
+    }
+
+    if (_isDirty) {
+      return Text(
+        l10n.bocciaScoreUnsavedChangesMessage,
+        style: theme.textTheme.bodySmall,
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return AlertDialog(
+      title: Text(l10n.bocciaScoreDialogTitle),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 720),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildOrderHeader(context),
+              const SizedBox(height: 16),
+              _buildScoreTable(context),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: _buildStatus(context),
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isSaving ? null : _close,
+          child: Text(l10n.closeBocciaScoreDialogButton),
+        ),
+        FilledButton(
+          onPressed: _isSaving ? null : _save,
+          child: Text(l10n.saveBocciaScoreButton),
+        ),
+      ],
+    );
+  }
+}
+
+enum _UnsavedAction {
+  returnToInput,
+  discardAndClose,
+  saveAndClose,
+}
+
+bool _scoreEquals(BocciaMatchScore a, BocciaMatchScore b) {
+  if (a.matchNo != b.matchNo ||
+      a.redTeamSlot != b.redTeamSlot ||
+      a.blueTeamSlot != b.blueTeamSlot ||
+      a.endScores.length != b.endScores.length) {
+    return false;
+  }
+
+  for (var index = 0; index < a.endScores.length; index += 1) {
+    final aEnd = a.endScores[index];
+    final bEnd = b.endScores[index];
+
+    if (aEnd.endNo != bEnd.endNo ||
+        aEnd.red != bEnd.red ||
+        aEnd.blue != bEnd.blue) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -298,4 +298,94 @@ extension TeamL10n on AppLocalizations {
   String get cancelDisplayNameEditButton => _isJapanese ? 'キャンセル' : 'Cancel';
 
   String get saveDisplayNameEditButton => _isJapanese ? '保存' : 'Save';
+
+  String get teamScheduleSportSectionTitle =>
+      _isJapanese ? 'スコア入力' : 'Score input';
+
+  String get teamScheduleSportNoneLabel => _isJapanese ? '未選択' : 'Not selected';
+
+  String get teamScheduleSportBocciaLabel => _isJapanese ? 'ボッチャ' : 'Boccia';
+
+  String get teamScheduleSportHelp => _isJapanese
+      ? '競技を選択すると、対戦カードからスコアを入力できます。'
+      : 'Select a sport to enter scores from match cards.';
+
+  String get savingTeamScheduleScoresMessage =>
+      _isJapanese ? 'スコアを保存中です…' : 'Saving scores...';
+
+  String teamScheduleScoresSaveFailedMessage(String detail) {
+    return _isJapanese
+        ? 'スコアの保存に失敗しました: $detail'
+        : 'Failed to save scores: $detail';
+  }
+
+  String get selectSportBeforeScoreInputMessage =>
+      _isJapanese ? '先に競技を選択してください。' : 'Select a sport first.';
+
+  String get unsupportedBocciaMatchMessage => _isJapanese
+      ? 'ボッチャのスコア入力は2チーム対戦のみ対応しています。'
+      : 'Boccia score input supports two-team matches only.';
+
+  String get inputBocciaScoreButton => _isJapanese ? 'スコア入力' : 'Enter score';
+
+  String get editBocciaScoreButton => _isJapanese ? 'スコア編集' : 'Edit score';
+
+  String bocciaScoreSummary({
+    required String redTeamName,
+    required int redScore,
+    required String blueTeamName,
+    required int blueScore,
+  }) {
+    return '$redTeamName $redScore - $blueScore $blueTeamName';
+  }
+
+  String get bocciaScoreDialogTitle =>
+      _isJapanese ? 'ボッチャ スコア入力' : 'Boccia score input';
+
+  String bocciaScoreDialogMatchTitle({
+    required String redTeamName,
+    required String blueTeamName,
+  }) {
+    return '$redTeamName vs $blueTeamName';
+  }
+
+  String get bocciaFirstTeamLabel => _isJapanese ? '先攻' : 'First';
+
+  String get bocciaSecondTeamLabel => _isJapanese ? '後攻' : 'Second';
+
+  String get swapBocciaOrderButton => _isJapanese ? '先攻 🔁 後攻' : 'Swap order';
+
+  String get swapBocciaOrderTooltip =>
+      _isJapanese ? '先攻と後攻をスコアごと入れ替える' : 'Swap teams and their scores';
+
+  String bocciaEndLabel(int endNo) {
+    return _isJapanese ? '$endNo E' : 'E$endNo';
+  }
+
+  String get bocciaTotalLabel => _isJapanese ? '合計' : 'Total';
+
+  String get saveBocciaScoreButton => _isJapanese ? '保存' : 'Save';
+
+  String get closeBocciaScoreDialogButton => _isJapanese ? '閉じる' : 'Close';
+
+  String get bocciaScoreSavedMessage => _isJapanese ? '保存しました' : 'Saved.';
+
+  String get bocciaScoreUnsavedChangesMessage =>
+      _isJapanese ? '未保存の変更があります' : 'There are unsaved changes.';
+
+  String get bocciaScoreDiscardChangesTitle =>
+      _isJapanese ? '未保存の変更があります' : 'Unsaved changes';
+
+  String get bocciaScoreDiscardChangesBody => _isJapanese
+      ? '保存していないスコア変更があります。閉じますか？'
+      : 'There are unsaved score changes. Do you want to close?';
+
+  String get returnToBocciaScoreInputButton =>
+      _isJapanese ? '入力に戻る' : 'Back to input';
+
+  String get discardBocciaScoreChangesButton =>
+      _isJapanese ? '保存せず閉じる' : 'Close without saving';
+
+  String get saveAndCloseBocciaScoreButton =>
+      _isJapanese ? '保存して閉じる' : 'Save and close';
 }


### PR DESCRIPTION
## 概要

#111 の対応として、チーム用対戦表にボッチャ用スコア入力 MVP を追加しました。

各対戦カードからスコア入力ダイアログを開き、6エンド分の赤 / 青スコアを入力できます。合計点は自動計算し、入力済みのスコアは対戦カード上にも表示します。

スコアは `SavedTeamSchedule.scores` 配下に保存し、Firestore 保存済みの共有URLを再読み込みした場合も復元できるようにしています。

## 変更内容

- チーム用対戦表の header card に競技選択を追加
- `scores.selected_sport` で選択競技を保存
- ボッチャ用スコア model を追加
- 各対戦カードにスコア入力 / 編集ボタンを追加
- ボッチャ用スコア入力ダイアログを追加
- 6エンド分の 0〜6 スコア入力を追加
- 合計点の自動計算を追加
- 先攻 / 後攻の入れ替えを追加
- 入れ替え時はスコアごと swap するように実装
- スコア保存用に `TeamScheduleRepository.updateScores` を追加
- Firestore / in-memory repository に score 更新処理を追加
- 共有URL復元時に保存済みスコアを復元
- Codespaces で core API と接続する README メモを追記

## 保存 shape

ボッチャスコアは `SavedTeamSchedule.scores` 配下に保存します。

```json
{
  "scores": {
    "selected_sport": "boccia",
    "boccia": {
      "matches": {
        "1": {
          "match_no": 1,
          "red_team_slot": 1,
          "blue_team_slot": 2,
          "end_count": 6,
          "end_scores": [
            {
              "end_no": 1,
              "red": 0,
              "blue": 0
            }
          ],
          "throw_logs": []
        }
      }
    }
  }
}
````

`throw_logs` は後続 Issue で投球順ログを追加するため、今回は空配列として保持しています。

## UI / 挙動

* 競技未選択時は、スコア入力前に競技選択を促す
* ボッチャ選択時のみスコア入力 / 編集を行う
* スコア入力ダイアログは枠外タップで閉じない
* 保存ボタンを押してもダイアログは閉じず、入力を継続できる
* 未保存変更がある状態で閉じる場合は確認を出す
* 「保存せず閉じる」「保存して閉じる」「入力に戻る」を選べる
* スコア入力済みの場合、対戦カードに合計スコアを表示する
* `selected_sport` を未選択に戻すとスコア表示は隠れる
* 再度ボッチャを選択すると保存済みスコアが再表示される

## 今回やらないこと

以下は後続 Issue に切り出します。

* 投球順ログ入力
* エンド別の投球場所設定
* メンバー別投球数の集計
* 公式ルール上の厳密な得点バリデーション
* エンド数可変
* 他競技対応
* 勝敗 / 順位集計

## 確認内容

* [x] `dart format`
* [x] `flutter analyze`
* [x] `flutter test`
* [x] `/team` でチーム用対戦表を生成できる
* [x] header card で競技をボッチャに変更できる
* [x] 各対戦カードからスコア入力ダイアログを開ける
* [x] 6エンド分のスコアを入力できる
* [x] 合計点が自動計算される
* [x] 先攻 / 後攻を入れ替えるとスコアごと入れ替わる
* [x] 保存後もダイアログが閉じず、入力を継続できる
* [x] 未保存変更ありで閉じる場合に確認が出る
* [x] 対戦カードに入力済みスコアが表示される
* [x] 共有URLを再読み込みしてもスコアが復元される
* [x] 競技を未選択に戻すとスコア表示が隠れる
* [x] 再度ボッチャを選択すると保存済みスコアが表示される

Closes #111
