### PR TITLE
📝 feat: add Boccia throw order logs refs #115

### DIFF
--- a/lib/features/team_scheduler/domain/boccia_score.dart
+++ b/lib/features/team_scheduler/domain/boccia_score.dart
@@ -216,7 +216,7 @@ class BocciaMatchScore {
         redPlayerSlots: redPlayerSlots,
         bluePlayerSlots: bluePlayerSlots,
       ),
-      throwLogs: const <Map<String, dynamic>>[],
+      throwLogs: const <BocciaThrowLog>[],
     );
   }
 
@@ -238,7 +238,7 @@ class BocciaMatchScore {
       throwingBoxAssignments: _normalizeThrowingBoxAssignments(
         _readThrowingBoxAssignments(json['throwing_box_assignments']),
       ),
-      throwLogs: _readObjectList(json['throw_logs']),
+      throwLogs: _readThrowLogs(json['throw_logs']),
     );
   }
 
@@ -247,7 +247,7 @@ class BocciaMatchScore {
   final int blueTeamSlot;
   final List<BocciaEndScore> endScores;
   final List<BocciaThrowingBoxAssignment> throwingBoxAssignments;
-  final List<Map<String, dynamic>> throwLogs;
+  final List<BocciaThrowLog> throwLogs;
 
   int get endCount => endScores.length;
 
@@ -267,6 +267,51 @@ class BocciaMatchScore {
 
   bool get hasAnyScore {
     return endScores.any((endScore) => endScore.red > 0 || endScore.blue > 0);
+  }
+
+  bool get hasAnyThrowLog {
+    return throwLogs.isNotEmpty;
+  }
+
+  bool get canEditThrowingBoxAssignments {
+    return !hasAnyThrowLog;
+  }
+
+  List<BocciaThrowLog> throwLogsForEnd(int endNo) {
+    return throwLogs.where((log) => log.endNo == endNo).toList(growable: false);
+  }
+
+  int throwLogCountForEnd(int endNo) {
+    return throwLogsForEnd(endNo).length;
+  }
+
+  int throwLogCountForEndSide({
+    required int endNo,
+    required BocciaThrowingSide side,
+  }) {
+    return throwLogs
+        .where((log) => log.endNo == endNo)
+        .where((log) => log.side == side)
+        .length;
+  }
+
+  int throwLogCountForEndBox({
+    required int endNo,
+    required int boxNo,
+  }) {
+    final normalizedBoxNo = _normalizeThrowingBoxNo(boxNo);
+    if (normalizedBoxNo == null) {
+      return 0;
+    }
+
+    return throwLogs
+        .where((log) => log.endNo == endNo)
+        .where((log) => log.boxNo == normalizedBoxNo)
+        .length;
+  }
+
+  bool canAddThrowLogForEnd(int endNo) {
+    return throwLogCountForEnd(endNo) < 12;
   }
 
   BocciaThrowingBoxAssignment? throwingBoxAssignment(int boxNo) {
@@ -302,7 +347,7 @@ class BocciaMatchScore {
     int? blueTeamSlot,
     List<BocciaEndScore>? endScores,
     List<BocciaThrowingBoxAssignment>? throwingBoxAssignments,
-    List<Map<String, dynamic>>? throwLogs,
+    List<BocciaThrowLog>? throwLogs,
   }) {
     return BocciaMatchScore(
       matchNo: matchNo ?? this.matchNo,
@@ -314,8 +359,8 @@ class BocciaMatchScore {
       throwingBoxAssignments: _normalizeThrowingBoxAssignments(
         throwingBoxAssignments ?? this.throwingBoxAssignments,
       ),
-      throwLogs: List<Map<String, dynamic>>.unmodifiable(
-        throwLogs ?? this.throwLogs,
+      throwLogs: List<BocciaThrowLog>.unmodifiable(
+        _normalizeThrowLogs(throwLogs ?? this.throwLogs),
       ),
     );
   }
@@ -343,6 +388,10 @@ class BocciaMatchScore {
     required int boxNo,
     int? playerSlot,
   }) {
+    if (!canEditThrowingBoxAssignments) {
+      return this;
+    }
+
     final normalizedBoxNo = _normalizeThrowingBoxNo(boxNo);
     if (normalizedBoxNo == null) {
       return this;
@@ -386,6 +435,71 @@ class BocciaMatchScore {
     return replaceThrowingBoxPlayer(boxNo: boxNo);
   }
 
+  BocciaMatchScore addThrowLog({
+    required int endNo,
+    required int boxNo,
+  }) {
+    if (!canAddThrowLogForEnd(endNo)) {
+      return this;
+    }
+
+    final normalizedBoxNo = _normalizeThrowingBoxNo(boxNo);
+    if (normalizedBoxNo == null) {
+      return this;
+    }
+
+    final assignment = throwingBoxAssignment(normalizedBoxNo);
+    final playerSlot = assignment?.playerSlot;
+    if (playerSlot == null) {
+      return this;
+    }
+
+    final nextThrowNo = throwLogCountForEnd(endNo) + 1;
+
+    return copyWith(
+      throwLogs: <BocciaThrowLog>[
+        ...throwLogs,
+        BocciaThrowLog(
+          endNo: endNo,
+          throwNo: nextThrowNo,
+          side: assignment!.side,
+          boxNo: normalizedBoxNo,
+          teamSlot: assignment.side == BocciaThrowingSide.red
+              ? redTeamSlot
+              : blueTeamSlot,
+          playerSlot: playerSlot,
+        ),
+      ],
+    );
+  }
+
+  BocciaMatchScore removeLastThrowLog({
+    required int endNo,
+  }) {
+    final endLogs = throwLogsForEnd(endNo);
+    if (endLogs.isEmpty) {
+      return this;
+    }
+
+    final lastEndLog = endLogs.last;
+
+    return copyWith(
+      throwLogs: throwLogs
+          .where((log) => !(log.endNo == lastEndLog.endNo &&
+              log.throwNo == lastEndLog.throwNo))
+          .toList(growable: false),
+    );
+  }
+
+  BocciaMatchScore clearThrowLogsForEnd({
+    required int endNo,
+  }) {
+    return copyWith(
+      throwLogs:
+          throwLogs.where((log) => log.endNo != endNo).toList(growable: false),
+    );
+  }
+
   BocciaMatchScore swapped() {
     return copyWith(
       redTeamSlot: blueTeamSlot,
@@ -396,6 +510,12 @@ class BocciaMatchScore {
       throwingBoxAssignments: _swapThrowingBoxAssignments(
         throwingBoxAssignments,
       ),
+      throwLogs: throwLogs
+          .map((log) => log.swapped(
+                redTeamSlot: blueTeamSlot,
+                blueTeamSlot: redTeamSlot,
+              ))
+          .toList(growable: false),
     );
   }
 
@@ -409,7 +529,7 @@ class BocciaMatchScore {
       'throwing_box_assignments': throwingBoxAssignments
           .map((assignment) => assignment.toJson())
           .toList(),
-      'throw_logs': throwLogs,
+      'throw_logs': throwLogs.map((log) => log.toJson()).toList(),
     };
   }
 }
@@ -462,6 +582,87 @@ class BocciaEndScore {
       'end_no': endNo,
       'red': red,
       'blue': blue,
+    };
+  }
+}
+
+class BocciaThrowLog {
+  const BocciaThrowLog({
+    required this.endNo,
+    required this.throwNo,
+    required this.side,
+    required this.boxNo,
+    required this.teamSlot,
+    required this.playerSlot,
+  });
+
+  factory BocciaThrowLog.fromJson(Map<String, dynamic> json) {
+    final boxNo = _normalizeThrowingBoxNo(json['box_no']) ?? 1;
+    final side = BocciaThrowingSideJson.fromJsonValue(
+      json['team_color'] ?? json['side'],
+    );
+
+    return BocciaThrowLog(
+      endNo: _readInt(json['end_no']),
+      throwNo: _readInt(json['throw_no']),
+      side: side,
+      boxNo: boxNo,
+      teamSlot: _readInt(json['team_slot']),
+      playerSlot: _readInt(json['player_slot']),
+    );
+  }
+
+  final int endNo;
+  final int throwNo;
+  final BocciaThrowingSide side;
+  final int boxNo;
+  final int teamSlot;
+  final int playerSlot;
+
+  BocciaThrowLog copyWith({
+    int? endNo,
+    int? throwNo,
+    BocciaThrowingSide? side,
+    int? boxNo,
+    int? teamSlot,
+    int? playerSlot,
+  }) {
+    final normalizedBoxNo = _normalizeThrowingBoxNo(boxNo ?? this.boxNo) ??
+        _normalizeThrowingBoxNo(this.boxNo) ??
+        this.boxNo;
+
+    return BocciaThrowLog(
+      endNo: endNo ?? this.endNo,
+      throwNo: throwNo ?? this.throwNo,
+      side: side ?? this.side,
+      boxNo: normalizedBoxNo,
+      teamSlot: teamSlot ?? this.teamSlot,
+      playerSlot: playerSlot ?? this.playerSlot,
+    );
+  }
+
+  BocciaThrowLog swapped({
+    required int redTeamSlot,
+    required int blueTeamSlot,
+  }) {
+    final nextBoxNo = _swappedThrowingBoxNo(boxNo);
+    final nextSide = _throwingSideForBoxNo(nextBoxNo);
+
+    return copyWith(
+      side: nextSide,
+      boxNo: nextBoxNo,
+      teamSlot: nextSide == BocciaThrowingSide.red ? redTeamSlot : blueTeamSlot,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'end_no': endNo,
+      'throw_no': throwNo,
+      'team_color': side.toJsonValue(),
+      'box_no': boxNo,
+      'team_slot': teamSlot,
+      'player_slot': playerSlot,
     };
   }
 }
@@ -520,15 +721,7 @@ class BocciaThrowingBoxAssignment {
   }
 
   BocciaThrowingBoxAssignment swapped() {
-    final nextBoxNo = switch (boxNo) {
-      1 => 2,
-      2 => 1,
-      3 => 4,
-      4 => 3,
-      5 => 6,
-      6 => 5,
-      _ => boxNo,
-    };
+    final nextBoxNo = _swappedThrowingBoxNo(boxNo);
 
     return BocciaThrowingBoxAssignment(
       boxNo: nextBoxNo,
@@ -589,6 +782,61 @@ List<BocciaThrowingBoxAssignment> _readThrowingBoxAssignments(Object? value) {
       .map((json) => BocciaThrowingBoxAssignment.fromJson(_readObject(json)))
       .where((assignment) => _normalizeThrowingBoxNo(assignment.boxNo) != null)
       .toList(growable: false);
+}
+
+List<BocciaThrowLog> _readThrowLogs(Object? value) {
+  if (value is! List) {
+    return const <BocciaThrowLog>[];
+  }
+
+  return _normalizeThrowLogs(
+    value
+        .whereType<Map>()
+        .map((json) => BocciaThrowLog.fromJson(_readObject(json)))
+        .where((log) => log.endNo > 0)
+        .where((log) => _normalizeThrowingBoxNo(log.boxNo) != null)
+        .where((log) => log.teamSlot > 0)
+        .where((log) => log.playerSlot > 0)
+        .toList(growable: false),
+  );
+}
+
+List<BocciaThrowLog> _normalizeThrowLogs(List<BocciaThrowLog> source) {
+  final grouped = <int, List<BocciaThrowLog>>{};
+
+  for (final log in source) {
+    if (log.endNo <= 0) {
+      continue;
+    }
+
+    final normalizedBoxNo = _normalizeThrowingBoxNo(log.boxNo);
+    if (normalizedBoxNo == null || log.teamSlot <= 0 || log.playerSlot <= 0) {
+      continue;
+    }
+
+    grouped.putIfAbsent(log.endNo, () => <BocciaThrowLog>[]).add(
+          log.copyWith(
+            boxNo: normalizedBoxNo,
+          ),
+        );
+  }
+
+  final endNos = grouped.keys.toList(growable: false)..sort();
+  final normalized = <BocciaThrowLog>[];
+
+  for (final endNo in endNos) {
+    final logs = grouped[endNo]!;
+    for (var index = 0; index < logs.length && index < 12; index += 1) {
+      normalized.add(
+        logs[index].copyWith(
+          endNo: endNo,
+          throwNo: index + 1,
+        ),
+      );
+    }
+  }
+
+  return List<BocciaThrowLog>.unmodifiable(normalized);
 }
 
 List<BocciaThrowingBoxAssignment> _initialThrowingBoxAssignments({
@@ -724,6 +972,18 @@ List<int> _preferredThrowingBoxNos({
   };
 }
 
+int _swappedThrowingBoxNo(int boxNo) {
+  return switch (boxNo) {
+    1 => 2,
+    2 => 1,
+    3 => 4,
+    4 => 3,
+    5 => 6,
+    6 => 5,
+    _ => boxNo,
+  };
+}
+
 BocciaThrowingSide _throwingSideForBoxNo(int boxNo) {
   return boxNo.isOdd ? BocciaThrowingSide.red : BocciaThrowingSide.blue;
 }
@@ -754,16 +1014,6 @@ Map<String, dynamic> _readObject(Object? value) {
   return <String, dynamic>{
     for (final entry in value.entries) entry.key.toString(): entry.value,
   };
-}
-
-List<Map<String, dynamic>> _readObjectList(Object? value) {
-  if (value is! List) {
-    return const <Map<String, dynamic>>[];
-  }
-
-  return List<Map<String, dynamic>>.unmodifiable(
-    value.whereType<Map>().map(_readObject),
-  );
 }
 
 int _readInt(Object? value, {int defaultValue = 0}) {

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -52,6 +52,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
 
   TeamScheduleScores _scores = const TeamScheduleScores.empty();
   bool _isSavingScores = false;
+  bool _isRefreshingScores = false;
   String? _scoresSaveErrorMessage;
 
   String _eventTitle = '';
@@ -528,8 +529,52 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     }
   }
 
+  Future<TeamScheduleScores?> _refreshScores() async {
+    final shareId = _shareId;
+    if (shareId == null || shareId.isEmpty || _isRefreshingScores) {
+      return null;
+    }
+
+    setState(() {
+      _isRefreshingScores = true;
+      _scoresSaveErrorMessage = null;
+    });
+
+    try {
+      final saved = await appTeamScheduleRepository.findByShareId(shareId);
+      if (saved == null) {
+        throw StateError('team schedule not found: $shareId');
+      }
+
+      final latestScores = TeamScheduleScores.fromJson(saved.scores);
+
+      if (!mounted) {
+        return latestScores;
+      }
+
+      setState(() {
+        _scores = latestScores;
+        _isRefreshingScores = false;
+      });
+
+      return latestScores;
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _scoresSaveErrorMessage = _formatError(error);
+          _isRefreshingScores = false;
+        });
+      }
+
+      return null;
+    }
+  }
+
   Future<void> _selectSport(TeamScheduleSport? sport) async {
-    if (sport == null || sport == _scores.selectedSport || _isSavingScores) {
+    if (sport == null ||
+        sport == _scores.selectedSport ||
+        _isSavingScores ||
+        _isRefreshingScores) {
       return;
     }
 
@@ -551,6 +596,18 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     final savedScores = await _saveScores(nextScores);
 
     return savedScores.boccia.matchScore(score.matchNo) ?? score;
+  }
+
+  Future<BocciaMatchScore?> _refreshBocciaMatchScore(
+    BocciaMatchScore fallbackScore,
+  ) async {
+    final latestScores = await _refreshScores();
+    if (latestScores == null) {
+      return null;
+    }
+
+    return latestScores.boccia.matchScore(fallbackScore.matchNo) ??
+        fallbackScore;
   }
 
   Future<void> _openBocciaScoreDialog(_TeamMatchViewData match) async {
@@ -600,6 +657,9 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           redPlayerOptions: _bocciaPlayerOptions(initialScore.redTeamSlot),
           bluePlayerOptions: _bocciaPlayerOptions(initialScore.blueTeamSlot),
           onSave: _saveBocciaMatchScore,
+          onRefresh: () {
+            return _refreshBocciaMatchScore(initialScore);
+          },
         );
       },
     );
@@ -856,6 +916,23 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       );
     }
 
