### PR TITLE
🔐 add Firestore rules repo management refs #124

### DIFF
--- a/docs/firebase-hosting-deploy.md
+++ b/docs/firebase-hosting-deploy.md
@@ -102,6 +102,44 @@ npx firebase deploy --only hosting --project lanske-srp
 
 主導線としては `https://lanske-srp.web.app` を使う。
 
+## Firestore Rules deploy
+
+Firestore Security Rules は `firestore.rules` で管理する。
+
+Rules の deploy は Hosting deploy とは別に行う。
+
+```bash
+npx firebase deploy --only firestore:rules --project lanske-srp
+```
+
+deploy 前に以下を確認する。
+
+* `firestore.rules` に必要な collection の rule が含まれている
+* `firebase.json` に Firestore Rules 設定が含まれている
+* 期限付きの全許可 rule に依存していない
+* 不要な `delete` 許可を追加していない
+
+現在クライアントから利用する主な collection は以下。
+
+| collection       | 用途                      | client write    |
+| ---------------- | ----------------------- | --------------- |
+| `events`         | doubles schedule の保存・復元 | create / update |
+| `team_schedules` | team schedule の保存・復元・編集 | create / update |
+| `core_*`         | core 由来の既存データ参照         | なし              |
+
+`core_*` collection は client から read のみ許可し、create / update / delete は許可しない。
+
+deploy 後は以下を軽く確認する。
+
+* doubles schedule を保存できる
+* doubles schedule を共有URLから復元できる
+* team schedule を保存できる
+* team schedule を共有URLから復元できる
+* team schedule の表示名編集を保存できる
+* team schedule のスコア更新を保存できる
+* Firebase Console の Rules が repo の `firestore.rules` と一致している
+rebase deploy --only firestore:rules --project lanske-srp
+
 ## Firestore data migration policy
 
 ver0.1.3 の `lanske-srp` 切り替えでは、旧 `srp-lanske-web-dev` の Firestore データは移行しない。

--- a/docs/firebase-hosting-deploy.md
+++ b/docs/firebase-hosting-deploy.md
@@ -138,7 +138,6 @@ deploy 後は以下を軽く確認する。
 * team schedule の表示名編集を保存できる
 * team schedule のスコア更新を保存できる
 * Firebase Console の Rules が repo の `firestore.rules` と一致している
-rebase deploy --only firestore:rules --project lanske-srp
 
 ## Firestore data migration policy
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,1 +1,38 @@
-{"flutter":{"platforms":{"android":{"default":{"projectId":"srp-lanske-web-dev","appId":"1:59678935940:android:223d8ed753bcc1a12a6bd1","fileOutput":"android/app/google-services.json"}},"dart":{"lib/firebase_options.dart":{"projectId":"lanske-srp","configurations":{"web":"1:635072049481:web:bc353875f3ec79965bea98"}}}}},"hosting":{"public":"build/web","ignore":["firebase.json","**/.*","**/node_modules/**"],"rewrites":[{"source":"**","destination":"/index.html"}]}}
+{
+    "flutter": {
+        "platforms": {
+            "android": {
+                "default": {
+                    "projectId": "srp-lanske-web-dev",
+                    "appId": "1:59678935940:android:223d8ed753bcc1a12a6bd1",
+                    "fileOutput": "android/app/google-services.json"
+                }
+            },
+            "dart": {
+                "lib/firebase_options.dart": {
+                    "projectId": "lanske-srp",
+                    "configurations": {
+                        "web": "1:635072049481:web:bc353875f3ec79965bea98"
+                    }
+                }
+            }
+        }
+    },
+    "hosting": {
+        "public": "build/web",
+        "ignore": [
+            "firebase.json",
+            "**/.*",
+            "**/node_modules/**"
+        ],
+        "rewrites": [
+            {
+                "source": "**",
+                "destination": "/index.html"
+            }
+        ]
+    },
+    "firestore": {
+        "rules": "firestore.rules"
+    }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,33 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isReadOnlyCoreCollection(collectionId) {
+      return collectionId.matches('^core_.*$');
+    }
+
+    // Public share documents used by doubles schedules.
+    match /events/{publicId} {
+      allow read, create, update: if true;
+      allow delete: if false;
+    }
+
+    // Public share documents used by team schedules, including boccia data.
+    match /team_schedules/{shareId} {
+      allow read, create, update: if true;
+      allow delete: if false;
+    }
+
+    // Existing core-generated data is readable from the client,
+    // but client writes are not allowed.
+    match /{collectionId}/{documentId} {
+      allow read: if isReadOnlyCoreCollection(collectionId);
+      allow create, update, delete: if false;
+    }
+
+    // Deny any collection or document path that is not explicitly handled above.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## 概要

Firestore Security Rules を Firebase Console 直接編集から repo 管理へ移しました。

`firestore.rules` を追加し、`firebase.json` から Firestore Rules を deploy できるようにしています。
また、Firestore Rules の deploy 手順と確認項目を docs に追記しました。

Closes #124

## 変更内容

- `firestore.rules` を追加
  - `events` の read / create / update を許可
  - `team_schedules` の read / create / update を許可
  - `core_*` collection は read only
  - delete は許可しない
  - 明示していない collection / document path は deny
- `firebase.json` に Firestore Rules 設定を追加
- `docs/firebase-hosting-deploy.md` に Firestore Rules deploy 手順を追加

## 確認内容

- [x] Firebase Console 上で Rules が更新されていることを確認
- [x] 本番環境で簡易動作確認
- [x] doubles schedule の保存・復元確認
- [x] team schedule の保存・復元確認
- [x] team schedule の編集系確認
- [x] `npx firebase deploy --only firestore:rules --project lanske-srp` で deploy できることを確認

## 補足

Firestore Rules の deploy は Hosting deploy とは別に行います。

```bash
npx firebase deploy --only firestore:rules --project lanske-srp
```