### PR TITLE
✨ feat: add boccia throwing box player assignments refs #116

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,18 +154,18 @@ flutter run -d web-server --web-hostname 0.0.0.0 --web-port 3000 \
 
 ### Codespaces で core API と接続して起動する
 
-`srp-lanske-web` を Codespaces で起動し、別 Codespace で起動している `srp-lanske-core` に接続する場合は、core 側の forwarded URL を `LANSKE_API_BASE_URL` に指定する。
+`srp-lanske-web` を Codespaces で起動し、別 Codespace で起動している `srp-lanske-core` に接続する場合は、core 側の forwarded URL を `LANSKE_CORE_API_BASE_URL` に指定する。
 
 ```bash
 flutter run -d chrome \
-  --dart-define=LANSKE_API_BASE_URL=https://<core-codespace-name>-8080.app.github.dev
+  --dart-define=LANSKE_CORE_API_BASE_URL=https://<core-codespace-name>-8080.app.github.dev
 ```
 
 Firestore event repository を使う場合は、必要に応じて以下も指定する。
 
 ```bash
 flutter run -d chrome \
-  --dart-define=LANSKE_API_BASE_URL=https://<core-codespace-name>-8080.app.github.dev \
+  --dart-define=LANSKE_CORE_API_BASE_URL=https://<core-codespace-name>-8080.app.github.dev \
   --dart-define=LANSKE_EVENT_REPOSITORY=firestore
 ```
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,30 @@ flutter run -d web-server --web-hostname 0.0.0.0 --web-port 3000 \
 
 `<core-api-url>` には Cloud Run などの公開 core API URL を指定します。
 
+### Codespaces で core API と接続して起動する
+
+`srp-lanske-web` を Codespaces で起動し、別 Codespace で起動している `srp-lanske-core` に接続する場合は、core 側の forwarded URL を `LANSKE_API_BASE_URL` に指定する。
+
+```bash
+flutter run -d chrome \
+  --dart-define=LANSKE_API_BASE_URL=https://<core-codespace-name>-8080.app.github.dev
+```
+
+Firestore event repository を使う場合は、必要に応じて以下も指定する。
+
+```bash
+flutter run -d chrome \
+  --dart-define=LANSKE_API_BASE_URL=https://<core-codespace-name>-8080.app.github.dev \
+  --dart-define=LANSKE_EVENT_REPOSITORY=firestore
+```
+
+注意:
+
+* web から core を叩く場合、基本的に `localhost` ではなく core Codespace の forwarded URL を使う
+* core の `8080` port が Private の場合、別 Codespace / ブラウザからのアクセスで `302 pf-signin` にリダイレクトされることがある
+* core の forwarded URL で `/health` が通ることを確認してから web を起動する
+* 詳細な起動・確認手順は `lee-esys/worklog/lanske/codespaces-web-core-runbook.md` を参照する
+
 ---
 
 ## 📚 ドキュメント

--- a/lib/features/team_scheduler/application/team_schedule_repository.dart
+++ b/lib/features/team_scheduler/application/team_schedule_repository.dart
@@ -17,4 +17,9 @@ abstract class TeamScheduleRepository {
     required String shareId,
     required SavedTeamScheduleDisplay display,
   });
+
+  Future<SavedTeamSchedule> updateScores({
+    required String shareId,
+    required Map<String, dynamic> scores,
+  });
 }