+    if (_isRefreshingScores) {
+      return Row(
+        children: [
+          const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            l10n.refreshingTeamScheduleScoresMessage,
+            style: theme.textTheme.bodySmall,
+          ),
+        ],
+      );
+    }
+
     if (error != null && error.isNotEmpty) {
       return Text(
         l10n.teamScheduleScoresSaveFailedMessage(error),
@@ -891,7 +968,8 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
               vertical: 10,
             ),
           ),
-          onChanged: _isSavingScores ? null : _selectSport,
+          onChanged:
+              _isSavingScores || _isRefreshingScores ? null : _selectSport,
           items: [
             for (final sport in TeamScheduleSport.values)
               DropdownMenuItem<TeamScheduleSport>(
@@ -905,7 +983,9 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           l10n.teamScheduleSportHelp,
           style: theme.textTheme.bodySmall,
         ),
-        if (_isSavingScores || _scoresSaveErrorMessage != null) ...[
+        if (_isSavingScores ||
+            _isRefreshingScores ||
+            _scoresSaveErrorMessage != null) ...[
           const SizedBox(height: 8),
           _buildScoreSaveStatus(context),
         ],
@@ -949,10 +1029,21 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
             const SizedBox(height: 8),
             SelectableText(shareUrl),
             const SizedBox(height: 12),
-            FilledButton.icon(
-              onPressed: _copyShareUrl,
-              icon: const Icon(Icons.copy),
-              label: Text(l10n.copyTeamScheduleShareUrlButton),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                FilledButton.icon(
+                  onPressed: _copyShareUrl,
+                  icon: const Icon(Icons.copy),
+                  label: Text(l10n.copyTeamScheduleShareUrlButton),
+                ),
+                OutlinedButton.icon(
+                  onPressed: _isRefreshingScores ? null : _refreshScores,
+                  icon: const Icon(Icons.refresh),
+                  label: Text(l10n.refreshLatestTeamScheduleButton),
+                ),
+              ],
             ),
           ],
         ),
