### PR TITLE
📚📝 feat: チーム用対戦表一覧とイベント情報編集を追加

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -3,6 +3,7 @@ import 'package:srp_lanske/l10n/l10n.dart';
 
 import '../features/doubles_scheduler/presentation/event_setup_page.dart';
 import '../features/doubles_scheduler/presentation/restored_schedule_page.dart';
+import '../features/team_scheduler/presentation/team_schedule_list_page.dart';
 import '../features/team_scheduler/presentation/team_schedule_page.dart';
 import '../features/team_scheduler/presentation/team_setup_page.dart';
 import 'theme/app_theme.dart';
@@ -33,6 +34,10 @@ class App extends StatelessWidget {
   Widget _homeForPath(String path) {
     if (path == '/team') {
       return const TeamSetupPage();
+    }
+
+    if (path == '/team/schedules') {
+      return const TeamScheduleListPage();
     }
 
     final teamScheduleMatch =

--- a/lib/features/team_scheduler/data/local_team_schedule_history_item.dart
+++ b/lib/features/team_scheduler/data/local_team_schedule_history_item.dart
@@ -1,0 +1,77 @@
+class LocalTeamScheduleHistoryItem {
+  const LocalTeamScheduleHistoryItem({
+    required this.shareId,
+    required this.eventTitle,
+    required this.teamCount,
+    required this.memberCount,
+    required this.hasMemo,
+    required this.createdAt,
+    required this.firstSavedAt,
+    required this.updatedAt,
+  });
+
+  final String shareId;
+  final String eventTitle;
+  final int teamCount;
+  final int memberCount;
+  final bool hasMemo;
+  final DateTime createdAt;
+  final DateTime firstSavedAt;
+  final DateTime updatedAt;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'share_id': shareId,
+      'event_title': eventTitle,
+      'team_count': teamCount,
+      'member_count': memberCount,
+      'has_memo': hasMemo,
+      'created_at': createdAt.toIso8601String(),
+      'first_saved_at': firstSavedAt.toIso8601String(),
+      'updated_at': updatedAt.toIso8601String(),
+    };
+  }
+
+  static LocalTeamScheduleHistoryItem fromJson(Map<String, dynamic> json) {
+    final firstSavedAt =
+        DateTime.tryParse(json['first_saved_at'] as String? ?? '') ??
+            DateTime.now();
+    final updatedAt = DateTime.tryParse(json['updated_at'] as String? ?? '') ??
+        DateTime.tryParse(json['last_opened_at'] as String? ?? '') ??
+        DateTime.now();
+
+    return LocalTeamScheduleHistoryItem(
+      shareId: (json['share_id'] as String? ?? '').trim().toUpperCase(),
+      eventTitle: json['event_title'] as String? ?? '',
+      teamCount: json['team_count'] as int? ?? 0,
+      memberCount: json['member_count'] as int? ?? 0,
+      hasMemo: json['has_memo'] as bool? ?? false,
+      createdAt: DateTime.tryParse(json['created_at'] as String? ?? '') ??
+          firstSavedAt,
+      firstSavedAt: firstSavedAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  LocalTeamScheduleHistoryItem copyWith({
+    String? shareId,
+    String? eventTitle,
+    int? teamCount,
+    int? memberCount,
+    bool? hasMemo,
+    DateTime? createdAt,
+    DateTime? firstSavedAt,
+    DateTime? updatedAt,
+  }) {
+    return LocalTeamScheduleHistoryItem(
+      shareId: shareId ?? this.shareId,
+      eventTitle: eventTitle ?? this.eventTitle,
+      teamCount: teamCount ?? this.teamCount,
+      memberCount: memberCount ?? this.memberCount,
+      hasMemo: hasMemo ?? this.hasMemo,
+      createdAt: createdAt ?? this.createdAt,
+      firstSavedAt: firstSavedAt ?? this.firstSavedAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+}

--- a/lib/features/team_scheduler/data/local_team_schedule_history_store.dart
+++ b/lib/features/team_scheduler/data/local_team_schedule_history_store.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'local_team_schedule_history_item.dart';
+
+class LocalTeamScheduleHistoryStore {
+  static const String _storageKey = 'team_schedule_history_items';
+  static const int _maxItems = 20;
+
+  Future<List<LocalTeamScheduleHistoryItem>> loadItems() async {
+    final prefs = await SharedPreferences.getInstance();
+    final rawItems = prefs.getStringList(_storageKey) ?? const [];
+
+    final items = <LocalTeamScheduleHistoryItem>[];
+
+    for (final rawItem in rawItems) {
+      try {
+        final decoded = jsonDecode(rawItem);
+        if (decoded is! Map<String, dynamic>) {
+          continue;
+        }
+
+        final item = LocalTeamScheduleHistoryItem.fromJson(decoded);
+        if (item.shareId.isEmpty) {
+          continue;
+        }
+
+        items.add(item);
+      } on FormatException {
+        continue;
+      } on TypeError {
+        continue;
+      }
+    }
+
+    items.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+
+    return items;
+  }
+
+  Future<void> upsert(LocalTeamScheduleHistoryItem item) async {
+    final normalizedShareId = item.shareId.trim().toUpperCase();
+
+    if (normalizedShareId.isEmpty) {
+      return;
+    }
+
+    final now = DateTime.now();
+    final existingItems = await loadItems();
+
+    LocalTeamScheduleHistoryItem? existingItem;
+    final nextItems = <LocalTeamScheduleHistoryItem>[];
+
+    for (final currentItem in existingItems) {
+      if (currentItem.shareId == normalizedShareId) {
+        existingItem = currentItem;
+        continue;
+      }
+
+      nextItems.add(currentItem);
+    }
+
+    final nextItem = item.copyWith(
+      shareId: normalizedShareId,
+      firstSavedAt: existingItem?.firstSavedAt ?? item.firstSavedAt,
+      updatedAt: now,
+    );
+
+    nextItems.insert(0, nextItem);
+
+    await _saveItems(nextItems.take(_maxItems).toList(growable: false));
+  }
+
+  Future<void> remove(String shareId) async {
+    final normalizedShareId = shareId.trim().toUpperCase();
+
+    if (normalizedShareId.isEmpty) {
+      return;
+    }
+
+    final existingItems = await loadItems();
+    final nextItems = existingItems
+        .where((item) => item.shareId != normalizedShareId)
+        .toList(growable: false);
+
+    await _saveItems(nextItems);
+  }
+
+  Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_storageKey);
+  }
+
+  Future<void> _saveItems(List<LocalTeamScheduleHistoryItem> items) async {
+    final prefs = await SharedPreferences.getInstance();
+
+    final rawItems =
+        items.map((item) => jsonEncode(item.toJson())).toList(growable: false);
+
+    await prefs.setStringList(_storageKey, rawItems);
+  }
+}

--- a/lib/features/team_scheduler/domain/saved_team_schedule.dart
+++ b/lib/features/team_scheduler/domain/saved_team_schedule.dart
@@ -130,6 +130,7 @@ class SavedTeamScheduleDisplay {
     required this.eventTitle,
     required this.teamNames,
     required this.memberNames,
+    this.memo = '',
   });
 
   factory SavedTeamScheduleDisplay.fromJson(Map<String, dynamic> json) {
@@ -137,18 +138,21 @@ class SavedTeamScheduleDisplay {
       eventTitle: _readString(json, 'event_title'),
       teamNames: _readIntStringMap(json, 'team_names'),
       memberNames: _readIntStringMap(json, 'member_names'),
+      memo: _readString(json, 'memo'),
     );
   }
 
   final String eventTitle;
   final Map<int, String> teamNames;
   final Map<int, String> memberNames;
+  final String memo;
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
       'event_title': eventTitle,
       'team_names': _writeIntStringMap(teamNames),
       'member_names': _writeIntStringMap(memberNames),
+      'memo': memo,
     };
   }
 }