--- a/lib/features/team_scheduler/data/firestore_team_schedule_repository.dart
+++ b/lib/features/team_scheduler/data/firestore_team_schedule_repository.dart
@@ -79,10 +79,7 @@ class FirestoreTeamScheduleRepository implements TeamScheduleRepository {
     required String shareId,
     required SavedTeamScheduleDisplay display,
   }) async {
-    final current = await findByShareId(shareId);
-    if (current == null) {
-      throw StateError('team schedule not found: $shareId');
-    }
+    final current = await _readExisting(shareId);
 
     final updated = current.copyWith(
       display: display,
@@ -92,6 +89,32 @@ class FirestoreTeamScheduleRepository implements TeamScheduleRepository {
     await _collection.doc(shareId).set(updated.toJson());
 
     return updated;
+  }
+
+  @override
+  Future<SavedTeamSchedule> updateScores({
+    required String shareId,
+    required Map<String, dynamic> scores,
+  }) async {
+    final current = await _readExisting(shareId);
+
+    final updated = current.copyWith(
+      scores: Map<String, dynamic>.unmodifiable(scores),
+      updatedAt: DateTime.now(),
+    );
+
+    await _collection.doc(shareId).set(updated.toJson());
+
+    return updated;
+  }
+
+  Future<SavedTeamSchedule> _readExisting(String shareId) async {
+    final current = await findByShareId(shareId);
+    if (current == null) {
+      throw StateError('team schedule not found: $shareId');
+    }
+
+    return current;
   }
 
   Future<String> _generateUniqueShareId() async {

--- a/lib/features/team_scheduler/data/in_memory_team_schedule_repository.dart
+++ b/lib/features/team_scheduler/data/in_memory_team_schedule_repository.dart
@@ -61,10 +61,7 @@ class InMemoryTeamScheduleRepository implements TeamScheduleRepository {
     required String shareId,
     required SavedTeamScheduleDisplay display,
   }) async {
-    final current = _schedulesByShareId[shareId];
-    if (current == null) {
-      throw StateError('team schedule not found: $shareId');
-    }
+    final current = _readExisting(shareId);
 
     final updated = current.copyWith(
       display: display,
@@ -73,6 +70,31 @@ class InMemoryTeamScheduleRepository implements TeamScheduleRepository {
 
     _schedulesByShareId[shareId] = updated;
     return updated;
+  }
+
+  @override
+  Future<SavedTeamSchedule> updateScores({
+    required String shareId,
+    required Map<String, dynamic> scores,
+  }) async {
+    final current = _readExisting(shareId);
+
+    final updated = current.copyWith(
+      scores: Map<String, dynamic>.unmodifiable(scores),
+      updatedAt: DateTime.now(),
+    );
+
+    _schedulesByShareId[shareId] = updated;
+    return updated;
+  }
+
+  SavedTeamSchedule _readExisting(String shareId) {
+    final current = _schedulesByShareId[shareId];
+    if (current == null) {
+      throw StateError('team schedule not found: $shareId');
+    }
+
+    return current;
   }
 
   String _generateUniqueShareId() {

--- a/lib/features/team_scheduler/domain/boccia_score.dart
+++ b/lib/features/team_scheduler/domain/boccia_score.dart
@@ -19,6 +19,27 @@ extension TeamScheduleSportJson on TeamScheduleSport {
   }
 }
 
+enum BocciaThrowingSide {
+  red,
+  blue,
+}
+
+extension BocciaThrowingSideJson on BocciaThrowingSide {
+  String toJsonValue() {
+    return switch (this) {
+      BocciaThrowingSide.red => 'red',
+      BocciaThrowingSide.blue => 'blue',
+    };
+  }
+
+  static BocciaThrowingSide fromJsonValue(Object? value) {
+    return switch (value?.toString()) {
+      'blue' => BocciaThrowingSide.blue,
+      _ => BocciaThrowingSide.red,
+    };
+  }
+}
+
 class TeamScheduleScores {
   const TeamScheduleScores({
     required this.selectedSport,
@@ -105,6 +126,8 @@ class BocciaScoreSheet {
   BocciaMatchScore initialMatchScore({
     required int matchNo,
     required List<int> teamSlots,
+    List<int> redPlayerSlots = const <int>[],
+    List<int> bluePlayerSlots = const <int>[],
   }) {
     if (teamSlots.length != 2) {
       throw ArgumentError.value(
@@ -118,17 +141,23 @@ class BocciaScoreSheet {
       matchNo: matchNo,
       redTeamSlot: teamSlots[0],
       blueTeamSlot: teamSlots[1],
+      redPlayerSlots: redPlayerSlots,
+      bluePlayerSlots: bluePlayerSlots,
     );
   }
 
   BocciaMatchScore matchScoreOrInitial({
     required int matchNo,
     required List<int> teamSlots,
+    List<int> redPlayerSlots = const <int>[],
+    List<int> bluePlayerSlots = const <int>[],
   }) {
     return matchScore(matchNo) ??
         initialMatchScore(
           matchNo: matchNo,
           teamSlots: teamSlots,
+          redPlayerSlots: redPlayerSlots,
+          bluePlayerSlots: bluePlayerSlots,
         );
   }
 
@@ -161,6 +190,7 @@ class BocciaMatchScore {
     required this.redTeamSlot,
     required this.blueTeamSlot,
     required this.endScores,
+    required this.throwingBoxAssignments,
     required this.throwLogs,
   });
 
@@ -169,6 +199,8 @@ class BocciaMatchScore {
     required int redTeamSlot,
     required int blueTeamSlot,
     int endCount = 6,
+    List<int> redPlayerSlots = const <int>[],
+    List<int> bluePlayerSlots = const <int>[],
   }) {
     return BocciaMatchScore(
       matchNo: matchNo,
@@ -179,6 +211,10 @@ class BocciaMatchScore {
           endCount,
           (index) => BocciaEndScore.empty(endNo: index + 1),
         ),
+      ),
+      throwingBoxAssignments: _initialThrowingBoxAssignments(
+        redPlayerSlots: redPlayerSlots,
+        bluePlayerSlots: bluePlayerSlots,
       ),
       throwLogs: const <Map<String, dynamic>>[],
     );
@@ -199,6 +235,9 @@ class BocciaMatchScore {
         parsedEndScores,
         endCount: endCount,
       ),
+      throwingBoxAssignments: _normalizeThrowingBoxAssignments(
+        _readThrowingBoxAssignments(json['throwing_box_assignments']),
+      ),
       throwLogs: _readObjectList(json['throw_logs']),
     );
   }
@@ -207,6 +246,7 @@ class BocciaMatchScore {
   final int redTeamSlot;
   final int blueTeamSlot;
   final List<BocciaEndScore> endScores;
+  final List<BocciaThrowingBoxAssignment> throwingBoxAssignments;
   final List<Map<String, dynamic>> throwLogs;
 
   int get endCount => endScores.length;
@@ -229,11 +269,39 @@ class BocciaMatchScore {
     return endScores.any((endScore) => endScore.red > 0 || endScore.blue > 0);
   }
 
+  BocciaThrowingBoxAssignment? throwingBoxAssignment(int boxNo) {
+    final normalizedBoxNo = _normalizeThrowingBoxNo(boxNo);
+    if (normalizedBoxNo == null) {
+      return null;
+    }
+
+    for (final assignment in throwingBoxAssignments) {
+      if (assignment.boxNo == normalizedBoxNo) {
+        return assignment;
+      }
+    }
+
+    return BocciaThrowingBoxAssignment.empty(boxNo: normalizedBoxNo);
+  }
+
+  List<BocciaThrowingBoxAssignment> get redThrowingBoxAssignments {
+    return throwingBoxAssignments
+        .where((assignment) => assignment.side == BocciaThrowingSide.red)
+        .toList(growable: false);
+  }
+
+  List<BocciaThrowingBoxAssignment> get blueThrowingBoxAssignments {
+    return throwingBoxAssignments
+        .where((assignment) => assignment.side == BocciaThrowingSide.blue)
+        .toList(growable: false);
+  }
+
   BocciaMatchScore copyWith({
     int? matchNo,
     int? redTeamSlot,
     int? blueTeamSlot,
     List<BocciaEndScore>? endScores,
+    List<BocciaThrowingBoxAssignment>? throwingBoxAssignments,
     List<Map<String, dynamic>>? throwLogs,
   }) {
     return BocciaMatchScore(
@@ -242,6 +310,9 @@ class BocciaMatchScore {
       blueTeamSlot: blueTeamSlot ?? this.blueTeamSlot,
       endScores: List<BocciaEndScore>.unmodifiable(
         endScores ?? this.endScores,
+      ),
+      throwingBoxAssignments: _normalizeThrowingBoxAssignments(
+        throwingBoxAssignments ?? this.throwingBoxAssignments,
       ),
       throwLogs: List<Map<String, dynamic>>.unmodifiable(
         throwLogs ?? this.throwLogs,
@@ -268,6 +339,34 @@ class BocciaMatchScore {
     );
   }
 
+  BocciaMatchScore replaceThrowingBoxPlayer({
+    required int boxNo,
+    int? playerSlot,
+  }) {
+    final normalizedBoxNo = _normalizeThrowingBoxNo(boxNo);
+    if (normalizedBoxNo == null) {
+      return this;
+    }
+
+    return copyWith(
+      throwingBoxAssignments: throwingBoxAssignments.map((assignment) {
+        if (assignment.boxNo != normalizedBoxNo) {
+          return assignment;
+        }
+
+        return assignment.copyWith(
+          playerSlot: playerSlot,
+        );
+      }).toList(growable: false),
+    );
+  }
+
+  BocciaMatchScore clearThrowingBoxPlayer({
+    required int boxNo,
+  }) {
+    return replaceThrowingBoxPlayer(boxNo: boxNo);
+  }
+
   BocciaMatchScore swapped() {
     return copyWith(
       redTeamSlot: blueTeamSlot,
@@ -275,6 +374,9 @@ class BocciaMatchScore {
       endScores: endScores
           .map((endScore) => endScore.swapped())
           .toList(growable: false),
+      throwingBoxAssignments: _swapThrowingBoxAssignments(
+        throwingBoxAssignments,
+      ),
     );
   }
 
@@ -285,6 +387,9 @@ class BocciaMatchScore {
       'blue_team_slot': blueTeamSlot,
       'end_count': endCount,
       'end_scores': endScores.map((endScore) => endScore.toJson()).toList(),
+      'throwing_box_assignments': throwingBoxAssignments
+          .map((assignment) => assignment.toJson())
+          .toList(),
       'throw_logs': throwLogs,
     };
   }
@@ -342,6 +447,88 @@ class BocciaEndScore {
   }
 }
 
+class BocciaThrowingBoxAssignment {
+  const BocciaThrowingBoxAssignment({
+    required this.boxNo,
+    required this.side,
+    required this.playerSlot,
+  });
+
+  factory BocciaThrowingBoxAssignment.empty({
+    required int boxNo,
+  }) {
+    final normalizedBoxNo = _normalizeThrowingBoxNo(boxNo) ?? boxNo;
+
+    return BocciaThrowingBoxAssignment(
+      boxNo: normalizedBoxNo,
+      side: _throwingSideForBoxNo(normalizedBoxNo),
+      playerSlot: null,
+    );
+  }
+
+  factory BocciaThrowingBoxAssignment.fromJson(Map<String, dynamic> json) {
+    final boxNo = _normalizeThrowingBoxNo(_readInt(json['box_no'])) ?? 1;
+
+    return BocciaThrowingBoxAssignment(
+      boxNo: boxNo,
+      side: _throwingSideForBoxNo(boxNo),
+      playerSlot: _normalizePlayerSlot(json['player_slot']),
+    );
+  }
+
+  final int boxNo;
+  final BocciaThrowingSide side;
+  final int? playerSlot;
+
+  bool get hasPlayer => playerSlot != null;
+  BocciaThrowingBoxAssignment copyWith({
+    int? boxNo,
+    BocciaThrowingSide? side,
+    Object? playerSlot = _unsetPlayerSlot,
+  }) {
+    final normalizedBoxNo = _normalizeThrowingBoxNo(boxNo ?? this.boxNo) ??
+        _normalizeThrowingBoxNo(this.boxNo) ??
+        this.boxNo;
+    final normalizedSide = _throwingSideForBoxNo(normalizedBoxNo);
+
+    return BocciaThrowingBoxAssignment(
+      boxNo: normalizedBoxNo,
+      side: side ?? normalizedSide,
+      playerSlot: identical(playerSlot, _unsetPlayerSlot)
+          ? this.playerSlot
+          : _normalizePlayerSlot(playerSlot),
+    );
+  }
+
+  BocciaThrowingBoxAssignment swapped() {
+    final nextBoxNo = switch (boxNo) {
+      1 => 2,
+      2 => 1,
+      3 => 4,
+      4 => 3,
+      5 => 6,
+      6 => 5,
+      _ => boxNo,
+    };
+
+    return BocciaThrowingBoxAssignment(
+      boxNo: nextBoxNo,
+      side: _throwingSideForBoxNo(nextBoxNo),
+      playerSlot: playerSlot,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'box_no': boxNo,
+      'side': side.toJsonValue(),
+      'player_slot': playerSlot,
+    };
+  }
+}
+
+const Object _unsetPlayerSlot = Object();
+
 List<BocciaEndScore> _readEndScores(Object? value) {
   if (value is! List) {
     return const <BocciaEndScore>[];
@@ -371,6 +558,173 @@ List<BocciaEndScore> _normalizeEndScores(
       },
     ),
   );
+}
+
+List<BocciaThrowingBoxAssignment> _readThrowingBoxAssignments(Object? value) {
+  if (value is! List) {
+    return const <BocciaThrowingBoxAssignment>[];
+  }
+
+  return value
+      .whereType<Map>()
+      .map((json) => BocciaThrowingBoxAssignment.fromJson(_readObject(json)))
+      .where((assignment) => _normalizeThrowingBoxNo(assignment.boxNo) != null)
+      .toList(growable: false);
+}
+
+List<BocciaThrowingBoxAssignment> _initialThrowingBoxAssignments({
+  required List<int> redPlayerSlots,
+  required List<int> bluePlayerSlots,
+}) {
+  final assignments = _emptyThrowingBoxAssignments().toList(growable: true);
+
+  void assign({
+    required BocciaThrowingSide side,
+    required List<int> playerSlots,
+  }) {
+    final normalizedPlayerSlots = playerSlots
+        .map(_normalizePlayerSlot)
+        .whereType<int>()
+        .toList(growable: false);
+    final boxNos = _preferredThrowingBoxNos(
+      side: side,
+      playerCount: normalizedPlayerSlots.length,
+    );
+
+    for (var index = 0;
+        index < normalizedPlayerSlots.length && index < boxNos.length;
+        index += 1) {
+      final boxNo = boxNos[index];
+      final assignmentIndex = assignments.indexWhere(
+        (assignment) => assignment.boxNo == boxNo,
+      );
+
+      if (assignmentIndex < 0) {
+        continue;
+      }
+
+      assignments[assignmentIndex] = assignments[assignmentIndex].copyWith(
+        playerSlot: normalizedPlayerSlots[index],
+      );
+    }
+  }
+
+  assign(
+    side: BocciaThrowingSide.red,
+    playerSlots: redPlayerSlots,
+  );
+  assign(
+    side: BocciaThrowingSide.blue,
+    playerSlots: bluePlayerSlots,
+  );
+
+  return List<BocciaThrowingBoxAssignment>.unmodifiable(assignments);
+}
+
+List<BocciaThrowingBoxAssignment> _emptyThrowingBoxAssignments() {
+  return List<BocciaThrowingBoxAssignment>.unmodifiable(
+    List<BocciaThrowingBoxAssignment>.generate(
+      6,
+      (index) => BocciaThrowingBoxAssignment.empty(boxNo: index + 1),
+    ),
+  );
+}
+
+List<BocciaThrowingBoxAssignment> _normalizeThrowingBoxAssignments(
+  List<BocciaThrowingBoxAssignment> source,
+) {
+  final sourceByBoxNo = <int, BocciaThrowingBoxAssignment>{
+    for (final assignment in source)
+      if (_normalizeThrowingBoxNo(assignment.boxNo) != null)
+        assignment.boxNo: assignment,
+  };
+
+  return List<BocciaThrowingBoxAssignment>.unmodifiable(
+    List<BocciaThrowingBoxAssignment>.generate(
+      6,
+      (index) {
+        final boxNo = index + 1;
+        final source = sourceByBoxNo[boxNo];
+
+        if (source == null) {
+          return BocciaThrowingBoxAssignment.empty(boxNo: boxNo);
+        }
+
+        return BocciaThrowingBoxAssignment(
+          boxNo: boxNo,
+          side: _throwingSideForBoxNo(boxNo),
+          playerSlot: _normalizePlayerSlot(source.playerSlot),
+        );
+      },
+    ),
+  );
+}
+
+List<BocciaThrowingBoxAssignment> _swapThrowingBoxAssignments(
+  List<BocciaThrowingBoxAssignment> source,
+) {
+  final normalized = _normalizeThrowingBoxAssignments(source);
+
+  final nextRedPlayerSlots = normalized
+      .where((assignment) => assignment.side == BocciaThrowingSide.blue)
+      .map((assignment) => assignment.playerSlot)
+      .whereType<int>()
+      .toList(growable: false);
+
+  final nextBluePlayerSlots = normalized
+      .where((assignment) => assignment.side == BocciaThrowingSide.red)
+      .map((assignment) => assignment.playerSlot)
+      .whereType<int>()
+      .toList(growable: false);
+
+  return _initialThrowingBoxAssignments(
+    redPlayerSlots: nextRedPlayerSlots,
+    bluePlayerSlots: nextBluePlayerSlots,
+  );
+}
+
+List<int> _preferredThrowingBoxNos({
+  required BocciaThrowingSide side,
+  required int playerCount,
+}) {
+  if (playerCount <= 0) {
+    return const <int>[];
+  }
+
+  return switch (side) {
+    BocciaThrowingSide.red => switch (playerCount) {
+        1 => const <int>[3],
+        2 => const <int>[3, 5],
+        _ => const <int>[1, 3, 5],
+      },
+    BocciaThrowingSide.blue => switch (playerCount) {
+        1 => const <int>[4],
+        2 => const <int>[2, 4],
+        _ => const <int>[2, 4, 6],
+      },
+  };
+}
+
+BocciaThrowingSide _throwingSideForBoxNo(int boxNo) {
+  return boxNo.isOdd ? BocciaThrowingSide.red : BocciaThrowingSide.blue;
+}
+
+int? _normalizeThrowingBoxNo(Object? value) {
+  final boxNo = _readInt(value);
+  if (boxNo < 1 || boxNo > 6) {
+    return null;
+  }
+
+  return boxNo;
+}
+
+int? _normalizePlayerSlot(Object? value) {
+  final playerSlot = _readInt(value);
+  if (playerSlot <= 0) {
+    return null;
+  }
+
+  return playerSlot;
 }
 
 Map<String, dynamic> _readObject(Object? value) {

--- a/lib/features/team_scheduler/domain/boccia_score.dart
+++ b/lib/features/team_scheduler/domain/boccia_score.dart
@@ -1,0 +1,414 @@
+enum TeamScheduleSport {
+  none,
+  boccia,
+}
+
+extension TeamScheduleSportJson on TeamScheduleSport {
+  String? toJsonValue() {
+    return switch (this) {
+      TeamScheduleSport.none => null,
+      TeamScheduleSport.boccia => 'boccia',
+    };
+  }
+
+  static TeamScheduleSport fromJsonValue(Object? value) {
+    return switch (value?.toString()) {
+      'boccia' => TeamScheduleSport.boccia,
+      _ => TeamScheduleSport.none,
+    };
+  }
+}
+
+class TeamScheduleScores {
+  const TeamScheduleScores({
+    required this.selectedSport,
+    required this.boccia,
+  });
+
+  const TeamScheduleScores.empty()
+      : selectedSport = TeamScheduleSport.none,
+        boccia = const BocciaScoreSheet.empty();
+
+  factory TeamScheduleScores.fromJson(Map<String, dynamic> json) {
+    return TeamScheduleScores(
+      selectedSport: TeamScheduleSportJson.fromJsonValue(
+        json['selected_sport'],
+      ),
+      boccia: BocciaScoreSheet.fromJson(_readObject(json['boccia'])),
+    );
+  }
+
+  final TeamScheduleSport selectedSport;
+  final BocciaScoreSheet boccia;
+
+  TeamScheduleScores copyWith({
+    TeamScheduleSport? selectedSport,
+    BocciaScoreSheet? boccia,
+  }) {
+    return TeamScheduleScores(
+      selectedSport: selectedSport ?? this.selectedSport,
+      boccia: boccia ?? this.boccia,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'selected_sport': selectedSport.toJsonValue(),
+      'boccia': boccia.toJson(),
+    };
+  }
+}
+
+class BocciaScoreSheet {
+  const BocciaScoreSheet({
+    required this.matches,
+  });
+
+  const BocciaScoreSheet.empty() : matches = const <int, BocciaMatchScore>{};
+
+  factory BocciaScoreSheet.fromJson(Map<String, dynamic> json) {
+    final matchesJson = json['matches'];
+    if (matchesJson is! Map) {
+      return const BocciaScoreSheet.empty();
+    }
+
+    final matches = <int, BocciaMatchScore>{};
+
+    for (final entry in matchesJson.entries) {
+      final value = entry.value;
+      if (value is! Map) {
+        continue;
+      }
+
+      final matchNoFromKey = _readInt(entry.key);
+      final parsed = BocciaMatchScore.fromJson(_readObject(value));
+      final matchNo = parsed.matchNo > 0 ? parsed.matchNo : matchNoFromKey;
+
+      if (matchNo <= 0) {
+        continue;
+      }
+
+      matches[matchNo] = parsed.copyWith(matchNo: matchNo);
+    }
+
+    return BocciaScoreSheet(
+      matches: Map<int, BocciaMatchScore>.unmodifiable(matches),
+    );
+  }
+
+  final Map<int, BocciaMatchScore> matches;
+
+  BocciaMatchScore? matchScore(int matchNo) {
+    return matches[matchNo];
+  }
+
+  BocciaMatchScore initialMatchScore({
+    required int matchNo,
+    required List<int> teamSlots,
+  }) {
+    if (teamSlots.length != 2) {
+      throw ArgumentError.value(
+        teamSlots,
+        'teamSlots',
+        'Boccia score input supports two-team matches only.',
+      );
+    }
+
+    return BocciaMatchScore.initial(
+      matchNo: matchNo,
+      redTeamSlot: teamSlots[0],
+      blueTeamSlot: teamSlots[1],
+    );
+  }
+
+  BocciaMatchScore matchScoreOrInitial({
+    required int matchNo,
+    required List<int> teamSlots,
+  }) {
+    return matchScore(matchNo) ??
+        initialMatchScore(
+          matchNo: matchNo,
+          teamSlots: teamSlots,
+        );
+  }
+
+  BocciaScoreSheet upsertMatch(BocciaMatchScore score) {
+    return BocciaScoreSheet(
+      matches: Map<int, BocciaMatchScore>.unmodifiable(
+        <int, BocciaMatchScore>{
+          ...matches,
+          score.matchNo: score,
+        },
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final sortedMatchNos = matches.keys.toList(growable: false)..sort();
+
+    return <String, dynamic>{
+      'matches': <String, dynamic>{
+        for (final matchNo in sortedMatchNos)
+          matchNo.toString(): matches[matchNo]!.toJson(),
+      },
+    };
+  }
+}
+
+class BocciaMatchScore {
+  const BocciaMatchScore({
+    required this.matchNo,
+    required this.redTeamSlot,
+    required this.blueTeamSlot,
+    required this.endScores,
+    required this.throwLogs,
+  });
+
+  factory BocciaMatchScore.initial({
+    required int matchNo,
+    required int redTeamSlot,
+    required int blueTeamSlot,
+    int endCount = 6,
+  }) {
+    return BocciaMatchScore(
+      matchNo: matchNo,
+      redTeamSlot: redTeamSlot,
+      blueTeamSlot: blueTeamSlot,
+      endScores: List<BocciaEndScore>.unmodifiable(
+        List<BocciaEndScore>.generate(
+          endCount,
+          (index) => BocciaEndScore.empty(endNo: index + 1),
+        ),
+      ),
+      throwLogs: const <Map<String, dynamic>>[],
+    );
+  }
+
+  factory BocciaMatchScore.fromJson(Map<String, dynamic> json) {
+    final parsedEndScores = _readEndScores(json['end_scores']);
+    final endCount = _readInt(
+      json['end_count'],
+      defaultValue: parsedEndScores.isEmpty ? 6 : parsedEndScores.length,
+    );
+
+    return BocciaMatchScore(
+      matchNo: _readInt(json['match_no']),
+      redTeamSlot: _readInt(json['red_team_slot']),
+      blueTeamSlot: _readInt(json['blue_team_slot']),
+      endScores: _normalizeEndScores(
+        parsedEndScores,
+        endCount: endCount,
+      ),
+      throwLogs: _readObjectList(json['throw_logs']),
+    );
+  }
+
+  final int matchNo;
+  final int redTeamSlot;
+  final int blueTeamSlot;
+  final List<BocciaEndScore> endScores;
+  final List<Map<String, dynamic>> throwLogs;
+
+  int get endCount => endScores.length;
+
+  int get totalRedScore {
+    return endScores.fold<int>(
+      0,
+      (sum, endScore) => sum + endScore.red,
+    );
+  }
+
+  int get totalBlueScore {
+    return endScores.fold<int>(
+      0,
+      (sum, endScore) => sum + endScore.blue,
+    );
+  }
+
+  bool get hasAnyScore {
+    return endScores.any((endScore) => endScore.red > 0 || endScore.blue > 0);
+  }
+
+  BocciaMatchScore copyWith({
+    int? matchNo,
+    int? redTeamSlot,
+    int? blueTeamSlot,
+    List<BocciaEndScore>? endScores,
+    List<Map<String, dynamic>>? throwLogs,
+  }) {
+    return BocciaMatchScore(
+      matchNo: matchNo ?? this.matchNo,
+      redTeamSlot: redTeamSlot ?? this.redTeamSlot,
+      blueTeamSlot: blueTeamSlot ?? this.blueTeamSlot,
+      endScores: List<BocciaEndScore>.unmodifiable(
+        endScores ?? this.endScores,
+      ),
+      throwLogs: List<Map<String, dynamic>>.unmodifiable(
+        throwLogs ?? this.throwLogs,
+      ),
+    );
+  }
+
+  BocciaMatchScore replaceEndScore({
+    required int endNo,
+    int? red,
+    int? blue,
+  }) {
+    return copyWith(
+      endScores: endScores.map((endScore) {
+        if (endScore.endNo != endNo) {
+          return endScore;
+        }
+
+        return endScore.copyWith(
+          red: red,
+          blue: blue,
+        );
+      }).toList(growable: false),
+    );
+  }
+
+  BocciaMatchScore swapped() {
+    return copyWith(
+      redTeamSlot: blueTeamSlot,
+      blueTeamSlot: redTeamSlot,
+      endScores: endScores
+          .map((endScore) => endScore.swapped())
+          .toList(growable: false),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'match_no': matchNo,
+      'red_team_slot': redTeamSlot,
+      'blue_team_slot': blueTeamSlot,
+      'end_count': endCount,
+      'end_scores': endScores.map((endScore) => endScore.toJson()).toList(),
+      'throw_logs': throwLogs,
+    };
+  }
+}
+
+class BocciaEndScore {
+  const BocciaEndScore({
+    required this.endNo,
+    required this.red,
+    required this.blue,
+  });
+
+  const BocciaEndScore.empty({
+    required this.endNo,
+  })  : red = 0,
+        blue = 0;
+
+  factory BocciaEndScore.fromJson(Map<String, dynamic> json) {
+    return BocciaEndScore(
+      endNo: _readInt(json['end_no']),
+      red: _clampScore(_readInt(json['red'])),
+      blue: _clampScore(_readInt(json['blue'])),
+    );
+  }
+
+  final int endNo;
+  final int red;
+  final int blue;
+
+  BocciaEndScore copyWith({
+    int? endNo,
+    int? red,
+    int? blue,
+  }) {
+    return BocciaEndScore(
+      endNo: endNo ?? this.endNo,
+      red: red == null ? this.red : _clampScore(red),
+      blue: blue == null ? this.blue : _clampScore(blue),
+    );
+  }
+
+  BocciaEndScore swapped() {
+    return copyWith(
+      red: blue,
+      blue: red,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'end_no': endNo,
+      'red': red,
+      'blue': blue,
+    };
+  }
+}
+
+List<BocciaEndScore> _readEndScores(Object? value) {
+  if (value is! List) {
+    return const <BocciaEndScore>[];
+  }
+
+  return value
+      .whereType<Map>()
+      .map((json) => BocciaEndScore.fromJson(_readObject(json)))
+      .where((endScore) => endScore.endNo > 0)
+      .toList(growable: false);
+}
+
+List<BocciaEndScore> _normalizeEndScores(
+  List<BocciaEndScore> source, {
+  required int endCount,
+}) {
+  final sourceByEndNo = <int, BocciaEndScore>{
+    for (final endScore in source) endScore.endNo: endScore,
+  };
+
+  return List<BocciaEndScore>.unmodifiable(
+    List<BocciaEndScore>.generate(
+      endCount,
+      (index) {
+        final endNo = index + 1;
+        return sourceByEndNo[endNo] ?? BocciaEndScore.empty(endNo: endNo);
+      },
+    ),
+  );
+}
+
+Map<String, dynamic> _readObject(Object? value) {
+  if (value is! Map) {
+    return const <String, dynamic>{};
+  }
+
+  return <String, dynamic>{
+    for (final entry in value.entries) entry.key.toString(): entry.value,
+  };
+}
+
+List<Map<String, dynamic>> _readObjectList(Object? value) {
+  if (value is! List) {
+    return const <Map<String, dynamic>>[];
+  }
+
+  return List<Map<String, dynamic>>.unmodifiable(
+    value.whereType<Map>().map(_readObject),
+  );
+}
+
+int _readInt(Object? value, {int defaultValue = 0}) {
+  if (value is int) {
+    return value;
+  }
+
+  if (value is num) {
+    return value.toInt();
+  }
+
+  if (value is String) {
+    return int.tryParse(value) ?? defaultValue;
+  }
+
+  return defaultValue;
+}
+
+int _clampScore(int value) {
+  return value.clamp(0, 6).toInt();
+}

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -414,6 +414,28 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         'Participant $playerSlot';
   }
 
+  _TeamViewData? _teamOrNull(int teamSlot) {
+    return _teamBySlot[teamSlot];
+  }
+
+  List<int> _teamMemberSlots(int teamSlot) {
+    final team = _teamOrNull(teamSlot);
+    if (team == null) {
+      return const <int>[];
+    }
+
+    return team.memberPlayerSlots;
+  }
+
+  List<BocciaScorePlayerOption> _bocciaPlayerOptions(int teamSlot) {
+    return _teamMemberSlots(teamSlot).map((playerSlot) {
+      return BocciaScorePlayerOption(
+        playerSlot: playerSlot,
+        displayName: _memberName(playerSlot),
+      );
+    }).toList(growable: false);
+  }
+
   SavedTeamScheduleDisplay _currentDisplay() {
     return SavedTeamScheduleDisplay(
       eventTitle: _eventTitle,
@@ -555,9 +577,16 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       return;
     }
 
+    final redTeamSlot = match.teamSlots[0];
+    final blueTeamSlot = match.teamSlots[1];
+    final redPlayerSlots = _teamMemberSlots(redTeamSlot);
+    final bluePlayerSlots = _teamMemberSlots(blueTeamSlot);
+
     final initialScore = _scores.boccia.matchScoreOrInitial(
       matchNo: match.matchNo,
       teamSlots: match.teamSlots,
+      redPlayerSlots: redPlayerSlots,
+      bluePlayerSlots: bluePlayerSlots,
     );
 
     await showDialog<BocciaMatchScore>(
@@ -568,6 +597,8 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           initialScore: initialScore,
           redTeamName: _teamName(initialScore.redTeamSlot),
           blueTeamName: _teamName(initialScore.blueTeamSlot),
+          redPlayerOptions: _bocciaPlayerOptions(initialScore.redTeamSlot),
+          bluePlayerOptions: _bocciaPlayerOptions(initialScore.blueTeamSlot),
           onSave: _saveBocciaMatchScore,
         );
       },

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -7,9 +7,11 @@ import 'package:srp_lanske/l10n/l10n.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 
 import '../application/team_generated_schedule_service.dart';
+import '../domain/boccia_score.dart';
 import '../domain/saved_team_schedule.dart';
 import '../domain/team_generated_schedule.dart';
 import 'models/team_setup_draft.dart';
+import 'widgets/boccia_score_dialog.dart';
 
 enum _TeamSchedulePageMode {
   create,
@@ -47,6 +49,10 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
   bool _isLoading = true;
   bool _isSavingDisplay = false;
   String? _displaySaveErrorMessage;
+
+  TeamScheduleScores _scores = const TeamScheduleScores.empty();
+  bool _isSavingScores = false;
+  String? _scoresSaveErrorMessage;
 
   String _eventTitle = '';
   Map<int, String> _teamDisplayNames = const {};
@@ -171,6 +177,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         _selectedTeamSlot = schedule.teams.first.teamSlot;
         _shareId = saved.shareId;
         _shareUrl = _buildShareUrl(saved.shareId);
+        _scores = TeamScheduleScores.fromJson(saved.scores);
         _isLoading = false;
       });
     } catch (error) {
@@ -236,6 +243,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         _selectedTeamSlot = schedule.teams.first.teamSlot;
         _shareId = saved.shareId;
         _shareUrl = _buildShareUrl(saved.shareId);
+        _scores = TeamScheduleScores.fromJson(saved.scores);
         _isLoading = false;
       });
     } catch (error) {
@@ -453,6 +461,128 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     }
   }
 
+  Future<TeamScheduleScores> _saveScores(TeamScheduleScores scores) async {
+    final shareId = _shareId;
+    if (shareId == null || shareId.isEmpty) {
+      setState(() {
+        _scores = scores;
+        _scoresSaveErrorMessage = null;
+      });
+      return scores;
+    }
+
+    setState(() {
+      _isSavingScores = true;
+      _scoresSaveErrorMessage = null;
+    });
+
+    try {
+      final saved = await appTeamScheduleRepository.updateScores(
+        shareId: shareId,
+        scores: scores.toJson(),
+      );
+
+      final savedScores = TeamScheduleScores.fromJson(saved.scores);
+
+      if (!mounted) {
+        return savedScores;
+      }
+
+      setState(() {
+        _scores = savedScores;
+        _isSavingScores = false;
+      });
+
+      return savedScores;
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _scoresSaveErrorMessage = _formatError(error);
+          _isSavingScores = false;
+        });
+      }
+
+      rethrow;
+    }
+  }
+
+  Future<void> _selectSport(TeamScheduleSport? sport) async {
+    if (sport == null || sport == _scores.selectedSport || _isSavingScores) {
+      return;
+    }
+
+    try {
+      await _saveScores(_scores.copyWith(selectedSport: sport));
+    } catch (_) {
+      // Error message is shown in the header card.
+    }
+  }
+
+  Future<BocciaMatchScore> _saveBocciaMatchScore(
+    BocciaMatchScore score,
+  ) async {
+    final nextScores = _scores.copyWith(
+      selectedSport: TeamScheduleSport.boccia,
+      boccia: _scores.boccia.upsertMatch(score),
+    );
+
+    final savedScores = await _saveScores(nextScores);
+
+    return savedScores.boccia.matchScore(score.matchNo) ?? score;
+  }
+
+  Future<void> _openBocciaScoreDialog(_TeamMatchViewData match) async {
+    final l10n = AppLocalizations.of(context);
+
+    if (_scores.selectedSport == TeamScheduleSport.none) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.selectSportBeforeScoreInputMessage)),
+      );
+      return;
+    }
+
+    if (_scores.selectedSport != TeamScheduleSport.boccia) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.selectSportBeforeScoreInputMessage)),
+      );
+      return;
+    }
+
+    if (match.teamSlots.length != 2) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.unsupportedBocciaMatchMessage)),
+      );
+      return;
+    }
+
+    final initialScore = _scores.boccia.matchScoreOrInitial(
+      matchNo: match.matchNo,
+      teamSlots: match.teamSlots,
+    );
+
+    await showDialog<BocciaMatchScore>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return BocciaScoreDialog(
+          initialScore: initialScore,
+          redTeamName: _teamName(initialScore.redTeamSlot),
+          blueTeamName: _teamName(initialScore.blueTeamSlot),
+          onSave: _saveBocciaMatchScore,
+        );
+      },
+    );
+  }
+
+  String _sportLabel(TeamScheduleSport sport) {
+    final l10n = AppLocalizations.of(context);
+
+    return switch (sport) {
+      TeamScheduleSport.none => l10n.teamScheduleSportNoneLabel,
+      TeamScheduleSport.boccia => l10n.teamScheduleSportBocciaLabel,
+    };
+  }
+
   String _matchTitle(BuildContext context, _TeamMatchViewData match) {
     final l10n = AppLocalizations.of(context);
     final teamNames = match.teamSlots.map(_teamName).toList(growable: false);
@@ -627,6 +757,8 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
               l10n.teamScheduleBackendDataNotice,
               style: theme.textTheme.bodySmall,
             ),