@@ -1216,7 +1307,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           const SizedBox(height: 8),
         ],
         FilledButton.tonalIcon(
-          onPressed: _isSavingScores
+          onPressed: _isSavingScores || _isRefreshingScores
               ? null
               : () {
                   _openBocciaScoreDialog(match);

--- a/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
+++ b/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
@@ -504,7 +504,9 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         FilledButton.tonalIcon(
-          onPressed: _isBusy || !_draftScore.canEditThrowingBoxAssignments ? null : _swapOrder,
+          onPressed: _isBusy || !_draftScore.canEditThrowingBoxAssignments
+              ? null
+              : _swapOrder,
           icon: const Icon(Icons.swap_horiz),
           label: Text(l10n.swapBocciaOrderButton),
         ),
@@ -590,9 +592,12 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     final l10n = AppLocalizations.of(context);
     final isSelected = endNo == _selectedEndNo;
 
-    final borderColor = isSelected ? _bocciaAccentTextColor : _bocciaAccentBorderColor;
-    final backgroundColor = isSelected ? _bocciaAccentBackgroundColor : _bocciaInputBackgroundColor;
-    final textColor = isSelected ? _bocciaAccentTextColor : theme.colorScheme.onSurface;
+    final borderColor =
+        isSelected ? _bocciaAccentTextColor : _bocciaAccentBorderColor;
+    final backgroundColor =
+        isSelected ? _bocciaAccentBackgroundColor : _bocciaInputBackgroundColor;
+    final textColor =
+        isSelected ? _bocciaAccentTextColor : theme.colorScheme.onSurface;
 
     return InkWell(
       onTap: () {
@@ -710,6 +715,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
   }) {
     return DropdownButton<int>(
       value: value,
+      dropdownColor: _bocciaSectionBackgroundColor,
       onChanged: _isBusy ? null : onChanged,
       items: [
         for (var score = 0; score <= 6; score += 1)
@@ -726,7 +732,8 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     final l10n = AppLocalizations.of(context);
     final assignments = _draftScore.throwingBoxAssignments;
     final canEditAssignments = _draftScore.canEditThrowingBoxAssignments;
-    final selectedEndThrowCount = _draftScore.throwLogCountForEnd(_selectedEndNo);
+    final selectedEndThrowCount =
+        _draftScore.throwLogCountForEnd(_selectedEndNo);
     final redThrowCount = _draftScore.throwLogCountForEndSide(
       endNo: _selectedEndNo,
       side: BocciaThrowingSide.red,
@@ -746,12 +753,18 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
               style: FilledButton.styleFrom(
                 backgroundColor: _bocciaButtonBackgroundColor,
                 foregroundColor: _bocciaButtonForegroundColor,
-                disabledBackgroundColor: _bocciaButtonBackgroundColor.withOpacity(0.45),
-                disabledForegroundColor: _bocciaButtonForegroundColor.withOpacity(0.5),
+                disabledBackgroundColor:
+                    _bocciaButtonBackgroundColor.withOpacity(0.45),
+                disabledForegroundColor:
+                    _bocciaButtonForegroundColor.withOpacity(0.5),
               ),
-              onPressed: _isBusy || !canEditAssignments ? null : _toggleThrowingBoxAssignmentMode,
+              onPressed: _isBusy || !canEditAssignments
+                  ? null
+                  : _toggleThrowingBoxAssignmentMode,
               icon: Icon(
-                _isEditingThrowingBoxAssignments ? Icons.list_alt : Icons.edit_location_alt,
+                _isEditingThrowingBoxAssignments
+                    ? Icons.list_alt
+                    : Icons.edit_location_alt,
               ),
               label: Text(
                 _isEditingThrowingBoxAssignments
@@ -817,7 +830,8 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
                 _buildThrowingBoxCard(
                   context,
                   assignment,
-                  isEditing: _isEditingThrowingBoxAssignments && canEditAssignments,
+                  isEditing:
+                      _isEditingThrowingBoxAssignments && canEditAssignments,
                 ),
                 if (assignment != assignments.last) const SizedBox(width: 8),
               ],
@@ -880,6 +894,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             DropdownButtonFormField<int?>(
               initialValue: selectedPlayerSlot,
               isExpanded: true,
+              dropdownColor: _bocciaSectionBackgroundColor,
               decoration: InputDecoration(
                 filled: true,
                 fillColor: _bocciaInputBackgroundColor,
@@ -895,7 +910,8 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
                   borderRadius: BorderRadius.circular(8),
                 ),
                 disabledBorder: OutlineInputBorder(
-                  borderSide: BorderSide(color: _bocciaAccentBorderColor.withOpacity(0.6)),
+                  borderSide: BorderSide(
+                      color: _bocciaAccentBorderColor.withOpacity(0.6)),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 contentPadding: const EdgeInsets.symmetric(
@@ -937,7 +953,9 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             ),
             const SizedBox(height: 8),
             Text(
-              assignment.hasPlayer ? l10n.bocciaThrowCountForBox(throwCount) : '',
+              assignment.hasPlayer
+                  ? l10n.bocciaThrowCountForBox(throwCount)
+                  : '',
               textAlign: TextAlign.center,
               style: theme.textTheme.bodySmall,
             ),
@@ -989,7 +1007,8 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
                 ),
               ),
               TextButton.icon(
-                onPressed: _isBusy || !hasLogs ? null : _clearSelectedEndThrowLogs,
+                onPressed:
+                    _isBusy || !hasLogs ? null : _clearSelectedEndThrowLogs,
                 icon: const Icon(Icons.delete_outline),
                 label: Text(l10n.clearBocciaEndThrowLogsButton),
               ),
@@ -1024,7 +1043,8 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               for (final log in columnLogs) _buildThrowOrderItem(context, log),
-              for (var index = columnLogs.length; index < 4; index += 1) const SizedBox(height: 36),
+              for (var index = columnLogs.length; index < 4; index += 1)
+                const SizedBox(height: 36),
             ],
           ),
         ),
@@ -1048,8 +1068,9 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
     final logs = _draftScore.throwLogsForEnd(_selectedEndNo);
-    final isLast =
-        logs.isNotEmpty && logs.last.endNo == log.endNo && logs.last.throwNo == log.throwNo;
+    final isLast = logs.isNotEmpty &&
+        logs.last.endNo == log.endNo &&
+        logs.last.throwNo == log.throwNo;
 
     return Container(
       height: 36,
@@ -1210,7 +1231,9 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
                 style: TextButton.styleFrom(
                   foregroundColor: _bocciaButtonForegroundColor,
                 ),
-                onPressed: _isBusy || widget.onRefresh == null ? null : _refreshLatestScore,
+                onPressed: _isBusy || widget.onRefresh == null
+                    ? null
+                    : _refreshLatestScore,
                 icon: const Icon(Icons.refresh),
                 label: Text(l10n.refreshLatestTeamScheduleButton),
               ),
@@ -1252,7 +1275,9 @@ bool _scoreEquals(BocciaMatchScore a, BocciaMatchScore b) {
     final aEnd = a.endScores[index];
     final bEnd = b.endScores[index];
 
-    if (aEnd.endNo != bEnd.endNo || aEnd.red != bEnd.red || aEnd.blue != bEnd.blue) {
+    if (aEnd.endNo != bEnd.endNo ||
+        aEnd.red != bEnd.red ||
+        aEnd.blue != bEnd.blue) {
       return false;
     }
   }

--- a/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
+++ b/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
@@ -11,6 +11,7 @@ class BocciaScoreDialog extends StatefulWidget {
     required this.redPlayerOptions,
     required this.bluePlayerOptions,
     required this.onSave,
+    this.onRefresh,
     super.key,
   });
 
@@ -20,6 +21,7 @@ class BocciaScoreDialog extends StatefulWidget {
   final List<BocciaScorePlayerOption> redPlayerOptions;
   final List<BocciaScorePlayerOption> bluePlayerOptions;
   final Future<BocciaMatchScore> Function(BocciaMatchScore score) onSave;
+  final Future<BocciaMatchScore?> Function()? onRefresh;
 
   @override
   State<BocciaScoreDialog> createState() => _BocciaScoreDialogState();
@@ -40,11 +42,15 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
   late BocciaMatchScore _lastSavedScore;
 
   bool _isSaving = false;
+  bool _isRefreshing = false;
   String? _statusMessage;
   String? _errorMessage;
 
+  bool get _isBusy => _isSaving || _isRefreshing;
+
   int _selectedEndNo = 1;
   bool _isEditingThrowingBoxAssignments = false;
+
   bool get _isDirty => !_scoreEquals(_draftScore, _lastSavedScore);
 
   @override
@@ -132,6 +138,86 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
       });
 
       return false;
+    }
+  }
+
+  Future<void> _refreshLatestScore() async {
+    final onRefresh = widget.onRefresh;
+    if (_isBusy || onRefresh == null) {
+      return;
+    }
+
+    final l10n = AppLocalizations.of(context);
+
+    if (_isDirty) {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) {
+          return AlertDialog(
+            title: Text(l10n.refreshBocciaScoreDiscardChangesTitle),
+            content: Text(l10n.refreshBocciaScoreDiscardChangesBody),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  Navigator.of(context).pop(false);
+                },
+                child: Text(l10n.cancelRefreshBocciaScoreButton),
+              ),
+              FilledButton(
+                onPressed: () {
+                  Navigator.of(context).pop(true);
+                },
+                child: Text(l10n.confirmRefreshBocciaScoreButton),
+              ),
+            ],
+          );
+        },
+      );
+
+      if (!mounted || confirmed != true) {
+        return;
+      }
+    }
+
+    setState(() {
+      _isRefreshing = true;
+      _statusMessage = null;
+      _errorMessage = null;
+    });
+
+    try {
+      final refreshed = await onRefresh();
+
+      if (!mounted) {
+        return;
+      }
+
+      if (refreshed == null) {
+        setState(() {
+          _errorMessage = l10n.refreshBocciaScoreFailedMessage;
+          _isRefreshing = false;
+        });
+        return;
+      }
+
+      setState(() {
+        _draftScore = refreshed;
+        _lastSavedScore = refreshed;
+        _selectedEndNo = 1;
+        _isEditingThrowingBoxAssignments = false;
+        _statusMessage = l10n.bocciaScoreRefreshedMessage;
+        _isRefreshing = false;
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _errorMessage = error.toString();
+        _isRefreshing = false;
+      });
     }
   }
 