--- a/lib/features/team_scheduler/presentation/team_navigation_drawer.dart
+++ b/lib/features/team_scheduler/presentation/team_navigation_drawer.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:srp_lanske/shared/utils/external_link.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../l10n/team_l10n.dart';
+
+const _supportPagePath = '/support/index.html';
+
+class TeamNavigationDrawer extends StatelessWidget {
+  const TeamNavigationDrawer({
+    super.key,
+    required this.showHomeLink,
+    this.onRefreshLatestInfo,
+  });
+
+  final bool showHomeLink;
+  final VoidCallback? onRefreshLatestInfo;
+
+  static double widthFor(BuildContext context) {
+    final screenWidth = MediaQuery.sizeOf(context).width;
+    return screenWidth * 0.85;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Drawer(
+      width: widthFor(context),
+      child: SafeArea(
+        child: Column(
+          children: [
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.fromLTRB(20, 20, 20, 16),
+              color: colorScheme.primaryContainer,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(
+                    Icons.groups_outlined,
+                    color: colorScheme.onPrimaryContainer,
+                    size: 32,
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    l10n.teamNavigationTitle,
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                          color: colorScheme.onPrimaryContainer,
+                          fontWeight: FontWeight.w700,
+                        ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    l10n.teamNavigationSubtitle,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: colorScheme.onPrimaryContainer,
+                        ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: ListView(
+                padding: EdgeInsets.zero,
+                children: [
+                  if (showHomeLink)
+                    if (showHomeLink)
+                      _TeamNavigationTile(
+                        icon: Icons.home_outlined,
+                        label: l10n.teamNavigationHome,
+                        onTap: () => _openPath(context, '/team'),
+                      ),
+                  _TeamNavigationTile(
+                    icon: Icons.list_alt_outlined,
+                    label: l10n.teamNavigationScheduleList,
+                    onTap: () => _openPath(context, '/team/schedules'),
+                  ),
+                  if (onRefreshLatestInfo != null)
+                    _TeamNavigationTile(
+                      icon: Icons.refresh,
+                      label: l10n.refreshLatestInfo,
+                      onTap: () {
+                        Navigator.of(context).pop();
+                        onRefreshLatestInfo!();
+                      },
+                    ),
+                  const Divider(height: 1),
+                  const Divider(height: 1),
+                  _TeamNavigationTile(
+                    icon: Icons.help_outline,
+                    label: l10n.teamNavigationSupport,
+                    onTap: () {
+                      Navigator.of(context).pop();
+                      openUrlInCurrentTab(_supportPagePath);
+                    },
+                  ),
+                  const Divider(height: 1),
+                  _TeamNavigationSectionHeader(
+                      label: l10n.teamNavigationServiceList),
+                  _TeamNavigationTile(
+                    icon: Icons.sports_tennis_outlined,
+                    label: l10n.teamNavigationDoublesScheduler,
+                    onTap: () => _openPath(context, '/'),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _openPath(BuildContext context, String path) {
+    Navigator.of(context).pop();
+    openUrlInCurrentTab(path);
+  }
+}
+
+class _TeamNavigationSectionHeader extends StatelessWidget {
+  const _TeamNavigationSectionHeader({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w700,
+            ),
+      ),
+    );
+  }
+}
+
+class _TeamNavigationTile extends StatelessWidget {
+  const _TeamNavigationTile({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(icon),
+      title: Text(label),
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/features/team_scheduler/presentation/team_navigation_drawer.dart
+++ b/lib/features/team_scheduler/presentation/team_navigation_drawer.dart
@@ -66,12 +66,11 @@ class TeamNavigationDrawer extends StatelessWidget {
                 padding: EdgeInsets.zero,
                 children: [
                   if (showHomeLink)
-                    if (showHomeLink)
-                      _TeamNavigationTile(
-                        icon: Icons.home_outlined,
-                        label: l10n.teamNavigationHome,
-                        onTap: () => _openPath(context, '/team'),
-                      ),
+                    _TeamNavigationTile(
+                      icon: Icons.home_outlined,
+                      label: l10n.teamNavigationHome,
+                      onTap: () => _openPath(context, '/team'),
+                    ),
                   _TeamNavigationTile(
                     icon: Icons.list_alt_outlined,
                     label: l10n.teamNavigationScheduleList,
@@ -86,7 +85,6 @@ class TeamNavigationDrawer extends StatelessWidget {
                         onRefreshLatestInfo!();
                       },
                     ),
-                  const Divider(height: 1),
                   const Divider(height: 1),
                   _TeamNavigationTile(
                     icon: Icons.help_outline,

--- a/lib/features/team_scheduler/presentation/team_schedule_list_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_list_page.dart
@@ -1,0 +1,280 @@
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../l10n/team_l10n.dart';
+import '../data/local_team_schedule_history_item.dart';
+import '../data/local_team_schedule_history_store.dart';
+import 'team_schedule_page.dart';
+
+class TeamScheduleListPage extends StatefulWidget {
+  const TeamScheduleListPage({super.key});
+
+  @override
+  State<TeamScheduleListPage> createState() => _TeamScheduleListPageState();
+}
+
+class _TeamScheduleListPageState extends State<TeamScheduleListPage> {
+  final LocalTeamScheduleHistoryStore _historyStore =
+      LocalTeamScheduleHistoryStore();
+
+  late Future<List<LocalTeamScheduleHistoryItem>> _itemsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _itemsFuture = _historyStore.loadItems();
+  }
+
+  Future<void> _reload() async {
+    setState(() {
+      _itemsFuture = _historyStore.loadItems();
+    });
+  }
+
+  void _openSchedule(LocalTeamScheduleHistoryItem item) {
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute<void>(
+        builder: (_) => TeamSchedulePage.restore(shareId: item.shareId),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.teamScheduleListTitle),
+        actions: [
+          IconButton(
+            tooltip: l10n.refreshLatestInfo,
+            onPressed: _reload,
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: FutureBuilder<List<LocalTeamScheduleHistoryItem>>(
+        future: _itemsFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (snapshot.hasError) {
+            return _TeamScheduleListMessage(
+              icon: Icons.error_outline,
+              title: l10n.teamScheduleListLoadErrorTitle,
+              message: l10n.teamScheduleListLoadErrorMessage,
+              actionLabel: l10n.refreshLatestInfo,
+              onActionPressed: _reload,
+            );
+          }
+
+          final items = snapshot.data ?? const [];
+
+          if (items.isEmpty) {
+            return _TeamScheduleListMessage(
+              icon: Icons.list_alt_outlined,
+              title: l10n.teamScheduleListEmptyTitle,
+              message: l10n.teamScheduleListEmptyMessage,
+            );
+          }
+
+          return RefreshIndicator(
+            onRefresh: _reload,
+            child: ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: items.length,
+              separatorBuilder: (context, index) => const SizedBox(height: 12),
+              itemBuilder: (context, index) {
+                final item = items[index];
+
+                return Card(
+                  clipBehavior: Clip.antiAlias,
+                  child: InkWell(
+                    onTap: () => _openSchedule(item),
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          CircleAvatar(
+                            backgroundColor:
+                                colorScheme.primary.withValues(alpha: 0.12),
+                            foregroundColor: colorScheme.primary,
+                            child: const Icon(Icons.groups_outlined),
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: _TeamScheduleListItemBody(item: item),
+                          ),
+                          const SizedBox(width: 8),
+                          Icon(
+                            Icons.chevron_right,
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _TeamScheduleListItemBody extends StatelessWidget {
+  const _TeamScheduleListItemBody({required this.item});
+
+  final LocalTeamScheduleHistoryItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final title = item.eventTitle.trim().isEmpty
+        ? l10n.teamScheduleUntitledEvent
+        : item.eventTitle.trim();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          l10n.teamScheduleListShareId(item.shareId),
+          style: textTheme.bodySmall?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 4,
+          children: [
+            _TeamScheduleListChip(
+              icon: Icons.groups_2_outlined,
+              label: l10n.teamScheduleListTeamCount(item.teamCount),
+            ),
+            _TeamScheduleListChip(
+              icon: Icons.person_outline,
+              label: l10n.teamScheduleListMemberCount(item.memberCount),
+            ),
+            _TeamScheduleListChip(
+              icon: Icons.schedule_outlined,
+              label: l10n.teamScheduleListUpdatedAt(
+                _formatUpdatedAt(item.updatedAt),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  String _formatUpdatedAt(DateTime updatedAt) {
+    final local = updatedAt.toLocal();
+    final year = local.year.toString().padLeft(4, '0');
+    final month = local.month.toString().padLeft(2, '0');
+    final day = local.day.toString().padLeft(2, '0');
+    final hour = local.hour.toString().padLeft(2, '0');
+    final minute = local.minute.toString().padLeft(2, '0');
+
+    return '$year/$month/$day $hour:$minute';
+  }
+}
+
+class _TeamScheduleListChip extends StatelessWidget {
+  const _TeamScheduleListChip({
+    required this.icon,
+    required this.label,
+  });
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Chip(
+      avatar: Icon(icon, size: 16),
+      label: Text(label),
+      visualDensity: VisualDensity.compact,
+      backgroundColor: colorScheme.surfaceContainerHighest,
+      side: BorderSide.none,
+    );
+  }
+}
+
+class _TeamScheduleListMessage extends StatelessWidget {
+  const _TeamScheduleListMessage({
+    required this.icon,
+    required this.title,
+    required this.message,
+    this.actionLabel,
+    this.onActionPressed,
+  });
+
+  final IconData icon;
+  final String title;
+  final String message;
+  final String? actionLabel;
+  final VoidCallback? onActionPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 48, color: colorScheme.primary),
+              const SizedBox(height: 16),
+              Text(
+                title,
+                style: textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                message,
+                style: textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              if (actionLabel != null && onActionPressed != null) ...[
+                const SizedBox(height: 16),
+                FilledButton.icon(
+                  onPressed: onActionPressed,
+                  icon: const Icon(Icons.refresh),
+                  label: Text(actionLabel!),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/team_scheduler/presentation/team_schedule_list_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_list_page.dart
@@ -147,9 +147,28 @@ class _TeamScheduleListItemBody extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          title,
-          style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(
+              child: Text(
+                title,
+                style: textTheme.titleMedium
+                    ?.copyWith(fontWeight: FontWeight.w700),
+              ),
+            ),
+            if (item.hasMemo) ...[
+              const SizedBox(width: 8),
+              Tooltip(
+                message: l10n.teamScheduleHasMemoTooltip,
+                child: Icon(
+                  Icons.edit_note_outlined,
+                  size: 20,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ],
         ),
         const SizedBox(height: 4),
         Text(

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -61,6 +61,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
   String? _scoresSaveErrorMessage;
 
   String _eventTitle = '';
+  String _memo = '';
   Map<int, String> _teamDisplayNames = const {};
   Map<int, String> _memberDisplayNames = const {};
   int? _selectedTeamSlot;
@@ -184,6 +185,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       setState(() {
         _schedule = schedule;
         _eventTitle = saved.display.eventTitle;
+        _memo = saved.display.memo;
         _teamDisplayNames = saved.display.teamNames;
         _memberDisplayNames = saved.display.memberNames;
         _selectedTeamSlot = schedule.teams.first.teamSlot;
@@ -246,6 +248,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         _eventTitle = saved.display.eventTitle.isEmpty
             ? schedule.eventTitle
             : saved.display.eventTitle;
+        _memo = saved.display.memo;
         _teamDisplayNames = saved.display.teamNames.isEmpty
             ? {
                 for (final team in schedule.teams)
@@ -310,7 +313,7 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         eventTitle: eventTitle,
         teamCount: schedule.teams.length,
         memberCount: schedule.members.length,
-        hasMemo: false,
+        hasMemo: saved.display.memo.trim().isNotEmpty,
         createdAt: saved.createdAt,
         firstSavedAt: saved.createdAt,
         updatedAt: saved.updatedAt,
@@ -481,13 +484,14 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       eventTitle: _eventTitle,
       teamNames: Map<int, String>.unmodifiable(_teamDisplayNames),
       memberNames: Map<int, String>.unmodifiable(_memberDisplayNames),
+      memo: _memo,
     );
   }
 
-  Future<void> _saveCurrentDisplay() async {
+  Future<SavedTeamSchedule?> _saveCurrentDisplay() async {
     final shareId = _shareId;
     if (shareId == null || shareId.isEmpty) {
-      return;
+      return null;
     }
 
     setState(() {
@@ -502,24 +506,29 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       );
 
       if (!mounted) {
-        return;
+        return saved;
       }
 
       setState(() {
         _eventTitle = saved.display.eventTitle;
+        _memo = saved.display.memo;
         _teamDisplayNames = saved.display.teamNames;
         _memberDisplayNames = saved.display.memberNames;
         _isSavingDisplay = false;
       });
+
+      return saved;
     } catch (error) {
       if (!mounted) {
-        return;
+        return null;
       }
 
       setState(() {
         _displaySaveErrorMessage = _formatError(error);
         _isSavingDisplay = false;
       });
+
+      return null;
     }
   }
 
@@ -800,16 +809,169 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     await _saveCurrentDisplay();
   }
 
-  Future<void> _editEventTitle() async {
+  Future<_TeamScheduleBulkEditResult?> _showBulkEditDialog(
+    BuildContext context, {
+    required _TeamScheduleViewData schedule,
+  }) {
     final l10n = AppLocalizations.of(context);
 
-    await _editDisplayName(
-      dialogTitle: l10n.editTeamScheduleEventTitleDialogTitle,
-      initialValue: _eventTitle,
-      onSaved: (value) {
-        _eventTitle = value;
+    final eventTitleController = TextEditingController(text: _eventTitle);
+    final memoController = TextEditingController(text: _memo);
+
+    final teamControllers = <int, TextEditingController>{
+      for (final team in schedule.teams)
+        team.teamSlot: TextEditingController(
+          text: _teamDisplayNames[team.teamSlot] ?? team.displayName,
+        ),
+    };
+
+    final memberControllers = <int, TextEditingController>{
+      for (final member in schedule.members)
+        member.playerSlot: TextEditingController(
+          text: _memberDisplayNames[member.playerSlot] ?? member.displayName,
+        ),
+    };
+
+    return showDialog<_TeamScheduleBulkEditResult>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(l10n.teamScheduleBulkEditTitle),
+          content: SizedBox(
+            width: 520,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextField(
+                    controller: eventTitleController,
+                    decoration: InputDecoration(
+                      labelText: l10n.teamScheduleEventTitleLabel,
+                    ),
+                    textInputAction: TextInputAction.next,
+                  ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: memoController,
+                    decoration: InputDecoration(
+                      labelText: l10n.teamScheduleMemoLabel,
+                      alignLabelWithHint: true,
+                    ),
+                    minLines: 3,
+                    maxLines: 6,
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    l10n.teamScheduleBulkEditTeamsSection,
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                  const SizedBox(height: 8),
+                  for (final team in schedule.teams) ...[
+                    TextField(
+                      controller: teamControllers[team.teamSlot],
+                      decoration: InputDecoration(
+                        labelText: l10n.teamScheduleTeamNameLabel(
+                          team.teamSlot,
+                        ),
+                      ),
+                      textInputAction: TextInputAction.next,
+                    ),
+                    const SizedBox(height: 12),
+                  ],
+                  const SizedBox(height: 12),
+                  Text(
+                    l10n.teamScheduleBulkEditMembersSection,
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                  const SizedBox(height: 8),
+                  for (final member in schedule.members) ...[
+                    TextField(
+                      controller: memberControllers[member.playerSlot],
+                      decoration: InputDecoration(
+                        labelText: member.displayName,
+                      ),
+                      textInputAction: TextInputAction.next,
+                    ),
+                    const SizedBox(height: 12),
+                  ],
+                ],
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: Text(l10n.cancel),
+            ),
+            FilledButton(
+              onPressed: () {
+                Navigator.of(context).pop(
+                  _TeamScheduleBulkEditResult(
+                    eventTitle: eventTitleController.text.trim(),
+                    memo: memoController.text.trim(),
+                    teamNames: {
+                      for (final entry in teamControllers.entries)
+                        entry.key: entry.value.text.trim(),
+                    },
+                    memberNames: {
+                      for (final entry in memberControllers.entries)
+                        entry.key: entry.value.text.trim(),
+                    },
+                  ),
+                );
+              },
+              child: Text(l10n.save),
+            ),
+          ],
+        );
       },
+    ).whenComplete(() {
+      eventTitleController.dispose();
+      memoController.dispose();
+
+      for (final controller in teamControllers.values) {
+        controller.dispose();
+      }
+      for (final controller in memberControllers.values) {
+        controller.dispose();
+      }
+    });
+  }
+
+  Future<void> _editTeamScheduleDetails() async {
+    final schedule = _schedule;
+    if (schedule == null || _isSavingDisplay) {
+      return;
+    }
+
+    final result = await _showBulkEditDialog(
+      context,
+      schedule: schedule,
     );
+
+    if (result == null) {
+      return;
+    }
+
+    setState(() {
+      _eventTitle =
+          result.eventTitle.isEmpty ? schedule.eventTitle : result.eventTitle;
+      _memo = result.memo;
+      _teamDisplayNames = Map<int, String>.unmodifiable(result.teamNames);
+      _memberDisplayNames = Map<int, String>.unmodifiable(result.memberNames);
+    });
+
+    await _saveCurrentDisplay();
+
+    final saved = await _saveCurrentDisplay();
+
+    if (saved != null) {
+      await _upsertLocalHistory(
+        saved: saved,
+        schedule: schedule,
+      );
+    }
   }
 
   Future<void> _editTeamName(int teamSlot) async {
@@ -866,10 +1028,14 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
                     ),
                   ),
                 ),
-                IconButton(
-                  tooltip: l10n.editTeamScheduleEventTitleTooltip,
-                  onPressed: _editEventTitle,
-                  icon: const Icon(Icons.edit_outlined),
+                TextButton.icon(
+                  onPressed: _isSavingDisplay ? null : _editTeamScheduleDetails,
+                  icon: Icon(
+                    _memo.trim().isEmpty
+                        ? Icons.edit_outlined
+                        : Icons.edit_note_outlined,
+                  ),
+                  label: Text(l10n.teamScheduleBulkEditButton),
                 ),
               ],
             ),
@@ -1569,6 +1735,20 @@ class _TeamMemberViewData {
 
   final int playerSlot;
   final String displayName;
+}
+
+class _TeamScheduleBulkEditResult {
+  const _TeamScheduleBulkEditResult({
+    required this.eventTitle,
+    required this.memo,
+    required this.teamNames,
+    required this.memberNames,
+  });
+
+  final String eventTitle;
+  final String memo;
+  final Map<int, String> teamNames;
+  final Map<int, String> memberNames;
 }
 
 class _TeamViewData {

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -7,10 +7,13 @@ import 'package:srp_lanske/l10n/l10n.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 
 import '../application/team_generated_schedule_service.dart';
+import '../data/local_team_schedule_history_item.dart';
+import '../data/local_team_schedule_history_store.dart';
 import '../domain/boccia_score.dart';
 import '../domain/saved_team_schedule.dart';
 import '../domain/team_generated_schedule.dart';
 import 'models/team_setup_draft.dart';
+import 'team_navigation_drawer.dart';
 import 'widgets/boccia_score_dialog.dart';
 
 enum _TeamSchedulePageMode {
@@ -43,6 +46,8 @@ class TeamSchedulePage extends StatefulWidget {
 
 class _TeamSchedulePageState extends State<TeamSchedulePage> {
   late final TeamGeneratedScheduleService _service;
+  final LocalTeamScheduleHistoryStore _historyStore =
+      LocalTeamScheduleHistoryStore();
 
   _TeamScheduleViewData? _schedule;
   String? _errorMessage;
@@ -170,6 +175,12 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         return;
       }
 
+      await _upsertLocalHistory(saved: saved, schedule: schedule);
+
+      if (!mounted) {
+        return;
+      }
+
       setState(() {
         _schedule = schedule;
         _eventTitle = saved.display.eventTitle;
@@ -224,6 +235,12 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         savedSetup: saved.setup,
       );
 
+      await _upsertLocalHistory(saved: saved, schedule: schedule);
+
+      if (!mounted) {
+        return;
+      }
+
       setState(() {
         _schedule = schedule;
         _eventTitle = saved.display.eventTitle.isEmpty
@@ -277,6 +294,28 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           fragment: '',
         )
         .toString();
+  }
+
+  Future<void> _upsertLocalHistory({
+    required SavedTeamSchedule saved,
+    required _TeamScheduleViewData schedule,
+  }) async {
+    final eventTitle = saved.display.eventTitle.trim().isEmpty
+        ? schedule.eventTitle
+        : saved.display.eventTitle.trim();
+
+    await _historyStore.upsert(
+      LocalTeamScheduleHistoryItem(
+        shareId: saved.shareId,
+        eventTitle: eventTitle,
+        teamCount: schedule.teams.length,
+        memberCount: schedule.members.length,
+        hasMemo: false,
+        createdAt: saved.createdAt,
+        firstSavedAt: saved.createdAt,
+        updatedAt: saved.updatedAt,
+      ),
+    );
   }
 
   _TeamScheduleViewData _buildViewData({
@@ -1478,6 +1517,21 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           foregroundColor: Colors.black87,
           surfaceTintColor: Colors.transparent,
           elevation: 0,
+          actions: [
+            Builder(
+              builder: (context) {
+                return IconButton(
+                  tooltip: l10n.teamNavigationMenuTooltip,
+                  onPressed: () => Scaffold.of(context).openEndDrawer(),
+                  icon: const Icon(Icons.menu),
+                );
+              },
+            ),
+          ],
+        ),
+        endDrawer: TeamNavigationDrawer(
+          showHomeLink: true,
+          onRefreshLatestInfo: _refreshScores,
         ),
         body: SafeArea(
           child: _buildBody(context),

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -962,8 +962,6 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       _memberDisplayNames = Map<int, String>.unmodifiable(result.memberNames);
     });
 
-    await _saveCurrentDisplay();
-
     final saved = await _saveCurrentDisplay();
 
     if (saved != null) {

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
 
 import 'models/team_setup_draft.dart';
+import 'team_navigation_drawer.dart';
 import 'team_schedule_page.dart';
 import 'widgets/team_participant_name_input_card.dart';
 import 'widgets/team_setup_number_field.dart';
@@ -321,7 +322,19 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
           foregroundColor: Colors.black87,
           surfaceTintColor: Colors.transparent,
           elevation: 0,
+          actions: [
+            Builder(
+              builder: (context) {
+                return IconButton(
+                  tooltip: l10n.teamNavigationMenuTooltip,
+                  onPressed: () => Scaffold.of(context).openEndDrawer(),
+                  icon: const Icon(Icons.menu),
+                );
+              },
+            ),
+          ],
         ),
+        endDrawer: const TeamNavigationDrawer(showHomeLink: true),
         body: SafeArea(
           child: ListView(
             padding: const EdgeInsets.all(12),

--- a/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
+++ b/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
@@ -754,9 +754,9 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
                 backgroundColor: _bocciaButtonBackgroundColor,
                 foregroundColor: _bocciaButtonForegroundColor,
                 disabledBackgroundColor:
-                    _bocciaButtonBackgroundColor.withOpacity(0.45),
+                    _bocciaButtonBackgroundColor.withValues(alpha: 0.45),
                 disabledForegroundColor:
-                    _bocciaButtonForegroundColor.withOpacity(0.5),
+                    _bocciaButtonForegroundColor.withValues(alpha: 0.5),
               ),
               onPressed: _isBusy || !canEditAssignments
                   ? null
@@ -875,7 +875,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
       decoration: BoxDecoration(
         color: isRed ? Colors.red.shade50 : Colors.blue.shade50,
         border: Border.all(
-          color: sideColor.withOpacity(0.35),
+          color: sideColor.withValues(alpha: 0.35),
         ),
         borderRadius: BorderRadius.circular(12),
       ),
@@ -911,7 +911,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
                 ),
                 disabledBorder: OutlineInputBorder(
                   borderSide: BorderSide(
-                      color: _bocciaAccentBorderColor.withOpacity(0.6)),
+                      color: _bocciaAccentBorderColor.withValues(alpha: 0.6)),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 contentPadding: const EdgeInsets.symmetric(

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -202,6 +202,32 @@ extension TeamL10n on AppLocalizations {
   String get defaultTeamScheduleEventTitle =>
       _isJapanese ? 'チーム練習会' : 'Team practice';
 
+  String get teamScheduleBulkEditTitle =>
+      _isJapanese ? 'まとめて編集' : 'Edit details';
+
+  String get teamScheduleBulkEditButton =>
+      _isJapanese ? 'まとめて編集' : 'Edit details';
+
+  String get teamScheduleEventTitleLabel =>
+      _isJapanese ? 'イベントタイトル' : 'Event title';
+
+  String get teamScheduleMemoLabel => _isJapanese ? 'メモ' : 'Memo';
+
+  String get teamScheduleHasMemoTooltip => _isJapanese ? 'メモあり' : 'Has memo';
+
+  String get teamScheduleBulkEditTeamsSection =>
+      _isJapanese ? 'チーム名' : 'Team names';
+
+  String get teamScheduleBulkEditMembersSection =>
+      _isJapanese ? 'メンバー名' : 'Member names';
+
+  String teamScheduleTeamNameLabel(int teamSlot) =>
+      _isJapanese ? 'チーム$teamSlot' : 'Team $teamSlot';
+
+  String get cancel => _isJapanese ? 'キャンセル' : 'Cancel';
+
+  String get save => _isJapanese ? '保存' : 'Save';
+
   String defaultTeamMemberName(int memberNo) {
     return _isJapanese ? '参加者$memberNo' : 'Participant $memberNo';
   }

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -142,6 +142,63 @@ extension TeamL10n on AppLocalizations {
 
   String get teamScheduleTitle => _isJapanese ? 'チーム対戦表' : 'Team match table';
 
+  String get teamScheduleListTitle =>
+      _isJapanese ? 'チーム対戦表一覧' : 'Team match tables';
+
+  String get teamScheduleListEmptyTitle =>
+      _isJapanese ? 'チーム対戦表はまだありません' : 'No team match tables yet';
+
+  String get teamScheduleListEmptyMessage => _isJapanese
+      ? 'チーム対戦表を作成または共有URLから開くと、この端末の一覧に表示されます。'
+      : 'Create a team match table or open one from a share URL to show it in this device list.';
+
+  String get teamScheduleListLoadErrorTitle =>
+      _isJapanese ? '一覧を読み込めませんでした' : 'Failed to load the list';
+
+  String get teamScheduleListLoadErrorMessage => _isJapanese
+      ? '端末内の保存履歴を確認できませんでした。もう一度お試しください。'
+      : 'Could not read the saved history on this device. Please try again.';
+
+  String get teamScheduleUntitledEvent =>
+      _isJapanese ? 'タイトル未設定のチーム対戦表' : 'Untitled team match table';
+
+  String teamScheduleListShareId(String shareId) {
+    return _isJapanese ? '共有ID: $shareId' : 'Share ID: $shareId';
+  }
+
+  String teamScheduleListTeamCount(int teamCount) {
+    return _isJapanese ? '$teamCountチーム' : '$teamCount teams';
+  }
+
+  String teamScheduleListMemberCount(int memberCount) {
+    return _isJapanese ? '$memberCount人' : '$memberCount members';
+  }
+
+  String teamScheduleListUpdatedAt(String updatedAt) {
+    return _isJapanese ? '更新: $updatedAt' : 'Updated: $updatedAt';
+  }
+
+  String get refreshLatestInfo => refreshLatestTeamScheduleButton;
+
+  String get teamNavigationMenuTooltip =>
+      _isJapanese ? 'チーム用メニューを開く' : 'Open team menu';
+
+  String get teamNavigationTitle => _isJapanese ? 'チーム乱数表' : 'Team scheduler';
+
+  String get teamNavigationSubtitle => _isJapanese ? 'チーム用メニュー' : 'Team menu';
+
+  String get teamNavigationHome => _isJapanese ? 'チームTOP' : 'Team setup';
+
+  String get teamNavigationScheduleList =>
+      _isJapanese ? '対戦表一覧' : 'Match table list';
+
+  String get teamNavigationSupport => _isJapanese ? 'サポート' : 'Support';
+
+  String get teamNavigationServiceList => _isJapanese ? 'サービス一覧' : 'Services';
+
+  String get teamNavigationDoublesScheduler =>
+      _isJapanese ? 'ダブルス乱数表' : 'Doubles scheduler';
+
   String get defaultTeamScheduleEventTitle =>
       _isJapanese ? 'チーム練習会' : 'Team practice';
 


### PR DESCRIPTION
## 概要

チーム用対戦表の一覧画面と、チーム用イベント情報のまとめて編集機能を追加しました。

## 対応 Issue

Closes #100
Closes #107

## 変更内容

### #100 チーム用対戦表一覧

* `/team/schedules` にチーム用対戦表一覧画面を追加
* チーム用対戦表のローカル履歴保存を追加
* 対戦表の作成時・復元時にローカル履歴へ反映
* 一覧から保存済みのチーム用対戦表を開けるように変更
* チーム用セットアップ画面 / 対戦表画面 / 一覧画面に右メニューを追加
* 右メニューに以下の導線を追加
  * チームTOP
  * 対戦表一覧
  * 最新の情報に更新
  * サポート
  * ダブルス乱数表

### #107 チーム用イベント情報編集

* チーム用対戦表の表示情報にメモを追加
* イベントタイトル、メモ、チーム名、メンバー名をまとめて編集できるダイアログを追加
* イベントタイトル横に `まとめて編集` ボタンを追加
* メモ本文は画面・一覧には表示せず、メモあり状態のみアイコンで表示
* ローカル履歴にメモあり状態を反映
* 一括編集後にローカル履歴も更新されるように変更

## 確認内容

* [x] dart format
* [x] flutter analyze
* [x] flutter test
* [x] チーム用対戦表を作成できる
* [x] 作成した対戦表が一覧に表示される
* [x] 一覧からチーム用対戦表を開ける
* [x] 共有IDからチーム用対戦表を復元できる
* [x] 復元した対戦表が一覧に反映される
* [x] 右メニューから各導線が動作する
* [x] まとめて編集でイベントタイトル / メモ / チーム名 / メンバー名を保存できる
* [x] メモあり時にボタン・一覧でアイコン表示される
* [x] メモを空に戻すとメモあり表示が消える

## 補足

* チーム用対戦表一覧は、既存ダブルス側と同様にローカル履歴ベースで表示します。
* 対戦表一覧を右側 drawer 的に表示する案は、今回は対象外とし、必要に応じて後続改善で扱います。
* 操作時の最新情報更新整理は #121 で別途検討します。