+            const SizedBox(height: 16),
+            _buildSportSelector(context),
             if (_isSavingDisplay || _displaySaveErrorMessage != null) ...[
               const SizedBox(height: 8),
               _buildDisplaySaveStatus(context),
@@ -669,6 +801,85 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     }
 
     return const SizedBox.shrink();
+  }
+
+  Widget _buildScoreSaveStatus(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final error = _scoresSaveErrorMessage;
+
+    if (_isSavingScores) {
+      return Row(
+        children: [
+          const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            l10n.savingTeamScheduleScoresMessage,
+            style: theme.textTheme.bodySmall,
+          ),
+        ],
+      );
+    }
+
+    if (error != null && error.isNotEmpty) {
+      return Text(
+        l10n.teamScheduleScoresSaveFailedMessage(error),
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+
+  Widget _buildSportSelector(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n.teamScheduleSportSectionTitle,
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 8),
+        DropdownButtonFormField<TeamScheduleSport>(
+          initialValue: _scores.selectedSport,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            contentPadding: EdgeInsets.symmetric(
+              horizontal: 12,
+              vertical: 10,
+            ),
+          ),
+          onChanged: _isSavingScores ? null : _selectSport,
+          items: [
+            for (final sport in TeamScheduleSport.values)
+              DropdownMenuItem<TeamScheduleSport>(
+                value: sport,
+                child: Text(_sportLabel(sport)),
+              ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Text(
+          l10n.teamScheduleSportHelp,
+          style: theme.textTheme.bodySmall,
+        ),
+        if (_isSavingScores || _scoresSaveErrorMessage != null) ...[
+          const SizedBox(height: 8),
+          _buildScoreSaveStatus(context),
+        ],
+      ],
+    );
   }
 
   Widget _buildShareCard(BuildContext context) {
@@ -946,6 +1157,48 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     );
   }
 