@@ -367,6 +453,39 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     };
   }
 
+  Widget _buildConcurrentEditNotice(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            Icons.info_outline,
+            size: 18,
+            color: theme.colorScheme.outline,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              l10n.teamScheduleConcurrentEditNotice,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildOrderHeader(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
@@ -375,7 +494,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         FilledButton.tonalIcon(
-          onPressed: _isSaving || !_draftScore.canEditThrowingBoxAssignments
+          onPressed: _isBusy || !_draftScore.canEditThrowingBoxAssignments
               ? null
               : _swapOrder,
           icon: const Icon(Icons.swap_horiz),
@@ -578,7 +697,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
   }) {
     return DropdownButton<int>(
       value: value,
-      onChanged: _isSaving ? null : onChanged,
+      onChanged: _isBusy ? null : onChanged,
       items: [
         for (var score = 0; score <= 6; score += 1)
           DropdownMenuItem<int>(
@@ -608,37 +727,11 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          children: [
-            Expanded(
-              child: Text(
-                l10n.bocciaThrowLogTitle(_selectedEndNo),
-                style: theme.textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-            Text(
-              l10n.bocciaThrowCountSummary(
-                redCount: redThrowCount,
-                blueCount: blueThrowCount,
-              ),
-              style: theme.textTheme.bodyMedium?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 4),
-        Text(
-          l10n.bocciaThrowLogHelp,
-          style: theme.textTheme.bodySmall,
-        ),
         const SizedBox(height: 8),
         Row(
           children: [
             FilledButton.tonalIcon(
-              onPressed: _isSaving || !canEditAssignments
+              onPressed: _isBusy || !canEditAssignments
                   ? null
                   : _toggleThrowingBoxAssignmentMode,
               icon: Icon(
@@ -672,6 +765,32 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
               style: theme.textTheme.bodySmall,
             ),
           ],
+        ),
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                l10n.bocciaThrowLogTitle(_selectedEndNo),
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            Text(
+              l10n.bocciaThrowCountSummary(
+                redCount: redThrowCount,
+                blueCount: blueThrowCount,
+              ),
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        Text(
+          l10n.bocciaThrowLogHelp,
+          style: theme.textTheme.bodySmall,
         ),
         const SizedBox(height: 8),
         SingleChildScrollView(
@@ -715,7 +834,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
       endNo: _selectedEndNo,
       boxNo: assignment.boxNo,
     );
-    final canAdd = !_isSaving &&
+    final canAdd = !_isBusy &&
         assignment.hasPlayer &&
         _draftScore.canAddThrowLogForEnd(_selectedEndNo) &&
         !isEditing;
@@ -752,7 +871,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
                   vertical: 8,
                 ),
               ),
-              onChanged: _isSaving
+              onChanged: _isBusy
                   ? null
                   : (value) {
                       _setThrowingBoxPlayer(
@@ -832,7 +951,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             ),
             TextButton.icon(
               onPressed:
-                  _isSaving || !hasLogs ? null : _clearSelectedEndThrowLogs,
+                  _isBusy || !hasLogs ? null : _clearSelectedEndThrowLogs,
               icon: const Icon(Icons.delete_outline),
               label: Text(l10n.clearBocciaEndThrowLogsButton),
             ),
@@ -915,7 +1034,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             IconButton(
               visualDensity: VisualDensity.compact,
               padding: EdgeInsets.zero,
-              onPressed: _isSaving ? null : _removeLastThrowLog,
+              onPressed: _isBusy ? null : _removeLastThrowLog,
               icon: const Icon(Icons.remove_circle_outline),
               tooltip: l10n.removeLastBocciaThrowLogTooltip,
             ),
@@ -938,6 +1057,23 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           ),
           const SizedBox(width: 8),
           Text(l10n.savingTeamScheduleScoresMessage),
+        ],
+      );
+    }
+
+    if (_isRefreshing) {
+      return Row(
+        children: [
+          const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            l10n.refreshingTeamScheduleScoresMessage,
+            style: theme.textTheme.bodySmall,
+          ),
         ],
       );
     }
@@ -990,6 +1126,8 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
+              _buildConcurrentEditNotice(context),
+              const SizedBox(height: 12),
               _buildOrderHeader(context),
               const SizedBox(height: 16),
               _buildScoreTable(context),
@@ -1010,13 +1148,21 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
                   child: _buildStatus(context),
                 ),
               ),
+              TextButton.icon(
+                onPressed: _isBusy || widget.onRefresh == null
+                    ? null
+                    : _refreshLatestScore,
+                icon: const Icon(Icons.refresh),
+                label: Text(l10n.refreshLatestTeamScheduleButton),
+              ),
+              const SizedBox(width: 8),
               TextButton(
-                onPressed: _isSaving ? null : _close,
+                onPressed: _isBusy ? null : _close,
                 child: Text(l10n.closeBocciaScoreDialogButton),
               ),
               const SizedBox(width: 8),
               FilledButton(
-                onPressed: _isSaving ? null : _save,
+                onPressed: _isBusy ? null : _save,
                 child: Text(l10n.saveBocciaScoreButton),
               ),
             ],
@@ -1050,6 +1196,17 @@ bool _scoreEquals(BocciaMatchScore a, BocciaMatchScore b) {
     if (aEnd.endNo != bEnd.endNo ||
         aEnd.red != bEnd.red ||
         aEnd.blue != bEnd.blue) {
+      return false;
+    }
+  }
+
+  for (var index = 0; index < a.throwingBoxAssignments.length; index += 1) {
+    final aAssignment = a.throwingBoxAssignments[index];
+    final bAssignment = b.throwingBoxAssignments[index];
+
+    if (aAssignment.boxNo != bAssignment.boxNo ||
+        aAssignment.side != bAssignment.side ||
+        aAssignment.playerSlot != bAssignment.playerSlot) {
       return false;
     }
   }

--- a/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
+++ b/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
@@ -43,6 +43,8 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
   String? _statusMessage;
   String? _errorMessage;
 
+  int _selectedEndNo = 1;
+  bool _isEditingThrowingBoxAssignments = false;
   bool get _isDirty => !_scoreEquals(_draftScore, _lastSavedScore);
 
   @override
@@ -190,6 +192,10 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
   }
 
   void _swapOrder() {
+    if (!_draftScore.canEditThrowingBoxAssignments) {
+      return;
+    }
+
     setState(() {
       _draftScore = _draftScore.swapped();
       _statusMessage = null;
@@ -203,6 +209,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     int? blue,
   }) {
     setState(() {
+      _selectedEndNo = endNo;
       _draftScore = _draftScore.replaceEndScore(
         endNo: endNo,
         red: red,
@@ -227,6 +234,139 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     });
   }
 
+  void _selectEnd(int endNo) {
+    setState(() {
+      _selectedEndNo = endNo;
+      _isEditingThrowingBoxAssignments = false;
+    });
+  }
+
+  void _toggleThrowingBoxAssignmentMode() {
+    if (!_draftScore.canEditThrowingBoxAssignments) {
+      return;
+    }
+
+    setState(() {
+      _isEditingThrowingBoxAssignments = !_isEditingThrowingBoxAssignments;
+    });
+  }
+
+  void _addThrowLog({
+    required int boxNo,
+  }) {
+    setState(() {
+      _draftScore = _draftScore.addThrowLog(
+        endNo: _selectedEndNo,
+        boxNo: boxNo,
+      );
+      _statusMessage = null;
+      _errorMessage = null;
+    });
+  }
+
+  void _removeLastThrowLog() {
+    setState(() {
+      _draftScore = _draftScore.removeLastThrowLog(
+        endNo: _selectedEndNo,
+      );
+      _statusMessage = null;
+      _errorMessage = null;
+    });
+  }
+
+  Future<void> _clearSelectedEndThrowLogs() async {
+    final hasLogs = _draftScore.throwLogCountForEnd(_selectedEndNo) > 0;
+    if (!hasLogs) {
+      return;
+    }
+
+    final l10n = AppLocalizations.of(context);
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(l10n.clearBocciaEndThrowLogsDialogTitle),
+          content: Text(l10n.clearBocciaEndThrowLogsDialogBody),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(false);
+              },
+              child: Text(l10n.cancelClearBocciaEndThrowLogsButton),
+            ),
+            FilledButton(
+              onPressed: () {
+                Navigator.of(context).pop(true);
+              },
+              child: Text(l10n.confirmClearBocciaEndThrowLogsButton),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (!mounted || confirmed != true) {
+      return;
+    }
+
+    setState(() {
+      _draftScore = _draftScore.clearThrowLogsForEnd(
+        endNo: _selectedEndNo,
+      );
+      _statusMessage = null;
+      _errorMessage = null;
+    });
+  }
+
+  String _playerNameForAssignment(
+    BocciaThrowingBoxAssignment assignment,
+    AppLocalizations l10n,
+  ) {
+    final playerSlot = assignment.playerSlot;
+    if (playerSlot == null) {
+      return l10n.bocciaUnusedThrowingBoxLabel;
+    }
+
+    final playerOptions = _playerOptionsForAssignment(assignment);
+    for (final option in playerOptions) {
+      if (option.playerSlot == playerSlot) {
+        return option.displayName;
+      }
+    }
+
+    return l10n.bocciaDefaultParticipantName(playerSlot);
+  }
+
+  String _playerNameForThrowLog(
+    BocciaThrowLog log,
+    AppLocalizations l10n,
+  ) {
+    final playerOptions = switch (log.side) {
+      BocciaThrowingSide.red => _redPlayerOptions(_draftScore),
+      BocciaThrowingSide.blue => _bluePlayerOptions(_draftScore),
+    };
+
+    for (final option in playerOptions) {
+      if (option.playerSlot == log.playerSlot) {
+        return option.displayName;
+      }
+    }
+
+    return l10n.bocciaDefaultParticipantName(log.playerSlot);
+  }
+
+  String _throwingSideLabel(
+    BocciaThrowingSide side,
+    AppLocalizations l10n,
+  ) {
+    return switch (side) {
+      BocciaThrowingSide.red => l10n.bocciaRedSideLabel,
+      BocciaThrowingSide.blue => l10n.bocciaBlueSideLabel,
+    };
+  }
+
   Widget _buildOrderHeader(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
@@ -235,7 +375,9 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         FilledButton.tonalIcon(
-          onPressed: _isSaving ? null : _swapOrder,
+          onPressed: _isSaving || !_draftScore.canEditThrowingBoxAssignments
+              ? null
+              : _swapOrder,
           icon: const Icon(Icons.swap_horiz),
           label: Text(l10n.swapBocciaOrderButton),
         ),
@@ -313,6 +455,42 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     );
   }
 
