### PR TITLE
✨ feat: add boccia throwing box player assignments refs #116

### DIFF
--- a/lib/features/team_scheduler/domain/boccia_score.dart
+++ b/lib/features/team_scheduler/domain/boccia_score.dart
@@ -348,15 +348,34 @@ class BocciaMatchScore {
       return this;
     }
 
+    final normalizedPlayerSlot = _normalizePlayerSlot(playerSlot);
+    final currentAssignment = throwingBoxAssignment(normalizedBoxNo);
+    final currentPlayerSlot = currentAssignment?.playerSlot;
+
+    final duplicatedAssignment = normalizedPlayerSlot == null
+        ? null
+        : throwingBoxAssignments
+            .where((assignment) => assignment.boxNo != normalizedBoxNo)
+            .where(
+                (assignment) => assignment.playerSlot == normalizedPlayerSlot)
+            .firstOrNull;
+
     return copyWith(
       throwingBoxAssignments: throwingBoxAssignments.map((assignment) {
-        if (assignment.boxNo != normalizedBoxNo) {
-          return assignment;
+        if (assignment.boxNo == normalizedBoxNo) {
+          return assignment.copyWith(
+            playerSlot: normalizedPlayerSlot,
+          );
         }
 
-        return assignment.copyWith(
-          playerSlot: playerSlot,
-        );
+        if (duplicatedAssignment != null &&
+            assignment.boxNo == duplicatedAssignment.boxNo) {
+          return assignment.copyWith(
+            playerSlot: currentPlayerSlot,
+          );
+        }
+
+        return assignment;
       }).toList(growable: false),
     );
   }

--- a/lib/features/team_scheduler/domain/boccia_score.dart
+++ b/lib/features/team_scheduler/domain/boccia_score.dart
@@ -19,6 +19,27 @@ extension TeamScheduleSportJson on TeamScheduleSport {
   }
 }
 