+  Widget _buildMatchScoreAction(
+    BuildContext context,
+    _TeamMatchViewData match,
+  ) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final score = _scores.boccia.matchScore(match.matchNo);
+    final hasScore = score?.hasAnyScore ?? false;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (_scores.selectedSport == TeamScheduleSport.boccia &&
+            score != null) ...[
+          Text(
+            l10n.bocciaScoreSummary(
+              redTeamName: _teamName(score.redTeamSlot),
+              redScore: score.totalRedScore,
+              blueTeamName: _teamName(score.blueTeamSlot),
+              blueScore: score.totalBlueScore,
+            ),
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+        FilledButton.tonalIcon(
+          onPressed: _isSavingScores
+              ? null
+              : () {
+                  _openBocciaScoreDialog(match);
+                },
+          icon: const Icon(Icons.edit_note),
+          label: Text(
+            hasScore ? l10n.editBocciaScoreButton : l10n.inputBocciaScoreButton,
+          ),
+        ),
+      ],
+    );
+  }
+
   Widget _buildMatchRow(BuildContext context, _TeamMatchViewData match) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
@@ -979,6 +1232,8 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
               ),
           ],
         ),
+        const SizedBox(height: 12),
+        _buildMatchScoreAction(context, match),
       ],
     );
   }

--- a/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
+++ b/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
@@ -1,0 +1,474 @@
+import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
+
+import '../../domain/boccia_score.dart';
+
+class BocciaScoreDialog extends StatefulWidget {
+  const BocciaScoreDialog({
+    required this.initialScore,
+    required this.redTeamName,
+    required this.blueTeamName,
+    required this.onSave,
+    super.key,
+  });
+
+  final BocciaMatchScore initialScore;
+  final String redTeamName;
+  final String blueTeamName;
+  final Future<BocciaMatchScore> Function(BocciaMatchScore score) onSave;
+
+  @override
+  State<BocciaScoreDialog> createState() => _BocciaScoreDialogState();
+}
+
+class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
+  late BocciaMatchScore _draftScore;
+  late BocciaMatchScore _lastSavedScore;
+
+  bool _isSaving = false;
+  String? _statusMessage;
+  String? _errorMessage;
+
+  bool get _isDirty => !_scoreEquals(_draftScore, _lastSavedScore);
+
+  @override
+  void initState() {
+    super.initState();
+    _draftScore = widget.initialScore;
+    _lastSavedScore = widget.initialScore;
+  }
+
+  String _redTeamName(BocciaMatchScore score) {
+    if (score.redTeamSlot == widget.initialScore.redTeamSlot) {
+      return widget.redTeamName;
+    }
+
+    return widget.blueTeamName;
+  }
+
+  String _blueTeamName(BocciaMatchScore score) {
+    if (score.blueTeamSlot == widget.initialScore.blueTeamSlot) {
+      return widget.blueTeamName;
+    }
+
+    return widget.redTeamName;
+  }
+
+  Future<bool> _save() async {
+    if (_isSaving) {
+      return false;
+    }
+
+    setState(() {
+      _isSaving = true;
+      _statusMessage = null;
+      _errorMessage = null;
+    });
+
+    try {
+      final saved = await widget.onSave(_draftScore);
+
+      if (!mounted) {
+        return false;
+      }
+
+      setState(() {
+        _draftScore = saved;
+        _lastSavedScore = saved;
+        _statusMessage = AppLocalizations.of(context).bocciaScoreSavedMessage;
+        _isSaving = false;
+      });
+
+      return true;
+    } catch (error) {
+      if (!mounted) {
+        return false;
+      }
+
+      setState(() {
+        _errorMessage = error.toString();
+        _isSaving = false;
+      });
+
+      return false;
+    }
+  }
+
+  Future<void> _close() async {
+    if (!_isDirty) {
+      Navigator.of(context).pop(_lastSavedScore);
+      return;
+    }
+
+    final action = await showDialog<_UnsavedAction>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        final l10n = AppLocalizations.of(context);
+
+        return AlertDialog(
+          title: Text(l10n.bocciaScoreDiscardChangesTitle),
+          content: Text(l10n.bocciaScoreDiscardChangesBody),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(_UnsavedAction.returnToInput);
+              },
+              child: Text(l10n.returnToBocciaScoreInputButton),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(_UnsavedAction.discardAndClose);
+              },
+              child: Text(l10n.discardBocciaScoreChangesButton),
+            ),
+            FilledButton(
+              onPressed: () {
+                Navigator.of(context).pop(_UnsavedAction.saveAndClose);
+              },
+              child: Text(l10n.saveAndCloseBocciaScoreButton),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (!mounted || action == null || action == _UnsavedAction.returnToInput) {
+      return;
+    }
+
+    if (action == _UnsavedAction.discardAndClose) {
+      Navigator.of(context).pop(_lastSavedScore);
+      return;
+    }
+
+    final saved = await _save();
+    if (!mounted || !saved) {
+      return;
+    }
+
+    Navigator.of(context).pop(_lastSavedScore);
+  }
+
+  void _swapOrder() {
+    setState(() {
+      _draftScore = _draftScore.swapped();
+      _statusMessage = null;
+      _errorMessage = null;
+    });
+  }
+
+  void _setEndScore({
+    required int endNo,
+    int? red,
+    int? blue,
+  }) {
+    setState(() {
+      _draftScore = _draftScore.replaceEndScore(
+        endNo: endNo,
+        red: red,
+        blue: blue,
+      );
+      _statusMessage = null;
+      _errorMessage = null;
+    });
+  }
+
+  Widget _buildOrderHeader(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        FilledButton.tonalIcon(
+          onPressed: _isSaving ? null : _swapOrder,
+          icon: const Icon(Icons.swap_horiz),
+          label: Text(l10n.swapBocciaOrderButton),
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(
+              child: _buildTeamHeader(
+                context,
+                label: l10n.bocciaFirstTeamLabel,
+                teamName: _redTeamName(_draftScore),
+                backgroundColor: Colors.red.shade50,
+                borderColor: Colors.red.shade200,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: _buildTeamHeader(
+                context,
+                label: l10n.bocciaSecondTeamLabel,
+                teamName: _blueTeamName(_draftScore),
+                backgroundColor: Colors.blue.shade50,
+                borderColor: Colors.blue.shade200,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Text(
+          l10n.bocciaScoreDialogMatchTitle(
+            redTeamName: _redTeamName(_draftScore),
+            blueTeamName: _blueTeamName(_draftScore),
+          ),
+          textAlign: TextAlign.center,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTeamHeader(
+    BuildContext context, {
+    required String label,
+    required String teamName,
+    required Color backgroundColor,
+    required Color borderColor,
+  }) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        border: Border.all(color: borderColor),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.labelLarge,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            teamName,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildScoreTable(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: DataTable(
+        headingRowHeight: 44,
+        dataRowMinHeight: 52,
+        dataRowMaxHeight: 56,
+        columns: [
+          const DataColumn(label: SizedBox(width: 56)),
+          for (final endScore in _draftScore.endScores)
+            DataColumn(
+              label: Text(l10n.bocciaEndLabel(endScore.endNo)),
+            ),
+          DataColumn(
+            label: Text(l10n.bocciaTotalLabel),
+          ),
+        ],
+        rows: [
+          DataRow(
+            color: WidgetStatePropertyAll(Colors.red.shade50),
+            cells: [
+              DataCell(Text(l10n.bocciaFirstTeamLabel)),
+              for (final endScore in _draftScore.endScores)
+                DataCell(
+                  _buildScoreDropdown(
+                    value: endScore.red,
+                    onChanged: (value) {
+                      if (value == null) {
+                        return;
+                      }
+
+                      _setEndScore(
+                        endNo: endScore.endNo,
+                        red: value,
+                      );
+                    },
+                  ),
+                ),
+              DataCell(
+                Text(
+                  _draftScore.totalRedScore.toString(),
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              ),
+            ],
+          ),
+          DataRow(
+            color: WidgetStatePropertyAll(Colors.blue.shade50),
+            cells: [
+              DataCell(Text(l10n.bocciaSecondTeamLabel)),
+              for (final endScore in _draftScore.endScores)
+                DataCell(
+                  _buildScoreDropdown(
+                    value: endScore.blue,
+                    onChanged: (value) {
+                      if (value == null) {
+                        return;
+                      }
+
+                      _setEndScore(
+                        endNo: endScore.endNo,
+                        blue: value,
+                      );
+                    },
+                  ),
+                ),
+              DataCell(
+                Text(
+                  _draftScore.totalBlueScore.toString(),
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildScoreDropdown({
+    required int value,
+    required ValueChanged<int?> onChanged,
+  }) {
+    return DropdownButton<int>(
+      value: value,
+      onChanged: _isSaving ? null : onChanged,
+      items: [
+        for (var score = 0; score <= 6; score += 1)
+          DropdownMenuItem<int>(
+            value: score,
+            child: Text(score.toString()),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildStatus(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    if (_isSaving) {
+      return Row(
+        children: [
+          const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          const SizedBox(width: 8),
+          Text(l10n.savingTeamScheduleScoresMessage),
+        ],
+      );
+    }
+
+    final errorMessage = _errorMessage;
+    if (errorMessage != null && errorMessage.isNotEmpty) {
+      return Text(
+        l10n.teamScheduleScoresSaveFailedMessage(errorMessage),
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      );
+    }
+
+    final statusMessage = _statusMessage;
+    if (statusMessage != null && statusMessage.isNotEmpty) {
+      return Text(
+        statusMessage,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.primary,
+          fontWeight: FontWeight.bold,
+        ),
+      );
+    }
+
+    if (_isDirty) {
+      return Text(
+        l10n.bocciaScoreUnsavedChangesMessage,
+        style: theme.textTheme.bodySmall,
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return AlertDialog(
+      title: Text(l10n.bocciaScoreDialogTitle),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 720),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildOrderHeader(context),
+              const SizedBox(height: 16),
+              _buildScoreTable(context),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: _buildStatus(context),
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isSaving ? null : _close,
+          child: Text(l10n.closeBocciaScoreDialogButton),
+        ),
+        FilledButton(
+          onPressed: _isSaving ? null : _save,
+          child: Text(l10n.saveBocciaScoreButton),
+        ),
+      ],
+    );
+  }
+}
+
+enum _UnsavedAction {
+  returnToInput,
+  discardAndClose,
+  saveAndClose,
+}
+
+bool _scoreEquals(BocciaMatchScore a, BocciaMatchScore b) {
+  if (a.matchNo != b.matchNo ||
+      a.redTeamSlot != b.redTeamSlot ||
+      a.blueTeamSlot != b.blueTeamSlot ||
+      a.endScores.length != b.endScores.length) {
+    return false;
+  }
+
+  for (var index = 0; index < a.endScores.length; index += 1) {
+    final aEnd = a.endScores[index];
+    final bEnd = b.endScores[index];
+
+    if (aEnd.endNo != bEnd.endNo ||
+        aEnd.red != bEnd.red ||
+        aEnd.blue != bEnd.blue) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
+++ b/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
@@ -8,6 +8,8 @@ class BocciaScoreDialog extends StatefulWidget {
     required this.initialScore,
     required this.redTeamName,
     required this.blueTeamName,
+    required this.redPlayerOptions,
+    required this.bluePlayerOptions,
     required this.onSave,
     super.key,
   });
@@ -15,10 +17,22 @@ class BocciaScoreDialog extends StatefulWidget {
   final BocciaMatchScore initialScore;
   final String redTeamName;
   final String blueTeamName;
+  final List<BocciaScorePlayerOption> redPlayerOptions;
+  final List<BocciaScorePlayerOption> bluePlayerOptions;
   final Future<BocciaMatchScore> Function(BocciaMatchScore score) onSave;
 
   @override
   State<BocciaScoreDialog> createState() => _BocciaScoreDialogState();
+}
+
+class BocciaScorePlayerOption {
+  const BocciaScorePlayerOption({
+    required this.playerSlot,
+    required this.displayName,
+  });
+
+  final int playerSlot;
+  final String displayName;
 }
 
 class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
@@ -52,6 +66,31 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     }
 
     return widget.redTeamName;
+  }
+
+  List<BocciaScorePlayerOption> _redPlayerOptions(BocciaMatchScore score) {
+    if (score.redTeamSlot == widget.initialScore.redTeamSlot) {
+      return widget.redPlayerOptions;
+    }
+
+    return widget.bluePlayerOptions;
+  }
+
+  List<BocciaScorePlayerOption> _bluePlayerOptions(BocciaMatchScore score) {
+    if (score.blueTeamSlot == widget.initialScore.blueTeamSlot) {
+      return widget.bluePlayerOptions;
+    }
+
+    return widget.redPlayerOptions;
+  }
+
+  List<BocciaScorePlayerOption> _playerOptionsForAssignment(
+    BocciaThrowingBoxAssignment assignment,
+  ) {
+    return switch (assignment.side) {
+      BocciaThrowingSide.red => _redPlayerOptions(_draftScore),
+      BocciaThrowingSide.blue => _bluePlayerOptions(_draftScore),
+    };
   }
 
   Future<bool> _save() async {
@@ -174,6 +213,20 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     });
   }
 
+  void _setThrowingBoxPlayer({
+    required int boxNo,
+    required int? playerSlot,
+  }) {
+    setState(() {
+      _draftScore = _draftScore.replaceThrowingBoxPlayer(
+        boxNo: boxNo,
+        playerSlot: playerSlot,
+      );
+      _statusMessage = null;
+      _errorMessage = null;
+    });
+  }
+
   Widget _buildOrderHeader(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
@@ -283,7 +336,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           DataRow(
             color: WidgetStatePropertyAll(Colors.red.shade50),
             cells: [
-              DataCell(Text(l10n.bocciaFirstTeamLabel)),
+              const DataCell(SizedBox.shrink()),
               for (final endScore in _draftScore.endScores)
                 DataCell(
                   _buildScoreDropdown(
@@ -311,7 +364,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           DataRow(
             color: WidgetStatePropertyAll(Colors.blue.shade50),
             cells: [
-              DataCell(Text(l10n.bocciaSecondTeamLabel)),
+              const DataCell(SizedBox.shrink()),
               for (final endScore in _draftScore.endScores)
                 DataCell(
                   _buildScoreDropdown(
@@ -355,6 +408,112 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             child: Text(score.toString()),
           ),
       ],
+    );
+  }
+
+  Widget _buildThrowingBoxSection(BuildContext context) {
+    final theme = Theme.of(context);
+    final assignments = _draftScore.throwingBoxAssignments;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '投球場所',
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          '赤は奇数ボックス、青は偶数ボックスに投球者を設定します。',
+          style: theme.textTheme.bodySmall,
+        ),
+        const SizedBox(height: 8),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: [
+              for (final assignment in assignments) ...[
+                _buildThrowingBoxCard(context, assignment),
+                if (assignment != assignments.last) const SizedBox(width: 8),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildThrowingBoxCard(
+    BuildContext context,
+    BocciaThrowingBoxAssignment assignment,
+  ) {
+    final theme = Theme.of(context);
+    final isRed = assignment.side == BocciaThrowingSide.red;
+    final playerOptions = _playerOptionsForAssignment(assignment);
+    final selectedPlayerSlot = playerOptions.any(
+      (option) => option.playerSlot == assignment.playerSlot,
+    )
+        ? assignment.playerSlot
+        : null;
+
+    return Container(
+      width: 150,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: isRed ? Colors.red.shade50 : Colors.blue.shade50,
+        border: Border.all(
+          color: isRed ? Colors.red.shade200 : Colors.blue.shade200,
+        ),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            '${assignment.boxNo}',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          DropdownButtonFormField<int?>(
+            initialValue: selectedPlayerSlot,
+            isExpanded: true,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: 8,
+                vertical: 8,
+              ),
+            ),
+            onChanged: _isSaving
+                ? null
+                : (value) {
+                    _setThrowingBoxPlayer(
+                      boxNo: assignment.boxNo,
+                      playerSlot: value,
+                    );
+                  },
+            items: [
+              const DropdownMenuItem<int?>(
+                value: null,
+                child: Text('未使用'),
+              ),
+              for (final option in playerOptions)
+                DropdownMenuItem<int?>(
+                  value: option.playerSlot,
+                  child: Text(
+                    option.displayName,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 
@@ -410,11 +569,16 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final dialogWidth = MediaQuery.sizeOf(context).width * 0.95;
 
     return AlertDialog(
+      insetPadding: const EdgeInsets.symmetric(
+        horizontal: 12,
+        vertical: 24,
+      ),
       title: Text(l10n.bocciaScoreDialogTitle),
-      content: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 720),
+      content: SizedBox(
+        width: dialogWidth,
         child: SingleChildScrollView(
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -422,6 +586,8 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
               _buildOrderHeader(context),
               const SizedBox(height: 16),
               _buildScoreTable(context),
+              const SizedBox(height: 16),
+              _buildThrowingBoxSection(context),
               const SizedBox(height: 12),
               Align(
                 alignment: Alignment.centerLeft,
@@ -455,7 +621,8 @@ bool _scoreEquals(BocciaMatchScore a, BocciaMatchScore b) {
   if (a.matchNo != b.matchNo ||
       a.redTeamSlot != b.redTeamSlot ||
       a.blueTeamSlot != b.blueTeamSlot ||
-      a.endScores.length != b.endScores.length) {
+      a.endScores.length != b.endScores.length ||
+      a.throwingBoxAssignments.length != b.throwingBoxAssignments.length) {
     return false;
   }
 
@@ -466,6 +633,17 @@ bool _scoreEquals(BocciaMatchScore a, BocciaMatchScore b) {
     if (aEnd.endNo != bEnd.endNo ||
         aEnd.red != bEnd.red ||
         aEnd.blue != bEnd.blue) {
+      return false;
+    }
+  }
+
+  for (var index = 0; index < a.throwingBoxAssignments.length; index += 1) {
+    final aAssignment = a.throwingBoxAssignments[index];
+    final bAssignment = b.throwingBoxAssignments[index];
+
+    if (aAssignment.boxNo != bAssignment.boxNo ||
+        aAssignment.side != bAssignment.side ||
+        aAssignment.playerSlot != bAssignment.playerSlot) {
       return false;
     }
   }

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -298,4 +298,94 @@ extension TeamL10n on AppLocalizations {
   String get cancelDisplayNameEditButton => _isJapanese ? 'キャンセル' : 'Cancel';
 
   String get saveDisplayNameEditButton => _isJapanese ? '保存' : 'Save';
+
+  String get teamScheduleSportSectionTitle =>
+      _isJapanese ? 'スコア入力' : 'Score input';
+
+  String get teamScheduleSportNoneLabel => _isJapanese ? '未選択' : 'Not selected';
+
+  String get teamScheduleSportBocciaLabel => _isJapanese ? 'ボッチャ' : 'Boccia';
+
+  String get teamScheduleSportHelp => _isJapanese
+      ? '競技を選択すると、対戦カードからスコアを入力できます。'
+      : 'Select a sport to enter scores from match cards.';
+
+  String get savingTeamScheduleScoresMessage =>
+      _isJapanese ? 'スコアを保存中です…' : 'Saving scores...';
+
+  String teamScheduleScoresSaveFailedMessage(String detail) {
+    return _isJapanese
+        ? 'スコアの保存に失敗しました: $detail'
+        : 'Failed to save scores: $detail';
+  }
+
+  String get selectSportBeforeScoreInputMessage =>
+      _isJapanese ? '先に競技を選択してください。' : 'Select a sport first.';
+
+  String get unsupportedBocciaMatchMessage => _isJapanese
+      ? 'ボッチャのスコア入力は2チーム対戦のみ対応しています。'
+      : 'Boccia score input supports two-team matches only.';
+
+  String get inputBocciaScoreButton => _isJapanese ? 'スコア入力' : 'Enter score';
+
+  String get editBocciaScoreButton => _isJapanese ? 'スコア編集' : 'Edit score';
+
+  String bocciaScoreSummary({
+    required String redTeamName,
+    required int redScore,
+    required String blueTeamName,
+    required int blueScore,
+  }) {
+    return '$redTeamName $redScore - $blueScore $blueTeamName';
+  }
+
+  String get bocciaScoreDialogTitle =>
+      _isJapanese ? 'ボッチャ スコア入力' : 'Boccia score input';
+
+  String bocciaScoreDialogMatchTitle({
+    required String redTeamName,
+    required String blueTeamName,
+  }) {
+    return '$redTeamName vs $blueTeamName';
+  }
+
+  String get bocciaFirstTeamLabel => _isJapanese ? '先攻' : 'First';
+
+  String get bocciaSecondTeamLabel => _isJapanese ? '後攻' : 'Second';
+
+  String get swapBocciaOrderButton => _isJapanese ? '先攻 🔁 後攻' : 'Swap order';
+
+  String get swapBocciaOrderTooltip =>
+      _isJapanese ? '先攻と後攻をスコアごと入れ替える' : 'Swap teams and their scores';
+
+  String bocciaEndLabel(int endNo) {
+    return _isJapanese ? '$endNo E' : 'E$endNo';
+  }
+
+  String get bocciaTotalLabel => _isJapanese ? '合計' : 'Total';
+
+  String get saveBocciaScoreButton => _isJapanese ? '保存' : 'Save';
+
+  String get closeBocciaScoreDialogButton => _isJapanese ? '閉じる' : 'Close';
+
+  String get bocciaScoreSavedMessage => _isJapanese ? '保存しました' : 'Saved.';
+
+  String get bocciaScoreUnsavedChangesMessage =>
+      _isJapanese ? '未保存の変更があります' : 'There are unsaved changes.';
+
+  String get bocciaScoreDiscardChangesTitle =>
+      _isJapanese ? '未保存の変更があります' : 'Unsaved changes';
+
+  String get bocciaScoreDiscardChangesBody => _isJapanese
+      ? '保存していないスコア変更があります。閉じますか？'
+      : 'There are unsaved score changes. Do you want to close?';
+
+  String get returnToBocciaScoreInputButton =>
+      _isJapanese ? '入力に戻る' : 'Back to input';
+
+  String get discardBocciaScoreChangesButton =>
+      _isJapanese ? '保存せず閉じる' : 'Close without saving';
+
+  String get saveAndCloseBocciaScoreButton =>
+      _isJapanese ? '保存して閉じる' : 'Save and close';
 }


### PR DESCRIPTION
## 概要

ボッチャ用スコア入力に、試合単位のスローイングボックス投球者割り当てを追加しました。

当初は「エンドごとに投球場所を変更・ローテーションする」想定でしたが、確認したところ公式ルールではなくローカル運用寄りだったため、エンド別の投球場所変更は実装対象外にしています。

代わりに、試合開始時に決めたスローイングボックス 1〜6 の投球者割り当てを保存・復元できるようにしました。

- 赤チームは奇数ボックス 1 / 3 / 5 に固定
- 青チームは偶数ボックス 2 / 4 / 6 に固定
- 個人戦は 3 / 4 を初期使用
- ペア戦は 2〜5 を初期使用
- チーム戦は 1〜6 を初期使用
- 人数差のある対戦でも、各チーム人数に応じた使用ボックスを初期設定
- 投球者選択時、別ボックスで選択済みの投球者を選んだ場合は入れ替え
- `swapped()` でチーム・スコア・投球ボックス割り当てを入れ替え
- Firestore 保存用 scores JSON に投球ボックス割り当てを含める
- スコアダイアログ幅を拡張
- スコア入力行の「先攻/後攻」表示を削除
- 保存状態メッセージをダイアログ下部の操作ボタン横に表示

Closes #116

## 作業記録

- 設計: 20分
- 実装: 20分

## 確認

- [x] dart format lib/
- [x] flutter analyze
- [x] flutter test
- [x] 動作確認OK