+  Widget _buildEndHeader(
+    BuildContext context,
+    int endNo,
+  ) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final isSelected = endNo == _selectedEndNo;
+
+    return InkWell(
+      onTap: () {
+        _selectEnd(endNo);
+      },
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: 10,
+          vertical: 6,
+        ),
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: isSelected ? theme.colorScheme.primary : Colors.transparent,
+            width: 2,
+          ),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          l10n.bocciaEndLabel(endNo),
+          style: theme.textTheme.labelLarge?.copyWith(
+            fontWeight: isSelected ? FontWeight.bold : null,
+            color: isSelected ? theme.colorScheme.primary : null,
+          ),
+        ),
+      ),
+    );
+  }
+
   Widget _buildScoreTable(BuildContext context) {
     final l10n = AppLocalizations.of(context);
 
@@ -326,7 +504,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           const DataColumn(label: SizedBox(width: 56)),
           for (final endScore in _draftScore.endScores)
             DataColumn(
-              label: Text(l10n.bocciaEndLabel(endScore.endNo)),
+              label: _buildEndHeader(context, endScore.endNo),
             ),
           DataColumn(
             label: Text(l10n.bocciaTotalLabel),
@@ -413,21 +591,87 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
 
   Widget _buildThrowingBoxSection(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
     final assignments = _draftScore.throwingBoxAssignments;
+    final canEditAssignments = _draftScore.canEditThrowingBoxAssignments;
+    final selectedEndThrowCount =
+        _draftScore.throwLogCountForEnd(_selectedEndNo);
+    final redThrowCount = _draftScore.throwLogCountForEndSide(
+      endNo: _selectedEndNo,
+      side: BocciaThrowingSide.red,
+    );
+    final blueThrowCount = _draftScore.throwLogCountForEndSide(
+      endNo: _selectedEndNo,
+      side: BocciaThrowingSide.blue,
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          '投球場所',
-          style: theme.textTheme.titleSmall?.copyWith(
-            fontWeight: FontWeight.bold,
-          ),
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                l10n.bocciaThrowLogTitle(_selectedEndNo),
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            Text(
+              l10n.bocciaThrowCountSummary(
+                redCount: redThrowCount,
+                blueCount: blueThrowCount,
+              ),
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
         ),
         const SizedBox(height: 4),
         Text(
-          '赤は奇数ボックス、青は偶数ボックスに投球者を設定します。',
+          l10n.bocciaThrowLogHelp,
           style: theme.textTheme.bodySmall,
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            FilledButton.tonalIcon(
+              onPressed: _isSaving || !canEditAssignments
+                  ? null
+                  : _toggleThrowingBoxAssignmentMode,
+              icon: Icon(
+                _isEditingThrowingBoxAssignments
+                    ? Icons.list_alt
+                    : Icons.edit_location_alt,
+              ),
+              label: Text(
+                _isEditingThrowingBoxAssignments
+                    ? l10n.bocciaReturnToThrowLogButton
+                    : l10n.bocciaThrowingBoxSettingsButton,
+              ),
+            ),
+            if (!canEditAssignments) ...[
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  l10n.bocciaThrowingBoxLockedMessage,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.outline,
+                  ),
+                ),
+              ),
+            ],
+            const SizedBox(width: 12),
+            Text(
+              l10n.bocciaThrowCountProgress(
+                count: selectedEndThrowCount,
+                maxCount: 12,
+              ),
+              style: theme.textTheme.bodySmall,
+            ),
+          ],
         ),
         const SizedBox(height: 8),
         SingleChildScrollView(
@@ -435,21 +679,30 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           child: Row(
             children: [
               for (final assignment in assignments) ...[
-                _buildThrowingBoxCard(context, assignment),
+                _buildThrowingBoxCard(
+                  context,
+                  assignment,
+                  isEditing:
+                      _isEditingThrowingBoxAssignments && canEditAssignments,
+                ),
                 if (assignment != assignments.last) const SizedBox(width: 8),
               ],
             ],
           ),
         ),
+        const SizedBox(height: 16),
+        _buildThrowOrderSection(context),
       ],
     );
   }
 
   Widget _buildThrowingBoxCard(
     BuildContext context,
-    BocciaThrowingBoxAssignment assignment,
-  ) {
+    BocciaThrowingBoxAssignment assignment, {
+    required bool isEditing,
+  }) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
     final isRed = assignment.side == BocciaThrowingSide.red;
     final playerOptions = _playerOptionsForAssignment(assignment);
     final selectedPlayerSlot = playerOptions.any(
@@ -457,6 +710,15 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     )
         ? assignment.playerSlot
         : null;
+    final playerName = _playerNameForAssignment(assignment, l10n);
+    final throwCount = _draftScore.throwLogCountForEndBox(
+      endNo: _selectedEndNo,
+      boxNo: assignment.boxNo,
+    );
+    final canAdd = !_isSaving &&
+        assignment.hasPlayer &&
+        _draftScore.canAddThrowLogForEnd(_selectedEndNo) &&
+        !isEditing;
 
     return Container(
       width: 150,
@@ -479,39 +741,184 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             ),
           ),
           const SizedBox(height: 8),