+enum BocciaThrowingSide {
+  red,
+  blue,
+}
+
+extension BocciaThrowingSideJson on BocciaThrowingSide {
+  String toJsonValue() {
+    return switch (this) {
+      BocciaThrowingSide.red => 'red',
+      BocciaThrowingSide.blue => 'blue',
+    };
+  }
+
+  static BocciaThrowingSide fromJsonValue(Object? value) {
+    return switch (value?.toString()) {
+      'blue' => BocciaThrowingSide.blue,
+      _ => BocciaThrowingSide.red,
+    };
+  }
+}
+
 class TeamScheduleScores {
   const TeamScheduleScores({
     required this.selectedSport,
@@ -105,6 +126,8 @@ class BocciaScoreSheet {
   BocciaMatchScore initialMatchScore({
     required int matchNo,
     required List<int> teamSlots,
+    List<int> redPlayerSlots = const <int>[],
+    List<int> bluePlayerSlots = const <int>[],
   }) {
     if (teamSlots.length != 2) {
       throw ArgumentError.value(
@@ -118,17 +141,23 @@ class BocciaScoreSheet {
       matchNo: matchNo,
       redTeamSlot: teamSlots[0],
       blueTeamSlot: teamSlots[1],
+      redPlayerSlots: redPlayerSlots,
+      bluePlayerSlots: bluePlayerSlots,
     );
   }
 
   BocciaMatchScore matchScoreOrInitial({
     required int matchNo,
     required List<int> teamSlots,
+    List<int> redPlayerSlots = const <int>[],
+    List<int> bluePlayerSlots = const <int>[],
   }) {
     return matchScore(matchNo) ??
         initialMatchScore(
           matchNo: matchNo,
           teamSlots: teamSlots,
+          redPlayerSlots: redPlayerSlots,
+          bluePlayerSlots: bluePlayerSlots,
         );
   }
 
@@ -161,6 +190,7 @@ class BocciaMatchScore {
     required this.redTeamSlot,
     required this.blueTeamSlot,
     required this.endScores,
+    required this.throwingBoxAssignments,
     required this.throwLogs,
   });
 
@@ -169,6 +199,8 @@ class BocciaMatchScore {
     required int redTeamSlot,
     required int blueTeamSlot,
     int endCount = 6,
+    List<int> redPlayerSlots = const <int>[],
+    List<int> bluePlayerSlots = const <int>[],
   }) {
     return BocciaMatchScore(
       matchNo: matchNo,
@@ -179,6 +211,10 @@ class BocciaMatchScore {
           endCount,
           (index) => BocciaEndScore.empty(endNo: index + 1),
         ),
+      ),
+      throwingBoxAssignments: _initialThrowingBoxAssignments(
+        redPlayerSlots: redPlayerSlots,
+        bluePlayerSlots: bluePlayerSlots,
       ),
       throwLogs: const <Map<String, dynamic>>[],
     );
@@ -199,6 +235,9 @@ class BocciaMatchScore {
         parsedEndScores,
         endCount: endCount,
       ),
+      throwingBoxAssignments: _normalizeThrowingBoxAssignments(
+        _readThrowingBoxAssignments(json['throwing_box_assignments']),
+      ),
       throwLogs: _readObjectList(json['throw_logs']),
     );
   }
@@ -207,6 +246,7 @@ class BocciaMatchScore {
   final int redTeamSlot;
   final int blueTeamSlot;
   final List<BocciaEndScore> endScores;
+  final List<BocciaThrowingBoxAssignment> throwingBoxAssignments;
   final List<Map<String, dynamic>> throwLogs;
 
   int get endCount => endScores.length;
@@ -229,11 +269,39 @@ class BocciaMatchScore {
     return endScores.any((endScore) => endScore.red > 0 || endScore.blue > 0);
   }
 
+  BocciaThrowingBoxAssignment? throwingBoxAssignment(int boxNo) {
+    final normalizedBoxNo = _normalizeThrowingBoxNo(boxNo);
+    if (normalizedBoxNo == null) {
+      return null;
+    }
+
+    for (final assignment in throwingBoxAssignments) {
+      if (assignment.boxNo == normalizedBoxNo) {
+        return assignment;
+      }
+    }
+
+    return BocciaThrowingBoxAssignment.empty(boxNo: normalizedBoxNo);
+  }
+
+  List<BocciaThrowingBoxAssignment> get redThrowingBoxAssignments {
+    return throwingBoxAssignments
+        .where((assignment) => assignment.side == BocciaThrowingSide.red)
+        .toList(growable: false);
+  }
+
+  List<BocciaThrowingBoxAssignment> get blueThrowingBoxAssignments {
+    return throwingBoxAssignments
+        .where((assignment) => assignment.side == BocciaThrowingSide.blue)
+        .toList(growable: false);
+  }
+
   BocciaMatchScore copyWith({
     int? matchNo,
     int? redTeamSlot,
     int? blueTeamSlot,
     List<BocciaEndScore>? endScores,
+    List<BocciaThrowingBoxAssignment>? throwingBoxAssignments,
     List<Map<String, dynamic>>? throwLogs,
   }) {
     return BocciaMatchScore(
@@ -242,6 +310,9 @@ class BocciaMatchScore {
       blueTeamSlot: blueTeamSlot ?? this.blueTeamSlot,
       endScores: List<BocciaEndScore>.unmodifiable(
         endScores ?? this.endScores,
+      ),
+      throwingBoxAssignments: _normalizeThrowingBoxAssignments(
+        throwingBoxAssignments ?? this.throwingBoxAssignments,
       ),
       throwLogs: List<Map<String, dynamic>>.unmodifiable(
         throwLogs ?? this.throwLogs,
@@ -268,6 +339,34 @@ class BocciaMatchScore {
     );
   }
 
+  BocciaMatchScore replaceThrowingBoxPlayer({
+    required int boxNo,
+    int? playerSlot,
+  }) {
+    final normalizedBoxNo = _normalizeThrowingBoxNo(boxNo);
+    if (normalizedBoxNo == null) {
+      return this;
+    }
+
+    return copyWith(
+      throwingBoxAssignments: throwingBoxAssignments.map((assignment) {
+        if (assignment.boxNo != normalizedBoxNo) {
+          return assignment;
+        }
+
+        return assignment.copyWith(
+          playerSlot: playerSlot,
+        );
+      }).toList(growable: false),
+    );
+  }
+
+  BocciaMatchScore clearThrowingBoxPlayer({
+    required int boxNo,
+  }) {
+    return replaceThrowingBoxPlayer(boxNo: boxNo);
+  }
+
   BocciaMatchScore swapped() {
     return copyWith(
       redTeamSlot: blueTeamSlot,
@@ -275,6 +374,9 @@ class BocciaMatchScore {
       endScores: endScores
           .map((endScore) => endScore.swapped())
           .toList(growable: false),
+      throwingBoxAssignments: _swapThrowingBoxAssignments(
+        throwingBoxAssignments,
+      ),
     );
   }
 
@@ -285,6 +387,9 @@ class BocciaMatchScore {
       'blue_team_slot': blueTeamSlot,
       'end_count': endCount,
       'end_scores': endScores.map((endScore) => endScore.toJson()).toList(),
+      'throwing_box_assignments': throwingBoxAssignments
+          .map((assignment) => assignment.toJson())
+          .toList(),
       'throw_logs': throwLogs,
     };
   }
@@ -342,6 +447,88 @@ class BocciaEndScore {
   }
 }
 
+class BocciaThrowingBoxAssignment {
+  const BocciaThrowingBoxAssignment({
+    required this.boxNo,
+    required this.side,
+    required this.playerSlot,
+  });
+
+  factory BocciaThrowingBoxAssignment.empty({
+    required int boxNo,
+  }) {
+    final normalizedBoxNo = _normalizeThrowingBoxNo(boxNo) ?? boxNo;
+
+    return BocciaThrowingBoxAssignment(
+      boxNo: normalizedBoxNo,
+      side: _throwingSideForBoxNo(normalizedBoxNo),
+      playerSlot: null,
+    );
+  }
+
+  factory BocciaThrowingBoxAssignment.fromJson(Map<String, dynamic> json) {
+    final boxNo = _normalizeThrowingBoxNo(_readInt(json['box_no'])) ?? 1;
+
+    return BocciaThrowingBoxAssignment(
+      boxNo: boxNo,
+      side: _throwingSideForBoxNo(boxNo),
+      playerSlot: _normalizePlayerSlot(json['player_slot']),
+    );
+  }
+
+  final int boxNo;
+  final BocciaThrowingSide side;
+  final int? playerSlot;
+
+  bool get hasPlayer => playerSlot != null;
+  BocciaThrowingBoxAssignment copyWith({
+    int? boxNo,
+    BocciaThrowingSide? side,
+    Object? playerSlot = _unsetPlayerSlot,
+  }) {
+    final normalizedBoxNo = _normalizeThrowingBoxNo(boxNo ?? this.boxNo) ??
+        _normalizeThrowingBoxNo(this.boxNo) ??
+        this.boxNo;
+    final normalizedSide = _throwingSideForBoxNo(normalizedBoxNo);
+
+    return BocciaThrowingBoxAssignment(
+      boxNo: normalizedBoxNo,
+      side: side ?? normalizedSide,
+      playerSlot: identical(playerSlot, _unsetPlayerSlot)
+          ? this.playerSlot
+          : _normalizePlayerSlot(playerSlot),
+    );
+  }
+
+  BocciaThrowingBoxAssignment swapped() {
+    final nextBoxNo = switch (boxNo) {
+      1 => 2,
+      2 => 1,
+      3 => 4,
+      4 => 3,
+      5 => 6,
+      6 => 5,
+      _ => boxNo,
+    };
+
+    return BocciaThrowingBoxAssignment(
+      boxNo: nextBoxNo,
+      side: _throwingSideForBoxNo(nextBoxNo),
+      playerSlot: playerSlot,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'box_no': boxNo,
+      'side': side.toJsonValue(),
+      'player_slot': playerSlot,
+    };
+  }
+}
+
+const Object _unsetPlayerSlot = Object();
+
 List<BocciaEndScore> _readEndScores(Object? value) {
   if (value is! List) {
     return const <BocciaEndScore>[];
@@ -371,6 +558,173 @@ List<BocciaEndScore> _normalizeEndScores(
       },
     ),
   );
+}
+
+List<BocciaThrowingBoxAssignment> _readThrowingBoxAssignments(Object? value) {
+  if (value is! List) {
+    return const <BocciaThrowingBoxAssignment>[];
+  }
+
+  return value
+      .whereType<Map>()
+      .map((json) => BocciaThrowingBoxAssignment.fromJson(_readObject(json)))
+      .where((assignment) => _normalizeThrowingBoxNo(assignment.boxNo) != null)
+      .toList(growable: false);
+}
+
+List<BocciaThrowingBoxAssignment> _initialThrowingBoxAssignments({
+  required List<int> redPlayerSlots,
+  required List<int> bluePlayerSlots,
+}) {
+  final assignments = _emptyThrowingBoxAssignments().toList(growable: true);
+
+  void assign({
+    required BocciaThrowingSide side,
+    required List<int> playerSlots,
+  }) {
+    final normalizedPlayerSlots = playerSlots
+        .map(_normalizePlayerSlot)
+        .whereType<int>()
+        .toList(growable: false);
+    final boxNos = _preferredThrowingBoxNos(
+      side: side,
+      playerCount: normalizedPlayerSlots.length,
+    );
+
+    for (var index = 0;
+        index < normalizedPlayerSlots.length && index < boxNos.length;
+        index += 1) {
+      final boxNo = boxNos[index];
+      final assignmentIndex = assignments.indexWhere(
+        (assignment) => assignment.boxNo == boxNo,
+      );
+
+      if (assignmentIndex < 0) {
+        continue;
+      }
+
+      assignments[assignmentIndex] = assignments[assignmentIndex].copyWith(
+        playerSlot: normalizedPlayerSlots[index],
+      );
+    }
+  }
+
+  assign(
+    side: BocciaThrowingSide.red,
+    playerSlots: redPlayerSlots,
+  );
+  assign(
+    side: BocciaThrowingSide.blue,
+    playerSlots: bluePlayerSlots,
+  );
+
+  return List<BocciaThrowingBoxAssignment>.unmodifiable(assignments);
+}
+
+List<BocciaThrowingBoxAssignment> _emptyThrowingBoxAssignments() {
+  return List<BocciaThrowingBoxAssignment>.unmodifiable(
+    List<BocciaThrowingBoxAssignment>.generate(
+      6,
+      (index) => BocciaThrowingBoxAssignment.empty(boxNo: index + 1),
+    ),
+  );
+}
+
+List<BocciaThrowingBoxAssignment> _normalizeThrowingBoxAssignments(
+  List<BocciaThrowingBoxAssignment> source,
+) {
+  final sourceByBoxNo = <int, BocciaThrowingBoxAssignment>{
+    for (final assignment in source)
+      if (_normalizeThrowingBoxNo(assignment.boxNo) != null)
+        assignment.boxNo: assignment,
+  };
+
+  return List<BocciaThrowingBoxAssignment>.unmodifiable(
+    List<BocciaThrowingBoxAssignment>.generate(
+      6,
+      (index) {
+        final boxNo = index + 1;
+        final source = sourceByBoxNo[boxNo];
+
+        if (source == null) {
+          return BocciaThrowingBoxAssignment.empty(boxNo: boxNo);
+        }
+
+        return BocciaThrowingBoxAssignment(
+          boxNo: boxNo,
+          side: _throwingSideForBoxNo(boxNo),
+          playerSlot: _normalizePlayerSlot(source.playerSlot),
+        );
+      },
+    ),
+  );
+}
+
+List<BocciaThrowingBoxAssignment> _swapThrowingBoxAssignments(
+  List<BocciaThrowingBoxAssignment> source,
+) {
+  final normalized = _normalizeThrowingBoxAssignments(source);
+
+  final nextRedPlayerSlots = normalized
+      .where((assignment) => assignment.side == BocciaThrowingSide.blue)
+      .map((assignment) => assignment.playerSlot)
+      .whereType<int>()
+      .toList(growable: false);
+
+  final nextBluePlayerSlots = normalized
+      .where((assignment) => assignment.side == BocciaThrowingSide.red)
+      .map((assignment) => assignment.playerSlot)
+      .whereType<int>()
+      .toList(growable: false);
+
+  return _initialThrowingBoxAssignments(
+    redPlayerSlots: nextRedPlayerSlots,
+    bluePlayerSlots: nextBluePlayerSlots,
+  );
+}
+
+List<int> _preferredThrowingBoxNos({
+  required BocciaThrowingSide side,
+  required int playerCount,
+}) {
+  if (playerCount <= 0) {
+    return const <int>[];
+  }
+
+  return switch (side) {
+    BocciaThrowingSide.red => switch (playerCount) {
+        1 => const <int>[3],
+        2 => const <int>[3, 5],
+        _ => const <int>[1, 3, 5],
+      },
+    BocciaThrowingSide.blue => switch (playerCount) {
+        1 => const <int>[4],
+        2 => const <int>[2, 4],
+        _ => const <int>[2, 4, 6],
+      },
+  };
+}
+
+BocciaThrowingSide _throwingSideForBoxNo(int boxNo) {
+  return boxNo.isOdd ? BocciaThrowingSide.red : BocciaThrowingSide.blue;
+}
+
+int? _normalizeThrowingBoxNo(Object? value) {
+  final boxNo = _readInt(value);
+  if (boxNo < 1 || boxNo > 6) {
+    return null;
+  }
+
+  return boxNo;
+}
+
+int? _normalizePlayerSlot(Object? value) {
+  final playerSlot = _readInt(value);
+  if (playerSlot <= 0) {
+    return null;
+  }
+
+  return playerSlot;
 }
 
 Map<String, dynamic> _readObject(Object? value) {

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -414,6 +414,28 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         'Participant $playerSlot';
   }
 
+  _TeamViewData? _teamOrNull(int teamSlot) {
+    return _teamBySlot[teamSlot];
+  }
+
+  List<int> _teamMemberSlots(int teamSlot) {
+    final team = _teamOrNull(teamSlot);
+    if (team == null) {
+      return const <int>[];
+    }
+
+    return team.memberPlayerSlots;
+  }
+
+  List<BocciaScorePlayerOption> _bocciaPlayerOptions(int teamSlot) {
+    return _teamMemberSlots(teamSlot).map((playerSlot) {
+      return BocciaScorePlayerOption(
+        playerSlot: playerSlot,
+        displayName: _memberName(playerSlot),
+      );
+    }).toList(growable: false);
+  }
+
   SavedTeamScheduleDisplay _currentDisplay() {
     return SavedTeamScheduleDisplay(
       eventTitle: _eventTitle,
@@ -555,9 +577,16 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       return;
     }
 
+    final redTeamSlot = match.teamSlots[0];
+    final blueTeamSlot = match.teamSlots[1];
+    final redPlayerSlots = _teamMemberSlots(redTeamSlot);
+    final bluePlayerSlots = _teamMemberSlots(blueTeamSlot);
+
     final initialScore = _scores.boccia.matchScoreOrInitial(
       matchNo: match.matchNo,
       teamSlots: match.teamSlots,
+      redPlayerSlots: redPlayerSlots,
+      bluePlayerSlots: bluePlayerSlots,
     );
 
     await showDialog<BocciaMatchScore>(
@@ -568,6 +597,8 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           initialScore: initialScore,
           redTeamName: _teamName(initialScore.redTeamSlot),
           blueTeamName: _teamName(initialScore.blueTeamSlot),
+          redPlayerOptions: _bocciaPlayerOptions(initialScore.redTeamSlot),
+          bluePlayerOptions: _bocciaPlayerOptions(initialScore.blueTeamSlot),
           onSave: _saveBocciaMatchScore,
         );
       },

--- a/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
+++ b/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
@@ -588,23 +588,32 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
               _buildScoreTable(context),
               const SizedBox(height: 16),
               _buildThrowingBoxSection(context),
-              const SizedBox(height: 12),
-              Align(
-                alignment: Alignment.centerLeft,
-                child: _buildStatus(context),
-              ),
             ],
           ),
         ),
       ),
       actions: [
-        TextButton(
-          onPressed: _isSaving ? null : _close,
-          child: Text(l10n.closeBocciaScoreDialogButton),
-        ),
-        FilledButton(
-          onPressed: _isSaving ? null : _save,
-          child: Text(l10n.saveBocciaScoreButton),
+        SizedBox(
+          width: dialogWidth,
+          child: Row(
+            children: [
+              Expanded(
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: _buildStatus(context),
+                ),
+              ),
+              TextButton(
+                onPressed: _isSaving ? null : _close,
+                child: Text(l10n.closeBocciaScoreDialogButton),
+              ),
+              const SizedBox(width: 8),
+              FilledButton(
+                onPressed: _isSaving ? null : _save,
+                child: Text(l10n.saveBocciaScoreButton),
+              ),
+            ],
+          ),
         ),
       ],
     );

--- a/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
+++ b/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
@@ -8,6 +8,8 @@ class BocciaScoreDialog extends StatefulWidget {
     required this.initialScore,
     required this.redTeamName,
     required this.blueTeamName,
+    required this.redPlayerOptions,
+    required this.bluePlayerOptions,
     required this.onSave,
     super.key,
   });
@@ -15,10 +17,22 @@ class BocciaScoreDialog extends StatefulWidget {
   final BocciaMatchScore initialScore;
   final String redTeamName;
   final String blueTeamName;
+  final List<BocciaScorePlayerOption> redPlayerOptions;
+  final List<BocciaScorePlayerOption> bluePlayerOptions;
   final Future<BocciaMatchScore> Function(BocciaMatchScore score) onSave;
 
   @override
   State<BocciaScoreDialog> createState() => _BocciaScoreDialogState();
+}
+
+class BocciaScorePlayerOption {
+  const BocciaScorePlayerOption({
+    required this.playerSlot,
+    required this.displayName,
+  });
+
+  final int playerSlot;
+  final String displayName;
 }
 
 class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
@@ -52,6 +66,31 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     }
 
     return widget.redTeamName;
+  }
+
+  List<BocciaScorePlayerOption> _redPlayerOptions(BocciaMatchScore score) {
+    if (score.redTeamSlot == widget.initialScore.redTeamSlot) {
+      return widget.redPlayerOptions;
+    }
+
+    return widget.bluePlayerOptions;
+  }
+
+  List<BocciaScorePlayerOption> _bluePlayerOptions(BocciaMatchScore score) {
+    if (score.blueTeamSlot == widget.initialScore.blueTeamSlot) {
+      return widget.bluePlayerOptions;
+    }
+
+    return widget.redPlayerOptions;
+  }
+
+  List<BocciaScorePlayerOption> _playerOptionsForAssignment(
+    BocciaThrowingBoxAssignment assignment,
+  ) {
+    return switch (assignment.side) {
+      BocciaThrowingSide.red => _redPlayerOptions(_draftScore),
+      BocciaThrowingSide.blue => _bluePlayerOptions(_draftScore),
+    };
   }
 
   Future<bool> _save() async {
@@ -174,6 +213,20 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     });
   }
 