-          DropdownButtonFormField<int?>(
-            initialValue: selectedPlayerSlot,
-            isExpanded: true,
-            decoration: const InputDecoration(
-              border: OutlineInputBorder(),
-              contentPadding: EdgeInsets.symmetric(
-                horizontal: 8,
-                vertical: 8,
+          if (isEditing)
+            DropdownButtonFormField<int?>(
+              initialValue: selectedPlayerSlot,
+              isExpanded: true,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                contentPadding: EdgeInsets.symmetric(
+                  horizontal: 8,
+                  vertical: 8,
+                ),
+              ),
+              onChanged: _isSaving
+                  ? null
+                  : (value) {
+                      _setThrowingBoxPlayer(
+                        boxNo: assignment.boxNo,
+                        playerSlot: value,
+                      );
+                    },
+              items: [
+                DropdownMenuItem<int?>(
+                  value: null,
+                  child: Text(l10n.bocciaUnusedThrowingBoxLabel),
+                ),
+                for (final option in playerOptions)
+                  DropdownMenuItem<int?>(
+                    value: option.playerSlot,
+                    child: Text(
+                      option.displayName,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+              ],
+            )
+          else ...[
+            Text(
+              playerName,
+              textAlign: TextAlign.center,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: assignment.hasPlayer ? FontWeight.bold : null,
               ),
             ),
-            onChanged: _isSaving
-                ? null
-                : (value) {
-                    _setThrowingBoxPlayer(
-                      boxNo: assignment.boxNo,
-                      playerSlot: value,
-                    );
-                  },
-            items: [
-              const DropdownMenuItem<int?>(
-                value: null,
-                child: Text('未使用'),
-              ),
-              for (final option in playerOptions)
-                DropdownMenuItem<int?>(
-                  value: option.playerSlot,
-                  child: Text(
-                    option.displayName,
-                    overflow: TextOverflow.ellipsis,
-                  ),
+            const SizedBox(height: 8),
+            Text(
+              assignment.hasPlayer
+                  ? l10n.bocciaThrowCountForBox(throwCount)
+                  : '',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall,
+            ),
+            const SizedBox(height: 8),
+            if (assignment.hasPlayer)
+              IconButton(
+                onPressed: canAdd
+                    ? () {
+                        _addThrowLog(boxNo: assignment.boxNo);
+                      }
+                    : null,
+                icon: const Icon(Icons.add),
+                tooltip: l10n.bocciaAddThrowLogTooltip,
+              )
+            else
+              const SizedBox(height: 48),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildThrowOrderSection(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final logs = _draftScore.throwLogsForEnd(_selectedEndNo);
+    final hasLogs = logs.isNotEmpty;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                l10n.bocciaThrowOrderTitle,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
                 ),
+              ),
+            ),
+            TextButton.icon(
+              onPressed:
+                  _isSaving || !hasLogs ? null : _clearSelectedEndThrowLogs,
+              icon: const Icon(Icons.delete_outline),
+              label: Text(l10n.clearBocciaEndThrowLogsButton),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        if (!hasLogs)
+          Text(
+            l10n.bocciaNoThrowLogsMessage,
+            style: theme.textTheme.bodySmall,
+          )
+        else
+          _buildThrowOrderGrid(context, logs),
+      ],
+    );
+  }
+
+  Widget _buildThrowOrderGrid(
+    BuildContext context,
+    List<BocciaThrowLog> logs,
+  ) {
+    final columns = <Widget>[];
+
+    for (var columnIndex = 0; columnIndex < 3; columnIndex += 1) {
+      final startIndex = columnIndex * 4;
+      final columnLogs = logs.skip(startIndex).take(4).toList(growable: false);
+
+      columns.add(
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              for (final log in columnLogs) _buildThrowOrderItem(context, log),
+              for (var index = columnLogs.length; index < 4; index += 1)
+                const SizedBox(height: 36),
             ],
           ),
+        ),
+      );
+
+      if (columnIndex < 2) {
+        columns.add(const SizedBox(width: 12));
+      }
+    }
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: columns,
+    );
+  }
+
+  Widget _buildThrowOrderItem(
+    BuildContext context,
+    BocciaThrowLog log,
+  ) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final logs = _draftScore.throwLogsForEnd(_selectedEndNo);
+    final isLast = logs.isNotEmpty &&
+        logs.last.endNo == log.endNo &&
+        logs.last.throwNo == log.throwNo;
+
+    return SizedBox(
+      height: 36,
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              l10n.bocciaThrowOrderItem(
+                throwNo: log.throwNo,
+                playerName: _playerNameForThrowLog(log, l10n),
+                sideLabel: _throwingSideLabel(log.side, l10n),
+                boxNo: log.boxNo,
+              ),
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall,
+            ),
+          ),
+          if (isLast)
+            IconButton(
+              visualDensity: VisualDensity.compact,
+              padding: EdgeInsets.zero,
+              onPressed: _isSaving ? null : _removeLastThrowLog,
+              icon: const Icon(Icons.remove_circle_outline),
+              tooltip: l10n.removeLastBocciaThrowLogTooltip,
+            ),
         ],
       ),
     );
@@ -631,7 +1038,8 @@ bool _scoreEquals(BocciaMatchScore a, BocciaMatchScore b) {
       a.redTeamSlot != b.redTeamSlot ||
       a.blueTeamSlot != b.blueTeamSlot ||
       a.endScores.length != b.endScores.length ||
-      a.throwingBoxAssignments.length != b.throwingBoxAssignments.length) {
+      a.throwingBoxAssignments.length != b.throwingBoxAssignments.length ||
+      a.throwLogs.length != b.throwLogs.length) {
     return false;
   }
 
@@ -646,13 +1054,16 @@ bool _scoreEquals(BocciaMatchScore a, BocciaMatchScore b) {
     }
   }
 
-  for (var index = 0; index < a.throwingBoxAssignments.length; index += 1) {
-    final aAssignment = a.throwingBoxAssignments[index];
-    final bAssignment = b.throwingBoxAssignments[index];
+  for (var index = 0; index < a.throwLogs.length; index += 1) {
+    final aLog = a.throwLogs[index];
+    final bLog = b.throwLogs[index];
 
-    if (aAssignment.boxNo != bAssignment.boxNo ||
-        aAssignment.side != bAssignment.side ||
-        aAssignment.playerSlot != bAssignment.playerSlot) {
+    if (aLog.endNo != bLog.endNo ||
+        aLog.throwNo != bLog.throwNo ||
+        aLog.side != bLog.side ||
+        aLog.boxNo != bLog.boxNo ||
+        aLog.teamSlot != bLog.teamSlot ||
+        aLog.playerSlot != bLog.playerSlot) {
       return false;
     }
   }

--- a/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
+++ b/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
@@ -48,6 +48,15 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
 
   bool get _isBusy => _isSaving || _isRefreshing;
 
+  Color get _bocciaDialogBackgroundColor => const Color(0xFFFBF9FD);
+  Color get _bocciaSectionBackgroundColor => const Color(0xFFF7F3FB);
+  Color get _bocciaInputBackgroundColor => const Color(0xFFFFFFFF);
+  Color get _bocciaAccentBackgroundColor => const Color(0xFFF1EAFB);
+  Color get _bocciaAccentBorderColor => const Color(0xFFD7C7F2);
+  Color get _bocciaAccentTextColor => const Color(0xFF6F57B6);
+  Color get _bocciaButtonBackgroundColor => const Color(0xFFE8DCF8);
+  Color get _bocciaButtonForegroundColor => const Color(0xFF5F43A8);
+
   int _selectedEndNo = 1;
   bool _isEditingThrowingBoxAssignments = false;
 
@@ -461,8 +470,9 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
       width: double.infinity,
       padding: const EdgeInsets.all(10),
       decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest,
+        color: _bocciaAccentBackgroundColor,
         borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: _bocciaAccentBorderColor),
       ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -470,14 +480,14 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           Icon(
             Icons.info_outline,
             size: 18,
-            color: theme.colorScheme.outline,
+            color: _bocciaAccentTextColor,
           ),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
               l10n.teamScheduleConcurrentEditNotice,
               style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
+                color: _bocciaAccentTextColor,
               ),
             ),
           ),
@@ -494,9 +504,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         FilledButton.tonalIcon(
-          onPressed: _isBusy || !_draftScore.canEditThrowingBoxAssignments
-              ? null
-              : _swapOrder,
+          onPressed: _isBusy || !_draftScore.canEditThrowingBoxAssignments ? null : _swapOrder,
           icon: const Icon(Icons.swap_horiz),
           label: Text(l10n.swapBocciaOrderButton),
         ),
@@ -582,6 +590,10 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     final l10n = AppLocalizations.of(context);
     final isSelected = endNo == _selectedEndNo;
 
+    final borderColor = isSelected ? _bocciaAccentTextColor : _bocciaAccentBorderColor;
+    final backgroundColor = isSelected ? _bocciaAccentBackgroundColor : _bocciaInputBackgroundColor;
+    final textColor = isSelected ? _bocciaAccentTextColor : theme.colorScheme.onSurface;
+
     return InkWell(
       onTap: () {
         _selectEnd(endNo);
@@ -593,17 +605,18 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           vertical: 6,
         ),
         decoration: BoxDecoration(
-          border: Border.all(
-            color: isSelected ? theme.colorScheme.primary : Colors.transparent,
-            width: 2,
-          ),
+          color: backgroundColor,
           borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: borderColor,
+            width: isSelected ? 2 : 1,
+          ),
         ),
         child: Text(
           l10n.bocciaEndLabel(endNo),
-          style: theme.textTheme.labelLarge?.copyWith(
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: textColor,
             fontWeight: isSelected ? FontWeight.bold : null,
-            color: isSelected ? theme.colorScheme.primary : null,
           ),
         ),
       ),