+  void _setThrowingBoxPlayer({
+    required int boxNo,
+    required int? playerSlot,
+  }) {
+    setState(() {
+      _draftScore = _draftScore.replaceThrowingBoxPlayer(
+        boxNo: boxNo,
+        playerSlot: playerSlot,
+      );
+      _statusMessage = null;
+      _errorMessage = null;
+    });
+  }
+
   Widget _buildOrderHeader(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
@@ -283,7 +336,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           DataRow(
             color: WidgetStatePropertyAll(Colors.red.shade50),
             cells: [
-              DataCell(Text(l10n.bocciaFirstTeamLabel)),
+              const DataCell(SizedBox.shrink()),
               for (final endScore in _draftScore.endScores)
                 DataCell(
                   _buildScoreDropdown(
@@ -311,7 +364,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           DataRow(
             color: WidgetStatePropertyAll(Colors.blue.shade50),
             cells: [
-              DataCell(Text(l10n.bocciaSecondTeamLabel)),
+              const DataCell(SizedBox.shrink()),
               for (final endScore in _draftScore.endScores)
                 DataCell(
                   _buildScoreDropdown(
@@ -355,6 +408,112 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             child: Text(score.toString()),
           ),
       ],
+    );
+  }
+
+  Widget _buildThrowingBoxSection(BuildContext context) {
+    final theme = Theme.of(context);
+    final assignments = _draftScore.throwingBoxAssignments;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '投球場所',
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          '赤は奇数ボックス、青は偶数ボックスに投球者を設定します。',
+          style: theme.textTheme.bodySmall,
+        ),
+        const SizedBox(height: 8),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: [
+              for (final assignment in assignments) ...[
+                _buildThrowingBoxCard(context, assignment),
+                if (assignment != assignments.last) const SizedBox(width: 8),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildThrowingBoxCard(
+    BuildContext context,
+    BocciaThrowingBoxAssignment assignment,
+  ) {
+    final theme = Theme.of(context);
+    final isRed = assignment.side == BocciaThrowingSide.red;
+    final playerOptions = _playerOptionsForAssignment(assignment);
+    final selectedPlayerSlot = playerOptions.any(
+      (option) => option.playerSlot == assignment.playerSlot,
+    )
+        ? assignment.playerSlot
+        : null;
+
+    return Container(
+      width: 150,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: isRed ? Colors.red.shade50 : Colors.blue.shade50,
+        border: Border.all(
+          color: isRed ? Colors.red.shade200 : Colors.blue.shade200,
+        ),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            '${assignment.boxNo}',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          DropdownButtonFormField<int?>(
+            initialValue: selectedPlayerSlot,
+            isExpanded: true,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: 8,
+                vertical: 8,
+              ),
+            ),
+            onChanged: _isSaving
+                ? null
+                : (value) {
+                    _setThrowingBoxPlayer(
+                      boxNo: assignment.boxNo,
+                      playerSlot: value,
+                    );
+                  },
+            items: [
+              const DropdownMenuItem<int?>(
+                value: null,
+                child: Text('未使用'),
+              ),
+              for (final option in playerOptions)
+                DropdownMenuItem<int?>(
+                  value: option.playerSlot,
+                  child: Text(
+                    option.displayName,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 
@@ -410,11 +569,16 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final dialogWidth = MediaQuery.sizeOf(context).width * 0.95;
 
     return AlertDialog(
+      insetPadding: const EdgeInsets.symmetric(
+        horizontal: 12,
+        vertical: 24,
+      ),
       title: Text(l10n.bocciaScoreDialogTitle),
-      content: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 720),
+      content: SizedBox(
+        width: dialogWidth,
         child: SingleChildScrollView(
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -422,6 +586,8 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
               _buildOrderHeader(context),
               const SizedBox(height: 16),
               _buildScoreTable(context),
+              const SizedBox(height: 16),
+              _buildThrowingBoxSection(context),
               const SizedBox(height: 12),
               Align(
                 alignment: Alignment.centerLeft,
@@ -455,7 +621,8 @@ bool _scoreEquals(BocciaMatchScore a, BocciaMatchScore b) {
   if (a.matchNo != b.matchNo ||
       a.redTeamSlot != b.redTeamSlot ||
       a.blueTeamSlot != b.blueTeamSlot ||
-      a.endScores.length != b.endScores.length) {
+      a.endScores.length != b.endScores.length ||
+      a.throwingBoxAssignments.length != b.throwingBoxAssignments.length) {
     return false;
   }
 
@@ -466,6 +633,17 @@ bool _scoreEquals(BocciaMatchScore a, BocciaMatchScore b) {
     if (aEnd.endNo != bEnd.endNo ||
         aEnd.red != bEnd.red ||
         aEnd.blue != bEnd.blue) {
+      return false;
+    }
+  }
+
+  for (var index = 0; index < a.throwingBoxAssignments.length; index += 1) {
+    final aAssignment = a.throwingBoxAssignments[index];
+    final bAssignment = b.throwingBoxAssignments[index];
+
+    if (aAssignment.boxNo != bAssignment.boxNo ||
+        aAssignment.side != bAssignment.side ||
+        aAssignment.playerSlot != bAssignment.playerSlot) {
       return false;
     }
   }


### PR DESCRIPTION
## 概要

ボッチャ用スコア入力に、試合単位のスローイングボックス投球者割り当てを追加しました。

当初は「エンドごとに投球場所を変更・ローテーションする」想定でしたが、確認したところ公式ルールではなくローカル運用寄りだったため、エンド別の投球場所変更は実装対象外にしています。

代わりに、試合開始時に決めたスローイングボックス 1〜6 の投球者割り当てを保存・復元できるようにしました。

- 赤チームは奇数ボックス 1 / 3 / 5 に固定
- 青チームは偶数ボックス 2 / 4 / 6 に固定
- 個人戦は 3 / 4 を初期使用
- ペア戦は 2〜5 を初期使用
- チーム戦は 1〜6 を初期使用
- 人数差のある対戦でも、各チーム人数に応じた使用ボックスを初期設定
- 投球者選択時、別ボックスで選択済みの投球者を選んだ場合は入れ替え
- `swapped()` でチーム・スコア・投球ボックス割り当てを入れ替え
- Firestore 保存用 scores JSON に投球ボックス割り当てを含める
- スコアダイアログ幅を拡張
- スコア入力行の「先攻/後攻」表示を削除
- 保存状態メッセージをダイアログ下部の操作ボタン横に表示

Closes #116

## 作業記録

- 設計: 20分
- 実装: 40分

## 確認

- [x] dart format lib/
- [x] flutter analyze
- [x] flutter test
- [x] 動作確認OK
- [ ] 