@@ -713,8 +726,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     final l10n = AppLocalizations.of(context);
     final assignments = _draftScore.throwingBoxAssignments;
     final canEditAssignments = _draftScore.canEditThrowingBoxAssignments;
-    final selectedEndThrowCount =
-        _draftScore.throwLogCountForEnd(_selectedEndNo);
+    final selectedEndThrowCount = _draftScore.throwLogCountForEnd(_selectedEndNo);
     final redThrowCount = _draftScore.throwLogCountForEndSide(
       endNo: _selectedEndNo,
       side: BocciaThrowingSide.red,
@@ -731,13 +743,15 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
         Row(
           children: [
             FilledButton.tonalIcon(
-              onPressed: _isBusy || !canEditAssignments
-                  ? null
-                  : _toggleThrowingBoxAssignmentMode,
+              style: FilledButton.styleFrom(
+                backgroundColor: _bocciaButtonBackgroundColor,
+                foregroundColor: _bocciaButtonForegroundColor,
+                disabledBackgroundColor: _bocciaButtonBackgroundColor.withOpacity(0.45),
+                disabledForegroundColor: _bocciaButtonForegroundColor.withOpacity(0.5),
+              ),
+              onPressed: _isBusy || !canEditAssignments ? null : _toggleThrowingBoxAssignmentMode,
               icon: Icon(
-                _isEditingThrowingBoxAssignments
-                    ? Icons.list_alt
-                    : Icons.edit_location_alt,
+                _isEditingThrowingBoxAssignments ? Icons.list_alt : Icons.edit_location_alt,
               ),
               label: Text(
                 _isEditingThrowingBoxAssignments
@@ -771,7 +785,8 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             Expanded(
               child: Text(
                 l10n.bocciaThrowLogTitle(_selectedEndNo),
-                style: theme.textTheme.titleSmall?.copyWith(
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: _bocciaAccentTextColor,
                   fontWeight: FontWeight.bold,
                 ),
               ),
@@ -783,6 +798,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
               ),
               style: theme.textTheme.bodyMedium?.copyWith(
                 fontWeight: FontWeight.bold,
+                color: _bocciaAccentTextColor,
               ),
             ),
           ],
@@ -801,8 +817,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
                 _buildThrowingBoxCard(
                   context,
                   assignment,
-                  isEditing:
-                      _isEditingThrowingBoxAssignments && canEditAssignments,
+                  isEditing: _isEditingThrowingBoxAssignments && canEditAssignments,
                 ),
                 if (assignment != assignments.last) const SizedBox(width: 8),
               ],
@@ -823,6 +838,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
     final isRed = assignment.side == BocciaThrowingSide.red;
+    final sideColor = isRed ? Colors.red : Colors.blue;
     final playerOptions = _playerOptionsForAssignment(assignment);
     final selectedPlayerSlot = playerOptions.any(
       (option) => option.playerSlot == assignment.playerSlot,
@@ -845,7 +861,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
       decoration: BoxDecoration(
         color: isRed ? Colors.red.shade50 : Colors.blue.shade50,
         border: Border.all(
-          color: isRed ? Colors.red.shade200 : Colors.blue.shade200,
+          color: sideColor.withOpacity(0.35),
         ),
         borderRadius: BorderRadius.circular(12),
       ),
@@ -864,9 +880,25 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             DropdownButtonFormField<int?>(
               initialValue: selectedPlayerSlot,
               isExpanded: true,
-              decoration: const InputDecoration(
-                border: OutlineInputBorder(),
-                contentPadding: EdgeInsets.symmetric(
+              decoration: InputDecoration(
+                filled: true,
+                fillColor: _bocciaInputBackgroundColor,
+                enabledBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: _bocciaAccentBorderColor),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(
+                    color: _bocciaAccentTextColor,
+                    width: 2,
+                  ),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                disabledBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: _bocciaAccentBorderColor.withOpacity(0.6)),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                contentPadding: const EdgeInsets.symmetric(
                   horizontal: 8,
                   vertical: 8,
                 ),
@@ -905,9 +937,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             ),
             const SizedBox(height: 8),
             Text(
-              assignment.hasPlayer
-                  ? l10n.bocciaThrowCountForBox(throwCount)
-                  : '',
+              assignment.hasPlayer ? l10n.bocciaThrowCountForBox(throwCount) : '',
               textAlign: TextAlign.center,
               style: theme.textTheme.bodySmall,
             ),
@@ -936,36 +966,45 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     final logs = _draftScore.throwLogsForEnd(_selectedEndNo);
     final hasLogs = logs.isNotEmpty;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            Expanded(
-              child: Text(
-                l10n.bocciaThrowOrderTitle,
-                style: theme.textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.bold,
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: _bocciaDialogBackgroundColor,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: _bocciaAccentBorderColor),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  l10n.bocciaThrowOrderTitle,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: _bocciaAccentTextColor,
+                  ),
                 ),
               ),
-            ),
-            TextButton.icon(
-              onPressed:
-                  _isBusy || !hasLogs ? null : _clearSelectedEndThrowLogs,
-              icon: const Icon(Icons.delete_outline),
-              label: Text(l10n.clearBocciaEndThrowLogsButton),
-            ),
-          ],
-        ),
-        const SizedBox(height: 8),
-        if (!hasLogs)
-          Text(
-            l10n.bocciaNoThrowLogsMessage,
-            style: theme.textTheme.bodySmall,
-          )
-        else
-          _buildThrowOrderGrid(context, logs),
-      ],
+              TextButton.icon(
+                onPressed: _isBusy || !hasLogs ? null : _clearSelectedEndThrowLogs,
+                icon: const Icon(Icons.delete_outline),
+                label: Text(l10n.clearBocciaEndThrowLogsButton),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          if (!hasLogs)
+            Text(
+              l10n.bocciaNoThrowLogsMessage,
+              style: theme.textTheme.bodySmall,
+            )
+          else
+            _buildThrowOrderGrid(context, logs),
+        ],
+      ),
     );
   }
 
@@ -985,8 +1024,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               for (final log in columnLogs) _buildThrowOrderItem(context, log),
-              for (var index = columnLogs.length; index < 4; index += 1)
-                const SizedBox(height: 36),
+              for (var index = columnLogs.length; index < 4; index += 1) const SizedBox(height: 36),
             ],
           ),
         ),
@@ -1010,12 +1048,17 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
     final logs = _draftScore.throwLogsForEnd(_selectedEndNo);
-    final isLast = logs.isNotEmpty &&
-        logs.last.endNo == log.endNo &&
-        logs.last.throwNo == log.throwNo;
+    final isLast =
+        logs.isNotEmpty && logs.last.endNo == log.endNo && logs.last.throwNo == log.throwNo;
 
-    return SizedBox(
+    return Container(
       height: 36,
+      padding: const EdgeInsets.only(left: 8, right: 4),
+      decoration: BoxDecoration(
+        color: _bocciaInputBackgroundColor,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: _bocciaAccentBorderColor),
+      ),
       child: Row(
         children: [
           Expanded(
@@ -1034,6 +1077,11 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             IconButton(
               visualDensity: VisualDensity.compact,
               padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(
+                minWidth: 28,
+                minHeight: 28,
+              ),
+              iconSize: 18,
               onPressed: _isBusy ? null : _removeLastThrowLog,
               icon: const Icon(Icons.remove_circle_outline),
               tooltip: l10n.removeLastBocciaThrowLogTooltip,
@@ -1120,20 +1168,30 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
         vertical: 24,
       ),
       title: Text(l10n.bocciaScoreDialogTitle),
+      backgroundColor: _bocciaDialogBackgroundColor,
       content: SizedBox(
         width: dialogWidth,
         child: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _buildConcurrentEditNotice(context),
-              const SizedBox(height: 12),
-              _buildOrderHeader(context),
-              const SizedBox(height: 16),
-              _buildScoreTable(context),
-              const SizedBox(height: 16),
-              _buildThrowingBoxSection(context),
-            ],
+          child: Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: _bocciaSectionBackgroundColor,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(color: _bocciaAccentBorderColor),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildConcurrentEditNotice(context),
+                const SizedBox(height: 12),
+                _buildOrderHeader(context),
+                const SizedBox(height: 16),
+                _buildScoreTable(context),
+                const SizedBox(height: 16),
+                _buildThrowingBoxSection(context),
+              ],
+            ),
           ),
         ),
       ),
@@ -1149,9 +1207,10 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
                 ),
               ),
               TextButton.icon(
-                onPressed: _isBusy || widget.onRefresh == null
-                    ? null
-                    : _refreshLatestScore,
+                style: TextButton.styleFrom(
+                  foregroundColor: _bocciaButtonForegroundColor,
+                ),
+                onPressed: _isBusy || widget.onRefresh == null ? null : _refreshLatestScore,
                 icon: const Icon(Icons.refresh),
                 label: Text(l10n.refreshLatestTeamScheduleButton),
               ),
@@ -1193,9 +1252,7 @@ bool _scoreEquals(BocciaMatchScore a, BocciaMatchScore b) {
     final aEnd = a.endScores[index];
     final bEnd = b.endScores[index];
 
-    if (aEnd.endNo != bEnd.endNo ||
-        aEnd.red != bEnd.red ||
-        aEnd.blue != bEnd.blue) {
+    if (aEnd.endNo != bEnd.endNo || aEnd.red != bEnd.red || aEnd.blue != bEnd.blue) {
       return false;
     }
   }

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -349,9 +349,37 @@ extension TeamL10n on AppLocalizations {
     return '$redTeamName vs $blueTeamName';
   }
 
+  String bocciaThrowLogTitle(int endNo) {
+    return _isJapanese ? '${endNo}E 投球ログ' : 'End $endNo throw log';
+  }
+
+  String get bocciaThrowLogHelp => _isJapanese
+      ? '投球場所に設定された参加者の＋を押すと、このエンドの投球ログに追加します。'
+      : 'Tap + for a participant assigned to a throwing box to add a throw log for this end.';
+
+  String bocciaThrowCountSummary({
+    required int redCount,
+    required int blueCount,
+  }) {
+    return _isJapanese
+        ? '投球数：赤：$redCount　青：$blueCount'
+        : 'Throws: Red $redCount / Blue $blueCount';
+  }
+
+  String bocciaThrowCountProgress({
+    required int count,
+    required int maxCount,
+  }) {
+    return _isJapanese ? '$count / $maxCount投' : '$count / $maxCount throws';
+  }
+
   String get bocciaFirstTeamLabel => _isJapanese ? '先攻' : 'First';
 
   String get bocciaSecondTeamLabel => _isJapanese ? '後攻' : 'Second';
+
+  String get bocciaRedSideLabel => _isJapanese ? '赤' : 'Red';
+
+  String get bocciaBlueSideLabel => _isJapanese ? '青' : 'Blue';
 
   String get swapBocciaOrderButton => _isJapanese ? '先攻 🔁 後攻' : 'Swap order';
 
@@ -361,6 +389,51 @@ extension TeamL10n on AppLocalizations {
   String bocciaEndLabel(int endNo) {
     return _isJapanese ? '$endNo E' : 'E$endNo';
   }
+
+  String get bocciaThrowingBoxSettingsButton =>
+      _isJapanese ? '投球場所を設定する' : 'Set throwing boxes';
+
+  String get bocciaReturnToThrowLogButton =>
+      _isJapanese ? '投球ログに戻る' : 'Back to throw log';
+
+  String get bocciaThrowingBoxLockedMessage => _isJapanese
+      ? '投球ログ入力後は投球場所を変更できません'
+      : 'Throwing boxes cannot be changed after throw logs are entered.';
+
+  String get bocciaUnusedThrowingBoxLabel => _isJapanese ? '未使用' : 'Unused';
+
+  String bocciaDefaultParticipantName(int playerSlot) {
+    return _isJapanese ? '参加者$playerSlot' : 'Participant $playerSlot';
+  }
+
+  String bocciaThrowCountForBox(int count) {
+    return _isJapanese ? '投球数：$count' : 'Throws: $count';
+  }
+
+  String get bocciaAddThrowLogTooltip =>
+      _isJapanese ? '投球ログを追加' : 'Add throw log';
+
+  String get bocciaThrowOrderTitle => _isJapanese ? '投球順' : 'Throw order';
+
+  String get bocciaNoThrowLogsMessage =>
+      _isJapanese ? 'まだ投球ログはありません。' : 'No throw logs yet.';
+
+  String get clearBocciaEndThrowLogsButton =>
+      _isJapanese ? 'このエンドの履歴をクリア' : 'Clear this end';
+
+  String bocciaThrowOrderItem({
+    required int throwNo,
+    required String playerName,
+    required String sideLabel,
+    required int boxNo,
+  }) {
+    return _isJapanese
+        ? '$throwNo. $playerName（$sideLabel / Box $boxNo）'
+        : '$throwNo. $playerName ($sideLabel / Box $boxNo)';
+  }
+
+  String get removeLastBocciaThrowLogTooltip =>
+      _isJapanese ? '最後の投球を取り消す' : 'Undo last throw';
 
   String get bocciaTotalLabel => _isJapanese ? '合計' : 'Total';
 
@@ -379,6 +452,19 @@ extension TeamL10n on AppLocalizations {
   String get bocciaScoreDiscardChangesBody => _isJapanese
       ? '保存していないスコア変更があります。閉じますか？'
       : 'There are unsaved score changes. Do you want to close?';
+
+  String get clearBocciaEndThrowLogsDialogTitle =>
+      _isJapanese ? 'このエンドの投球履歴をクリアしますか？' : 'Clear throw logs for this end?';
+
+  String get clearBocciaEndThrowLogsDialogBody => _isJapanese
+      ? '選択中エンドの投球順と投球数を削除します。この操作は元に戻せません。'
+      : 'This will delete the throw order and throw counts for the selected end. This action cannot be undone.';
+
+  String get cancelClearBocciaEndThrowLogsButton =>
+      _isJapanese ? 'キャンセル' : 'Cancel';
+
+  String get confirmClearBocciaEndThrowLogsButton =>
+      _isJapanese ? 'クリア' : 'Clear';
 
   String get returnToBocciaScoreInputButton =>
       _isJapanese ? '入力に戻る' : 'Back to input';

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -319,6 +319,35 @@ extension TeamL10n on AppLocalizations {
         : 'Failed to save scores: $detail';
   }
 
+  String get refreshLatestTeamScheduleButton =>
+      _isJapanese ? '最新の情報に更新' : 'Refresh latest';
+
+  String get teamScheduleConcurrentEditNotice => _isJapanese
+      ? '複数端末で同時に編集すると、保存内容が意図どおり反映されない場合があります。'
+      : 'When editing from multiple devices at the same time, saved data may not be reflected as intended.';
+
+  String get refreshingTeamScheduleScoresMessage =>
+      _isJapanese ? '最新のスコア情報を取得しています...' : 'Refreshing latest score data...';
+
+  String get bocciaScoreRefreshedMessage =>
+      _isJapanese ? '最新の情報に更新しました' : 'Refreshed latest data';
+
+  String get refreshBocciaScoreFailedMessage =>
+      _isJapanese ? '最新の情報を取得できませんでした' : 'Failed to refresh latest data';
+
+  String get refreshBocciaScoreDiscardChangesTitle => _isJapanese
+      ? '未保存の変更を破棄して更新しますか？'
+      : 'Discard unsaved changes and refresh?';
+
+  String get refreshBocciaScoreDiscardChangesBody => _isJapanese
+      ? '最新の情報に更新すると、保存していない入力内容は破棄されます。'
+      : 'Refreshing latest data will discard unsaved changes.';
+
+  String get cancelRefreshBocciaScoreButton => _isJapanese ? 'キャンセル' : 'Cancel';
+
+  String get confirmRefreshBocciaScoreButton =>
+      _isJapanese ? '更新する' : 'Refresh';
+
   String get selectSportBeforeScoreInputMessage =>
       _isJapanese ? '先に競技を選択してください。' : 'Select a sport first.';
 


### PR DESCRIPTION
## 概要

ボッチャのスコア入力に、エンドごとの投球順ログを追加します。

## 変更内容

* ボッチャ用スコアに投球場所設定と投球順ログを追加
* 各エンドで投球場所に設定された参加者の `＋` から投球ログを追加できるように変更
* 1エンド12投までの投球ログ上限を追加
* 最後の投球の取り消しと、選択中エンドの投球履歴クリアに対応
* 投球ログ入力後は投球場所を変更できないように制御
* `scores` JSON に投球場所設定と投球順ログを保存・復元
* ボッチャスコア入力画面に同時編集時の注意書きを追加
* ボッチャスコア入力画面とチーム対戦表画面に「最新の情報に更新」導線を追加
* ボッチャスコア入力画面を紫系の配色に調整

## 確認

* [x] dart format lib/
* [x] flutter analyze
* [x] flutter test
* [x] docs 更新要否確認：今回は更新なし

## 補足

* 複数端末で同時編集した場合、現時点では後勝ち保存になる可能性があります。
* 今回は注意書きと手動更新導線までを追加し、競合検知・編集権限制御はログイン機能や共有権限設計の後続対応で検討します。
* ボッチャ専用ページ化や競技別テーマカラー整理は、後続の UI / 構想整理で扱います。

Closes #115
