### PR TITLE
🎨 Tune team MVP UI refs #103

### DIFF
--- a/lib/features/team_scheduler/presentation/team_navigation_drawer.dart
+++ b/lib/features/team_scheduler/presentation/team_navigation_drawer.dart
@@ -3,10 +3,18 @@ import 'package:srp_lanske/shared/utils/external_link.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../l10n/team_l10n.dart';
+import '../data/local_team_schedule_history_item.dart';
+import 'team_schedule_page.dart';
+import 'widgets/team_schedule_history_list_view.dart';
 
 const _supportPagePath = '/support/index.html';
 
-class TeamNavigationDrawer extends StatelessWidget {
+enum _TeamDrawerView {
+  menu,
+  schedules,
+}
+
+class TeamNavigationDrawer extends StatefulWidget {
   const TeamNavigationDrawer({
     super.key,
     required this.showHomeLink,
@@ -22,88 +30,54 @@ class TeamNavigationDrawer extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
-    final colorScheme = Theme.of(context).colorScheme;
+  State<TeamNavigationDrawer> createState() => _TeamNavigationDrawerState();
+}
 
+class _TeamNavigationDrawerState extends State<TeamNavigationDrawer> {
+  _TeamDrawerView _view = _TeamDrawerView.menu;
+
+  void _showSchedules() {
+    setState(() {
+      _view = _TeamDrawerView.schedules;
+    });
+  }
+
+  void _showMenu() {
+    setState(() {
+      _view = _TeamDrawerView.menu;
+    });
+  }
+
+  void _openPath(BuildContext context, String path) {
+    Navigator.of(context).pop();
+    openUrlInCurrentTab(path);
+  }
+
+  void _openSchedule(
+    BuildContext context,
+    LocalTeamScheduleHistoryItem item,
+  ) {
+    Navigator.of(context).pop();
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => TeamSchedulePage.restore(shareId: item.shareId),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Drawer(
-      width: widthFor(context),
+      width: TeamNavigationDrawer.widthFor(context),
       child: SafeArea(
         child: Column(
           children: [
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.fromLTRB(20, 20, 20, 16),
-              color: colorScheme.primaryContainer,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Icon(
-                    Icons.groups_outlined,
-                    color: colorScheme.onPrimaryContainer,
-                    size: 32,
-                  ),
-                  const SizedBox(height: 12),
-                  Text(
-                    l10n.teamNavigationTitle,
-                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                          color: colorScheme.onPrimaryContainer,
-                          fontWeight: FontWeight.w700,
-                        ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    l10n.teamNavigationSubtitle,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: colorScheme.onPrimaryContainer,
-                        ),
-                  ),
-                ],
-              ),
-            ),
+            _buildHeader(context),
             Expanded(
-              child: ListView(
-                padding: EdgeInsets.zero,
-                children: [
-                  if (showHomeLink)
-                    _TeamNavigationTile(
-                      icon: Icons.home_outlined,
-                      label: l10n.teamNavigationHome,
-                      onTap: () => _openPath(context, '/team'),
-                    ),
-                  _TeamNavigationTile(
-                    icon: Icons.list_alt_outlined,
-                    label: l10n.teamNavigationScheduleList,
-                    onTap: () => _openPath(context, '/team/schedules'),
-                  ),
-                  if (onRefreshLatestInfo != null)
-                    _TeamNavigationTile(
-                      icon: Icons.refresh,
-                      label: l10n.refreshLatestInfo,
-                      onTap: () {
-                        Navigator.of(context).pop();
-                        onRefreshLatestInfo!();
-                      },
-                    ),
-                  const Divider(height: 1),
-                  _TeamNavigationTile(
-                    icon: Icons.help_outline,
-                    label: l10n.teamNavigationSupport,
-                    onTap: () {
-                      Navigator.of(context).pop();
-                      openUrlInCurrentTab(_supportPagePath);
-                    },
-                  ),
-                  const Divider(height: 1),
-                  _TeamNavigationSectionHeader(
-                      label: l10n.teamNavigationServiceList),
-                  _TeamNavigationTile(
-                    icon: Icons.sports_tennis_outlined,
-                    label: l10n.teamNavigationDoublesScheduler,
-                    onTap: () => _openPath(context, '/'),
-                  ),
-                ],
-              ),
+              child: switch (_view) {
+                _TeamDrawerView.menu => _buildMenu(context),
+                _TeamDrawerView.schedules => _buildScheduleList(context),
+              },
             ),
           ],
         ),
@@ -111,9 +85,113 @@ class TeamNavigationDrawer extends StatelessWidget {
     );
   }
 
-  void _openPath(BuildContext context, String path) {
-    Navigator.of(context).pop();
-    openUrlInCurrentTab(path);
+  Widget _buildHeader(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 16),
+      color: colorScheme.primaryContainer,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            Icons.groups_outlined,
+            color: colorScheme.onPrimaryContainer,
+            size: 32,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            l10n.teamNavigationTitle,
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  color: colorScheme.onPrimaryContainer,
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            l10n.teamNavigationSubtitle,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onPrimaryContainer,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMenu(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return ListView(
+      padding: EdgeInsets.zero,
+      children: [
+        if (widget.showHomeLink)
+          _TeamNavigationTile(
+            icon: Icons.home_outlined,
+            label: l10n.teamNavigationHome,
+            onTap: () => _openPath(context, '/team'),
+          ),
+        _TeamNavigationTile(
+          icon: Icons.list_alt_outlined,
+          label: l10n.teamNavigationScheduleList,
+          onTap: _showSchedules,
+        ),
+        if (widget.onRefreshLatestInfo != null)
+          _TeamNavigationTile(
+            icon: Icons.refresh,
+            label: l10n.refreshLatestInfo,
+            onTap: () {
+              Navigator.of(context).pop();
+              widget.onRefreshLatestInfo!();
+            },
+          ),
+        const Divider(height: 1),
+        _TeamNavigationTile(
+          icon: Icons.help_outline,
+          label: l10n.teamNavigationSupport,
+          onTap: () {
+            Navigator.of(context).pop();
+            openUrlInCurrentTab(_supportPagePath);
+          },
+        ),
+        const Divider(height: 1),
+        _TeamNavigationSectionHeader(label: l10n.teamNavigationServiceList),
+        _TeamNavigationTile(
+          icon: Icons.sports_tennis_outlined,
+          label: l10n.teamNavigationDoublesScheduler,
+          onTap: () => _openPath(context, '/'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildScheduleList(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ListTile(
+          leading: const Icon(Icons.arrow_back),
+          title: Text(
+            l10n.teamScheduleListTitle,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+          onTap: _showMenu,
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: TeamScheduleHistoryListView(
+            padding: const EdgeInsets.all(12),
+            onOpenSchedule: (item) => _openSchedule(context, item),
+          ),
+        ),
+      ],
+    );
   }
 }
 

--- a/lib/features/team_scheduler/presentation/team_schedule_list_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_list_page.dart
@@ -3,35 +3,16 @@ import 'package:flutter/material.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../l10n/team_l10n.dart';
 import '../data/local_team_schedule_history_item.dart';
-import '../data/local_team_schedule_history_store.dart';
 import 'team_schedule_page.dart';
+import 'widgets/team_schedule_history_list_view.dart';
 
-class TeamScheduleListPage extends StatefulWidget {
+class TeamScheduleListPage extends StatelessWidget {
   const TeamScheduleListPage({super.key});
 
-  @override
-  State<TeamScheduleListPage> createState() => _TeamScheduleListPageState();
-}
-
-class _TeamScheduleListPageState extends State<TeamScheduleListPage> {
-  final LocalTeamScheduleHistoryStore _historyStore =
-      LocalTeamScheduleHistoryStore();
-
-  late Future<List<LocalTeamScheduleHistoryItem>> _itemsFuture;
-
-  @override
-  void initState() {
-    super.initState();
-    _itemsFuture = _historyStore.loadItems();
-  }
-
-  Future<void> _reload() async {
-    setState(() {
-      _itemsFuture = _historyStore.loadItems();
-    });
-  }
-
-  void _openSchedule(LocalTeamScheduleHistoryItem item) {
+  void _openSchedule(
+    BuildContext context,
+    LocalTeamScheduleHistoryItem item,
+  ) {
     Navigator.of(context).pushReplacement(
       MaterialPageRoute<void>(
         builder: (_) => TeamSchedulePage.restore(shareId: item.shareId),
@@ -42,257 +23,13 @@ class _TeamScheduleListPageState extends State<TeamScheduleListPage> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final colorScheme = Theme.of(context).colorScheme;
 
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.teamScheduleListTitle),
-        actions: [
-          IconButton(
-            tooltip: l10n.refreshLatestInfo,
-            onPressed: _reload,
-            icon: const Icon(Icons.refresh),
-          ),
-        ],
       ),
-      body: FutureBuilder<List<LocalTeamScheduleHistoryItem>>(
-        future: _itemsFuture,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState != ConnectionState.done) {
-            return const Center(child: CircularProgressIndicator());
-          }
-
-          if (snapshot.hasError) {
-            return _TeamScheduleListMessage(
-              icon: Icons.error_outline,
-              title: l10n.teamScheduleListLoadErrorTitle,
-              message: l10n.teamScheduleListLoadErrorMessage,
-              actionLabel: l10n.refreshLatestInfo,
-              onActionPressed: _reload,
-            );
-          }
-
-          final items = snapshot.data ?? const [];
-
-          if (items.isEmpty) {
-            return _TeamScheduleListMessage(
-              icon: Icons.list_alt_outlined,
-              title: l10n.teamScheduleListEmptyTitle,
-              message: l10n.teamScheduleListEmptyMessage,
-            );
-          }
-
-          return RefreshIndicator(
-            onRefresh: _reload,
-            child: ListView.separated(
-              padding: const EdgeInsets.all(16),
-              itemCount: items.length,
-              separatorBuilder: (context, index) => const SizedBox(height: 12),
-              itemBuilder: (context, index) {
-                final item = items[index];
-
-                return Card(
-                  clipBehavior: Clip.antiAlias,
-                  child: InkWell(
-                    onTap: () => _openSchedule(item),
-                    child: Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          CircleAvatar(
-                            backgroundColor:
-                                colorScheme.primary.withValues(alpha: 0.12),
-                            foregroundColor: colorScheme.primary,
-                            child: const Icon(Icons.groups_outlined),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: _TeamScheduleListItemBody(item: item),
-                          ),
-                          const SizedBox(width: 8),
-                          Icon(
-                            Icons.chevron_right,
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                );
-              },
-            ),
-          );
-        },
-      ),
-    );
-  }
-}
-
-class _TeamScheduleListItemBody extends StatelessWidget {
-  const _TeamScheduleListItemBody({required this.item});
-
-  final LocalTeamScheduleHistoryItem item;
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
-    final textTheme = Theme.of(context).textTheme;
-    final colorScheme = Theme.of(context).colorScheme;
-
-    final title = item.eventTitle.trim().isEmpty
-        ? l10n.teamScheduleUntitledEvent
-        : item.eventTitle.trim();
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Expanded(
-              child: Text(
-                title,
-                style: textTheme.titleMedium
-                    ?.copyWith(fontWeight: FontWeight.w700),
-              ),
-            ),
-            if (item.hasMemo) ...[
-              const SizedBox(width: 8),
-              Tooltip(
-                message: l10n.teamScheduleHasMemoTooltip,
-                child: Icon(
-                  Icons.edit_note_outlined,
-                  size: 20,
-                  color: colorScheme.onSurfaceVariant,
-                ),
-              ),
-            ],
-          ],
-        ),
-        const SizedBox(height: 4),
-        Text(
-          l10n.teamScheduleListShareId(item.shareId),
-          style: textTheme.bodySmall?.copyWith(
-            color: colorScheme.onSurfaceVariant,
-          ),
-        ),
-        const SizedBox(height: 8),
-        Wrap(
-          spacing: 8,
-          runSpacing: 4,
-          children: [
-            _TeamScheduleListChip(
-              icon: Icons.groups_2_outlined,
-              label: l10n.teamScheduleListTeamCount(item.teamCount),
-            ),
-            _TeamScheduleListChip(
-              icon: Icons.person_outline,
-              label: l10n.teamScheduleListMemberCount(item.memberCount),
-            ),
-            _TeamScheduleListChip(
-              icon: Icons.schedule_outlined,
-              label: l10n.teamScheduleListUpdatedAt(
-                _formatUpdatedAt(item.updatedAt),
-              ),
-            ),
-          ],
-        ),
-      ],
-    );
-  }
-
-  String _formatUpdatedAt(DateTime updatedAt) {
-    final local = updatedAt.toLocal();
-    final year = local.year.toString().padLeft(4, '0');
-    final month = local.month.toString().padLeft(2, '0');
-    final day = local.day.toString().padLeft(2, '0');
-    final hour = local.hour.toString().padLeft(2, '0');
-    final minute = local.minute.toString().padLeft(2, '0');
-
-    return '$year/$month/$day $hour:$minute';
-  }
-}
-
-class _TeamScheduleListChip extends StatelessWidget {
-  const _TeamScheduleListChip({
-    required this.icon,
-    required this.label,
-  });
-
-  final IconData icon;
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Chip(
-      avatar: Icon(icon, size: 16),
-      label: Text(label),
-      visualDensity: VisualDensity.compact,
-      backgroundColor: colorScheme.surfaceContainerHighest,
-      side: BorderSide.none,
-    );
-  }
-}
-
-class _TeamScheduleListMessage extends StatelessWidget {
-  const _TeamScheduleListMessage({
-    required this.icon,
-    required this.title,
-    required this.message,
-    this.actionLabel,
-    this.onActionPressed,
-  });
-
-  final IconData icon;
-  final String title;
-  final String message;
-  final String? actionLabel;
-  final VoidCallback? onActionPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 420),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(icon, size: 48, color: colorScheme.primary),
-              const SizedBox(height: 16),
-              Text(
-                title,
-                style: textTheme.titleLarge?.copyWith(
-                  fontWeight: FontWeight.w700,
-                ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 8),
-              Text(
-                message,
-                style: textTheme.bodyMedium?.copyWith(
-                  color: colorScheme.onSurfaceVariant,
-                ),
-                textAlign: TextAlign.center,
-              ),
-              if (actionLabel != null && onActionPressed != null) ...[
-                const SizedBox(height: 16),
-                FilledButton.icon(
-                  onPressed: onActionPressed,
-                  icon: const Icon(Icons.refresh),
-                  label: Text(actionLabel!),
-                ),
-              ],
-            ],
-          ),
-        ),
+      body: TeamScheduleHistoryListView(
+        onOpenSchedule: (item) => _openSchedule(context, item),
       ),
     );
   }

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -1409,18 +1409,16 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
   }
 
   Widget _buildRoundCard(BuildContext context, _TeamRoundViewData round) {
-    final schedule = _schedule!;
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
-    final isNextRound = round.roundNo == schedule.nextRoundNo;
 
     return Card(
       elevation: 0,
-      color: isNextRound ? Colors.blue.shade50 : Colors.white,
+      color: Colors.white,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(12),
         side: BorderSide(
-          color: isNextRound ? Colors.blue.shade300 : Colors.transparent,
+          color: Colors.transparent,
         ),
       ),
       child: Padding(
@@ -1436,14 +1434,6 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                if (isNextRound) ...[
-                  const SizedBox(width: 8),
-                  Chip(
-                    label: Text(l10n.nextTeamMatchTitle),
-                    visualDensity: VisualDensity.compact,
-                    backgroundColor: Colors.blue.shade100,
-                  ),
-                ],
               ],
             ),
             const SizedBox(height: 12),
@@ -1461,47 +1451,130 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     BuildContext context,
     _TeamMatchViewData match,
   ) {
-    final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
     final score = _scores.boccia.matchScore(match.matchNo);
     final hasScore = score?.hasAnyScore ?? false;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        if (_scores.selectedSport == TeamScheduleSport.boccia &&
-            score != null) ...[
-          Text(
-            l10n.bocciaScoreSummary(
-              redTeamName: _teamName(score.redTeamSlot),
-              redScore: score.totalRedScore,
-              blueTeamName: _teamName(score.blueTeamSlot),
-              blueScore: score.totalBlueScore,
-            ),
-            style: theme.textTheme.bodyMedium?.copyWith(
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          const SizedBox(height: 8),
-        ],
-        FilledButton.tonalIcon(
-          onPressed: _isSavingScores || _isRefreshingScores
-              ? null
-              : () {
-                  _openBocciaScoreDialog(match);
-                },
-          icon: const Icon(Icons.edit_note),
-          label: Text(
-            hasScore ? l10n.editBocciaScoreButton : l10n.inputBocciaScoreButton,
-          ),
+    return FilledButton.tonalIcon(
+      onPressed: _isSavingScores || _isRefreshingScores
+          ? null
+          : () {
+              _openBocciaScoreDialog(match);
+            },
+      icon: const Icon(Icons.edit_note),
+      label: Text(
+        hasScore ? l10n.editBocciaScoreButton : l10n.inputBocciaScoreButton,
+      ),
+    );
+  }
+
+  ({int firstTeamSlot, int secondTeamSlot, int? firstScore, int? secondScore})
+      _matchDisplayOrder(_TeamMatchViewData match) {
+    final score = _scores.boccia.matchScore(match.matchNo);
+
+    if (_scores.selectedSport == TeamScheduleSport.boccia &&
+        score != null &&
+        match.teamSlots.length == 2) {
+      return (
+        firstTeamSlot: score.redTeamSlot,
+        secondTeamSlot: score.blueTeamSlot,
+        firstScore: score.totalRedScore,
+        secondScore: score.totalBlueScore,
+      );
+    }
+
+    return (
+      firstTeamSlot: match.teamSlots[0],
+      secondTeamSlot:
+          match.teamSlots.length > 1 ? match.teamSlots[1] : match.teamSlots[0],
+      firstScore: null,
+      secondScore: null,
+    );
+  }
+
+  Widget _buildMatchTeamPill(
+    BuildContext context, {
+    required int teamSlot,
+  }) {
+    final theme = Theme.of(context);
+    final isSelected = teamSlot == _selectedTeamSlot;
+
+    return ActionChip(
+      label: Text(
+        _teamName(teamSlot),
+        overflow: TextOverflow.ellipsis,
+      ),
+      avatar: isSelected ? const Icon(Icons.check, size: 18) : null,
+      onPressed: () => _selectTeam(teamSlot),
+      backgroundColor: isSelected ? Colors.blue.shade50 : null,
+      side: BorderSide(
+        color: isSelected ? Colors.blue.shade300 : Colors.grey.shade300,
+      ),
+      labelStyle: theme.textTheme.bodyMedium?.copyWith(
+        fontWeight: isSelected ? FontWeight.w600 : null,
+      ),
+    );
+  }
+
+  Widget _buildMatchScorePill(
+    BuildContext context, {
+    required int? score,
+  }) {
+    final theme = Theme.of(context);
+
+    return Container(
+      constraints: const BoxConstraints(minWidth: 36),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey.shade300),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        score?.toString() ?? '-',
+        style: theme.textTheme.bodyMedium?.copyWith(
+          fontWeight: FontWeight.bold,
         ),
-      ],
+      ),
     );
   }
 
   Widget _buildMatchRow(BuildContext context, _TeamMatchViewData match) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
+    final display = _matchDisplayOrder(match);
+    final supportsInlineScore = match.teamSlots.length == 2;
+
+    if (!supportsInlineScore) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            l10n.teamCourtTitle(match.courtNo),
+            style: theme.textTheme.labelLarge,
+          ),
+          const SizedBox(height: 6),
+          Text(
+            _matchTitle(context, match),
+            style: theme.textTheme.bodyLarge?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (final teamSlot in match.teamSlots)
+                _buildMatchTeamPill(context, teamSlot: teamSlot),
+            ],
+          ),
+          const SizedBox(height: 12),
+          _buildMatchScoreAction(context, match),
+        ],
+      );
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -1510,26 +1583,34 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
           l10n.teamCourtTitle(match.courtNo),
           style: theme.textTheme.labelLarge,
         ),
-        const SizedBox(height: 6),
-        Text(
-          _matchTitle(context, match),
-          style: theme.textTheme.bodyLarge?.copyWith(
-            fontWeight: FontWeight.w600,
-          ),
-        ),
         const SizedBox(height: 8),
         Wrap(
           spacing: 8,
           runSpacing: 8,
+          crossAxisAlignment: WrapCrossAlignment.center,
           children: [
-            for (final teamSlot in match.teamSlots)
-              ActionChip(
-                label: Text(_teamName(teamSlot)),
-                avatar: teamSlot == _selectedTeamSlot
-                    ? const Icon(Icons.check, size: 18)
-                    : null,
-                onPressed: () => _selectTeam(teamSlot),
+            _buildMatchTeamPill(
+              context,
+              teamSlot: display.firstTeamSlot,
+            ),
+            _buildMatchScorePill(
+              context,
+              score: display.firstScore,
+            ),
+            Text(
+              'vs',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
               ),
+            ),
+            _buildMatchScorePill(
+              context,
+              score: display.secondScore,
+            ),
+            _buildMatchTeamPill(
+              context,
+              teamSlot: display.secondTeamSlot,
+            ),
           ],
         ),
         const SizedBox(height: 12),
@@ -1615,8 +1696,6 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         _buildHeaderCard(context),
         const SizedBox(height: 12),
         _buildShareCard(context),
-        const SizedBox(height: 12),
-        _buildNextRoundCard(context),
         const SizedBox(height: 12),
         _buildTeamListCard(context),
         const SizedBox(height: 12),

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -835,6 +835,8 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     return showDialog<_TeamScheduleBulkEditResult>(
       context: context,
       builder: (context) {
+        final theme = Theme.of(context);
+
         return AlertDialog(
           title: Text(l10n.teamScheduleBulkEditTitle),
           content: SizedBox(
@@ -862,12 +864,14 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
                     maxLines: 6,
                   ),
                   const SizedBox(height: 24),
-                  Text(
-                    l10n.teamScheduleBulkEditTeamsSection,
-                    style: Theme.of(context).textTheme.titleSmall,
-                  ),
-                  const SizedBox(height: 8),
                   for (final team in schedule.teams) ...[
+                    Text(
+                      _teamName(team.teamSlot),
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
                     TextField(
                       controller: teamControllers[team.teamSlot],
                       decoration: InputDecoration(
@@ -878,22 +882,21 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
                       textInputAction: TextInputAction.next,
                     ),
                     const SizedBox(height: 12),
-                  ],
-                  const SizedBox(height: 12),
-                  Text(
-                    l10n.teamScheduleBulkEditMembersSection,
-                    style: Theme.of(context).textTheme.titleSmall,
-                  ),
-                  const SizedBox(height: 8),
-                  for (final member in schedule.members) ...[
-                    TextField(
-                      controller: memberControllers[member.playerSlot],
-                      decoration: InputDecoration(
-                        labelText: member.displayName,
+                    for (final playerSlot in team.memberPlayerSlots) ...[
+                      TextField(
+                        controller: memberControllers[playerSlot],
+                        decoration: InputDecoration(
+                          labelText: _memberName(playerSlot),
+                        ),
+                        textInputAction: TextInputAction.next,
                       ),
-                      textInputAction: TextInputAction.next,
-                    ),
-                    const SizedBox(height: 12),
+                      const SizedBox(height: 12),
+                    ],
+                    if (team != schedule.teams.last) ...[
+                      const SizedBox(height: 4),
+                      const Divider(),
+                      const SizedBox(height: 16),
+                    ],
                   ],
                 ],
               ),
@@ -1417,9 +1420,6 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       color: Colors.white,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(12),
-        side: BorderSide(
-          color: Colors.transparent,
-        ),
       ),
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -1530,11 +1530,14 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         borderRadius: BorderRadius.circular(12),
         border: Border.all(color: Colors.grey.shade300),
       ),
-      alignment: Alignment.center,
-      child: Text(
-        score?.toString() ?? '-',
-        style: theme.textTheme.bodyMedium?.copyWith(
-          fontWeight: FontWeight.bold,
+      child: Center(
+        widthFactor: 1,
+        heightFactor: 1,
+        child: Text(
+          score?.toString() ?? '-',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
         ),
       ),
     );

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -1046,11 +1046,6 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
               ),
               style: theme.textTheme.bodyMedium,
             ),
-            const SizedBox(height: 8),
-            Text(
-              l10n.teamScheduleBackendDataNotice,
-              style: theme.textTheme.bodySmall,
-            ),
             const SizedBox(height: 16),
             _buildSportSelector(context),
             if (_isSavingDisplay || _displaySaveErrorMessage != null) ...[
@@ -1155,36 +1150,40 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          l10n.teamScheduleSportSectionTitle,
-          style: theme.textTheme.titleSmall?.copyWith(
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-        const SizedBox(height: 8),
-        DropdownButtonFormField<TeamScheduleSport>(
-          initialValue: _scores.selectedSport,
-          decoration: const InputDecoration(
-            border: OutlineInputBorder(),
-            contentPadding: EdgeInsets.symmetric(
-              horizontal: 12,
-              vertical: 10,
-            ),
-          ),
-          onChanged:
-              _isSavingScores || _isRefreshingScores ? null : _selectSport,
-          items: [
-            for (final sport in TeamScheduleSport.values)
-              DropdownMenuItem<TeamScheduleSport>(
-                value: sport,
-                child: Text(_sportLabel(sport)),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(
+              l10n.teamScheduleSportSectionTitle,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.bold,
               ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: DropdownButtonFormField<TeamScheduleSport>(
+                initialValue: _scores.selectedSport,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 10,
+                  ),
+                ),
+                onChanged: _isSavingScores || _isRefreshingScores
+                    ? null
+                    : _selectSport,
+                items: [
+                  for (final sport in TeamScheduleSport.values)
+                    DropdownMenuItem<TeamScheduleSport>(
+                      value: sport,
+                      child: Text(_sportLabel(sport)),
+                    ),
+                ],
+              ),
+            ),
           ],
-        ),
-        const SizedBox(height: 8),
-        Text(
-          l10n.teamScheduleSportHelp,
-          style: theme.textTheme.bodySmall,
         ),
         if (_isSavingScores ||
             _isRefreshingScores ||
@@ -1197,7 +1196,6 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
   }
 
   Widget _buildShareCard(BuildContext context) {
-    final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
     final shareId = _shareId;
     final shareUrl = _shareUrl;
@@ -1210,43 +1208,20 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       elevation: 0,
       color: Colors.white,
       child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+        padding: const EdgeInsets.all(12),
+        child: Wrap(
+          spacing: 8,
+          runSpacing: 8,
           children: [
-            Text(
-              l10n.teamScheduleShareTitle,
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
+            FilledButton.tonalIcon(
+              onPressed: _copyShareUrl,
+              icon: const Icon(Icons.copy),
+              label: Text(l10n.copyTeamScheduleShareUrlButton),
             ),
-            const SizedBox(height: 8),
-            Text(l10n.teamScheduleShareDescription),
-            const SizedBox(height: 12),
-            SelectableText(
-              l10n.teamScheduleShareIdLabel(shareId),
-              style: theme.textTheme.bodyMedium?.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(height: 8),
-            SelectableText(shareUrl),
-            const SizedBox(height: 12),
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                FilledButton.icon(
-                  onPressed: _copyShareUrl,
-                  icon: const Icon(Icons.copy),
-                  label: Text(l10n.copyTeamScheduleShareUrlButton),
-                ),
-                OutlinedButton.icon(
-                  onPressed: _isRefreshingScores ? null : _refreshScores,
-                  icon: const Icon(Icons.refresh),
-                  label: Text(l10n.refreshLatestTeamScheduleButton),
-                ),
-              ],
+            FilledButton.tonalIcon(
+              onPressed: _isRefreshingScores ? null : _refreshScores,
+              icon: const Icon(Icons.refresh),
+              label: Text(l10n.refreshLatestTeamScheduleButton),
             ),
           ],
         ),

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -1232,53 +1232,6 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     );
   }
 
-  Widget _buildNextRoundCard(BuildContext context) {
-    final schedule = _schedule!;
-    final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context);
-    final nextRound = schedule.rounds.firstWhere(
-      (round) => round.roundNo == schedule.nextRoundNo,
-      orElse: () => schedule.rounds.first,
-    );
-
-    return Card(
-      elevation: 0,
-      color: Colors.blue.shade100,
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              l10n.nextTeamMatchTitle,
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              l10n.teamRoundTitle(nextRound.roundNo),
-              style: theme.textTheme.bodyMedium,
-            ),
-            const SizedBox(height: 8),
-            for (final match in nextRound.matches) ...[
-              Text(
-                l10n.teamCourtMatchTitle(
-                  courtNo: match.courtNo,
-                  matchTitle: _matchTitle(context, match),
-                ),
-                style: theme.textTheme.bodyLarge?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              if (match != nextRound.matches.last) const SizedBox(height: 4),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-
   Widget _buildTeamListCard(BuildContext context) {
     final schedule = _schedule!;
     final theme = Theme.of(context);

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -301,16 +301,13 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
           crossAxisAlignment: WrapCrossAlignment.center,
           children: [
             Text(
-              l10n.teamSetupSummaryCompact(
-                teamCount: _derivedTeamCount,
-                distribution: _teamDistributionText,
-              ),
+              '${l10n.teamCountSummary(_derivedTeamCount)} / ${l10n.teamDistributionSummary(_teamDistributionText)}',
               style: theme.textTheme.titleMedium?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
             ),
             Text(
-              l10n.teamSetupSummaryHelpCompact,
+              l10n.teamCountSummaryHelp,
               style: theme.textTheme.bodySmall,
             ),
           ],

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -319,10 +319,9 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
       color: Colors.white,
       child: Padding(
         padding: const EdgeInsets.all(12),
-        child: Wrap(
-          spacing: 16,
-          runSpacing: 8,
-          crossAxisAlignment: WrapCrossAlignment.center,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
           children: [
             Text(
               '${l10n.teamCountSummary(_derivedTeamCount)} / ${l10n.teamDistributionSummary(_teamDistributionText)}',
@@ -330,6 +329,7 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
                 fontWeight: FontWeight.bold,
               ),
             ),
+            const SizedBox(height: 8),
             Text(
               l10n.teamCountSummaryHelp,
               style: theme.textTheme.bodySmall,

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -24,9 +24,9 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
   static const _minTeamsPerMatch = 2;
   static const _maxTeamsPerMatch = 25;
 
-  static const _leftColumnMinWidth = 220.0;
-  static const _rightColumnMinWidth = 220.0;
-  static const _columnGap = 16.0;
+  static const _numberFieldMinWidth = 220.0;
+  static const _numberFieldGap = 12.0;
+  static const _setupContentMaxWidth = 560.0;
 
   int _concurrentMatchCount = 1;
   int _participantCount = 8;
@@ -190,104 +190,121 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
     );
   }
 
-  Widget _buildNumberFields(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
+  String _participantInputButtonLabel(AppLocalizations l10n) {
+    if (l10n.localeName.startsWith('ja')) {
+      return '参加者入力';
+    }
 
-    return Column(
-      children: [
-        TeamSetupNumberField(
-          label: l10n.concurrentMatchCountLabel,
-          value: _concurrentMatchCount,
-          minValue: _minConcurrentMatchCount,
-          maxValue: _effectiveMaxConcurrentMatchCount,
-          onChanged: _setConcurrentMatchCount,
-          tooltipDecrement: l10n.decrementConcurrentMatchCountTooltip,
-          tooltipIncrement: l10n.incrementConcurrentMatchCountTooltip,
-          showRangeHelp: false,
-        ),
-        const SizedBox(height: 12),
-        TeamSetupNumberField(
-          label: l10n.participantCountLabel,
-          value: _participantCount,
-          minValue: _minParticipantCount,
-          maxValue: _maxParticipantCount,
-          onChanged: _setParticipantCount,
-          tooltipDecrement: l10n.decrementParticipantCountTooltip,
-          tooltipIncrement: l10n.incrementParticipantCountTooltip,
-          showRangeHelp: false,
-        ),
-        const SizedBox(height: 12),
-        TeamSetupNumberField(
-          label: l10n.preferredTeamSizeLabel,
-          value: _preferredTeamSize,
-          minValue: _minPreferredTeamSize,
-          maxValue: _effectiveMaxPreferredTeamSize,
-          onChanged: _setPreferredTeamSize,
-          tooltipDecrement: l10n.decrementPreferredTeamSizeTooltip,
-          tooltipIncrement: l10n.incrementPreferredTeamSizeTooltip,
-          showRangeHelp: false,
-        ),
-        const SizedBox(height: 12),
-        TeamSetupNumberField(
-          label: l10n.teamsPerMatchLabel,
-          value: _teamsPerMatch,
-          minValue: _minTeamsPerMatch,
-          maxValue: _effectiveMaxTeamsPerMatch,
-          onChanged: _setTeamsPerMatch,
-          tooltipDecrement: l10n.decrementTeamsPerMatchTooltip,
-          tooltipIncrement: l10n.incrementTeamsPerMatchTooltip,
-          showRangeHelp: false,
-        ),
-      ],
+    return l10n.teamParticipantInputTitle;
+  }
+
+  Future<void> _showParticipantNameInputDialog() async {
+    await showDialog<void>(
+      context: context,
+      builder: (context) {
+        final l10n = AppLocalizations.of(context);
+
+        return AlertDialog(
+          contentPadding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+          content: SizedBox(
+            width: 520,
+            child: TeamParticipantNameInputCard(
+              participantNames: _participantNames,
+              participantCount: _participantCount,
+              maxParticipantCount: _maxParticipantCount,
+              onApply: _applyParticipantNames,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: Text(l10n.cancel),
+            ),
+          ],
+        );
+      },
     );
   }
 
-  Widget _buildSetupInputs(BuildContext context) {
+  Widget _buildParticipantInputButton(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return TextButton(
+      onPressed: _showParticipantNameInputDialog,
+      style: TextButton.styleFrom(
+        minimumSize: Size.zero,
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        visualDensity: VisualDensity.compact,
+      ),
+      child: Text(_participantInputButtonLabel(l10n)),
+    );
+  }
+
+  Widget _buildNumberFields(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final fields = [
+      TeamSetupNumberField(
+        label: l10n.concurrentMatchCountLabel,
+        value: _concurrentMatchCount,
+        minValue: _minConcurrentMatchCount,
+        maxValue: _effectiveMaxConcurrentMatchCount,
+        onChanged: _setConcurrentMatchCount,
+        tooltipDecrement: l10n.decrementConcurrentMatchCountTooltip,
+        tooltipIncrement: l10n.incrementConcurrentMatchCountTooltip,
+        showRangeHelp: false,
+      ),
+      TeamSetupNumberField(
+        label: l10n.teamsPerMatchLabel,
+        value: _teamsPerMatch,
+        minValue: _minTeamsPerMatch,
+        maxValue: _effectiveMaxTeamsPerMatch,
+        onChanged: _setTeamsPerMatch,
+        tooltipDecrement: l10n.decrementTeamsPerMatchTooltip,
+        tooltipIncrement: l10n.incrementTeamsPerMatchTooltip,
+        showRangeHelp: false,
+      ),
+      TeamSetupNumberField(
+        label: l10n.participantCountLabel,
+        value: _participantCount,
+        minValue: _minParticipantCount,
+        maxValue: _maxParticipantCount,
+        onChanged: _setParticipantCount,
+        tooltipDecrement: l10n.decrementParticipantCountTooltip,
+        tooltipIncrement: l10n.incrementParticipantCountTooltip,
+        showRangeHelp: false,
+      ),
+      TeamSetupNumberField(
+        label: l10n.preferredTeamSizeLabel,
+        value: _preferredTeamSize,
+        minValue: _minPreferredTeamSize,
+        maxValue: _effectiveMaxPreferredTeamSize,
+        onChanged: _setPreferredTeamSize,
+        tooltipDecrement: l10n.decrementPreferredTeamSizeTooltip,
+        tooltipIncrement: l10n.incrementPreferredTeamSizeTooltip,
+        showRangeHelp: false,
+        titleTrailing: _buildParticipantInputButton(context),
+      ),
+    ];
+
     return LayoutBuilder(
       builder: (context, constraints) {
         final useTwoColumns = constraints.maxWidth >=
-            _leftColumnMinWidth + _rightColumnMinWidth + _columnGap;
+            (_numberFieldMinWidth * 2) + _numberFieldGap;
+        final itemWidth = useTwoColumns
+            ? (constraints.maxWidth - _numberFieldGap) / 2
+            : constraints.maxWidth;
 
-        if (!useTwoColumns) {
-          return Column(
-            children: [
-              _buildNumberFields(context),
-              const SizedBox(height: 16),
-              TeamParticipantNameInputCard(
-                participantNames: _participantNames,
-                participantCount: _participantCount,
-                maxParticipantCount: _maxParticipantCount,
-                onApply: _applyParticipantNames,
-              ),
-            ],
-          );
-        }
-
-        final leftColumnWidth = _leftColumnMinWidth;
-        final rightColumnWidth =
-            constraints.maxWidth - leftColumnWidth - _columnGap;
-
-        return IntrinsicHeight(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
+        return Wrap(
+          spacing: _numberFieldGap,
+          runSpacing: _numberFieldGap,
+          children: [
+            for (final field in fields)
               SizedBox(
-                width: _leftColumnMinWidth,
-                child: _buildNumberFields(context),
+                width: itemWidth,
+                child: field,
               ),
-              const SizedBox(width: _columnGap),
-              SizedBox(
-                width: rightColumnWidth,
-                child: TeamParticipantNameInputCard(
-                  participantNames: _participantNames,
-                  participantCount: _participantCount,
-                  maxParticipantCount: _maxParticipantCount,
-                  onApply: _applyParticipantNames,
-                  expandToFillHeight: true,
-                ),
-              ),
-            ],
-          ),
+          ],
         );
       },
     );
@@ -371,9 +388,20 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
                 style: Theme.of(context).textTheme.bodySmall,
               ),
               const SizedBox(height: 16),
-              _buildSetupInputs(context),
-              const SizedBox(height: 16),
-              _buildSummaryCard(context),
+              Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(
+                    maxWidth: _setupContentMaxWidth,
+                  ),
+                  child: Column(
+                    children: [
+                      _buildNumberFields(context),
+                      const SizedBox(height: 16),
+                      _buildSummaryCard(context),
+                    ],
+                  ),
+                ),
+              ),
               const SizedBox(height: 20),
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -273,6 +273,7 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
         tooltipDecrement: l10n.decrementParticipantCountTooltip,
         tooltipIncrement: l10n.incrementParticipantCountTooltip,
         showRangeHelp: false,
+        titleTrailing: _buildParticipantInputButton(context),
       ),
       TeamSetupNumberField(
         label: l10n.preferredTeamSizeLabel,
@@ -283,7 +284,6 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
         tooltipDecrement: l10n.decrementPreferredTeamSizeTooltip,
         tooltipIncrement: l10n.incrementPreferredTeamSizeTooltip,
         showRangeHelp: false,
-        titleTrailing: _buildParticipantInputButton(context),
       ),
     ];
 

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -189,120 +189,133 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
   Widget _buildNumberFields(BuildContext context) {
     final l10n = AppLocalizations.of(context);
 
+    return Column(
+      children: [
+        TeamSetupNumberField(
+          label: l10n.concurrentMatchCountLabel,
+          value: _concurrentMatchCount,
+          minValue: _minConcurrentMatchCount,
+          maxValue: _effectiveMaxConcurrentMatchCount,
+          onChanged: _setConcurrentMatchCount,
+          tooltipDecrement: l10n.decrementConcurrentMatchCountTooltip,
+          tooltipIncrement: l10n.incrementConcurrentMatchCountTooltip,
+          showRangeHelp: false,
+        ),
+        const SizedBox(height: 12),
+        TeamSetupNumberField(
+          label: l10n.participantCountLabel,
+          value: _participantCount,
+          minValue: _minParticipantCount,
+          maxValue: _maxParticipantCount,
+          onChanged: _setParticipantCount,
+          tooltipDecrement: l10n.decrementParticipantCountTooltip,
+          tooltipIncrement: l10n.incrementParticipantCountTooltip,
+          showRangeHelp: false,
+        ),
+        const SizedBox(height: 12),
+        TeamSetupNumberField(
+          label: l10n.preferredTeamSizeLabel,
+          value: _preferredTeamSize,
+          minValue: _minPreferredTeamSize,
+          maxValue: _effectiveMaxPreferredTeamSize,
+          onChanged: _setPreferredTeamSize,
+          tooltipDecrement: l10n.decrementPreferredTeamSizeTooltip,
+          tooltipIncrement: l10n.incrementPreferredTeamSizeTooltip,
+          showRangeHelp: false,
+        ),
+        const SizedBox(height: 12),
+        TeamSetupNumberField(
+          label: l10n.teamsPerMatchLabel,
+          value: _teamsPerMatch,
+          minValue: _minTeamsPerMatch,
+          maxValue: _effectiveMaxTeamsPerMatch,
+          onChanged: _setTeamsPerMatch,
+          tooltipDecrement: l10n.decrementTeamsPerMatchTooltip,
+          tooltipIncrement: l10n.incrementTeamsPerMatchTooltip,
+          showRangeHelp: false,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSetupInputs(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
         final useTwoColumns = constraints.maxWidth >= 760;
-        final itemWidth = useTwoColumns
-            ? (constraints.maxWidth - 12) / 2
-            : constraints.maxWidth;
 
-        return Wrap(
-          spacing: 12,
-          runSpacing: 12,
-          children: [
-            SizedBox(
-              width: itemWidth,
-              child: TeamSetupNumberField(
-                label: l10n.concurrentMatchCountLabel,
-                value: _concurrentMatchCount,
-                minValue: _minConcurrentMatchCount,
-                maxValue: _effectiveMaxConcurrentMatchCount,
-                onChanged: _setConcurrentMatchCount,
-                tooltipDecrement: l10n.decrementConcurrentMatchCountTooltip,
-                tooltipIncrement: l10n.incrementConcurrentMatchCountTooltip,
+        if (!useTwoColumns) {
+          return Column(
+            children: [
+              _buildNumberFields(context),
+              const SizedBox(height: 16),
+              TeamParticipantNameInputCard(
+                participantNames: _participantNames,
+                participantCount: _participantCount,
+                maxParticipantCount: _maxParticipantCount,
+                onApply: _applyParticipantNames,
               ),
-            ),
-            SizedBox(
-              width: itemWidth,
-              child: TeamSetupNumberField(
-                label: l10n.participantCountLabel,
-                value: _participantCount,
-                minValue: _minParticipantCount,
-                maxValue: _maxParticipantCount,
-                onChanged: _setParticipantCount,
-                tooltipDecrement: l10n.decrementParticipantCountTooltip,
-                tooltipIncrement: l10n.incrementParticipantCountTooltip,
+            ],
+          );
+        }
+
+        final columnWidth = (constraints.maxWidth - 16) / 2;
+
+        return IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              SizedBox(
+                width: columnWidth,
+                child: _buildNumberFields(context),
               ),
-            ),
-            SizedBox(
-              width: itemWidth,
-              child: TeamSetupNumberField(
-                label: l10n.preferredTeamSizeLabel,
-                value: _preferredTeamSize,
-                minValue: _minPreferredTeamSize,
-                maxValue: _effectiveMaxPreferredTeamSize,
-                onChanged: _setPreferredTeamSize,
-                tooltipDecrement: l10n.decrementPreferredTeamSizeTooltip,
-                tooltipIncrement: l10n.incrementPreferredTeamSizeTooltip,
+              const SizedBox(width: 16),
+              SizedBox(
+                width: columnWidth,
+                child: TeamParticipantNameInputCard(
+                  participantNames: _participantNames,
+                  participantCount: _participantCount,
+                  maxParticipantCount: _maxParticipantCount,
+                  onApply: _applyParticipantNames,
+                  expandToFillHeight: true,
+                ),
               ),
-            ),
-            SizedBox(
-              width: itemWidth,
-              child: TeamSetupNumberField(
-                label: l10n.teamsPerMatchLabel,
-                value: _teamsPerMatch,
-                minValue: _minTeamsPerMatch,
-                maxValue: _effectiveMaxTeamsPerMatch,
-                onChanged: _setTeamsPerMatch,
-                tooltipDecrement: l10n.decrementTeamsPerMatchTooltip,
-                tooltipIncrement: l10n.incrementTeamsPerMatchTooltip,
-              ),
-            ),
-          ],
+            ],
+          ),
         );
       },
     );
   }
 
-  Widget _buildSummaryCards(BuildContext context) {
+  Widget _buildSummaryCard(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
 
-    return Column(
-      children: [
-        Card(
-          elevation: 0,
-          color: Colors.white,
-          child: Padding(
-            padding: const EdgeInsets.all(12),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  l10n.teamCountSummary(_derivedTeamCount),
-                  style: const TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Text(l10n.teamCountSummaryHelp),
-              ],
+    return Card(
+      elevation: 0,
+      color: Colors.white,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Wrap(
+          spacing: 16,
+          runSpacing: 8,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            Text(
+              l10n.teamSetupSummaryCompact(
+                teamCount: _derivedTeamCount,
+                distribution: _teamDistributionText,
+              ),
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
             ),
-          ),
-        ),
-        const SizedBox(height: 12),
-        Card(
-          elevation: 0,
-          color: Colors.white,
-          child: Padding(
-            padding: const EdgeInsets.all(12),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  l10n.teamDistributionSummary(_teamDistributionText),
-                  style: const TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Text(l10n.teamDistributionSummaryHelp),
-              ],
+            Text(
+              l10n.teamSetupSummaryHelpCompact,
+              style: theme.textTheme.bodySmall,
             ),
-          ),
+          ],
         ),
-      ],
+      ),
     );
   }
 
@@ -354,38 +367,9 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
                 style: Theme.of(context).textTheme.bodySmall,
               ),
               const SizedBox(height: 16),
-              _buildNumberFields(context),
+              _buildSetupInputs(context),
               const SizedBox(height: 16),
-              TeamParticipantNameInputCard(
-                participantNames: _participantNames,
-                participantCount: _participantCount,
-                maxParticipantCount: _maxParticipantCount,
-                onApply: _applyParticipantNames,
-              ),
-              const SizedBox(height: 16),
-              _buildSummaryCards(context),
-              const SizedBox(height: 16),
-              Card(
-                elevation: 0,
-                color: Colors.white,
-                child: Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        l10n.teamSetupAlphaNoticeTitle,
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      Text(l10n.teamSetupAlphaNoticeBody),
-                    ],
-                  ),
-                ),
-              ),
+              _buildSummaryCard(context),
               const SizedBox(height: 20),
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/features/team_scheduler/presentation/team_setup_page.dart
+++ b/lib/features/team_scheduler/presentation/team_setup_page.dart
@@ -24,6 +24,10 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
   static const _minTeamsPerMatch = 2;
   static const _maxTeamsPerMatch = 25;
 
+  static const _leftColumnMinWidth = 220.0;
+  static const _rightColumnMinWidth = 220.0;
+  static const _columnGap = 16.0;
+
   int _concurrentMatchCount = 1;
   int _participantCount = 8;
   int _preferredTeamSize = 2;
@@ -241,7 +245,8 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
   Widget _buildSetupInputs(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final useTwoColumns = constraints.maxWidth >= 760;
+        final useTwoColumns = constraints.maxWidth >=
+            _leftColumnMinWidth + _rightColumnMinWidth + _columnGap;
 
         if (!useTwoColumns) {
           return Column(
@@ -258,19 +263,21 @@ class _TeamSetupPageState extends State<TeamSetupPage> {
           );
         }
 
-        final columnWidth = (constraints.maxWidth - 16) / 2;
+        final leftColumnWidth = _leftColumnMinWidth;
+        final rightColumnWidth =
+            constraints.maxWidth - leftColumnWidth - _columnGap;
 
         return IntrinsicHeight(
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               SizedBox(
-                width: columnWidth,
+                width: _leftColumnMinWidth,
                 child: _buildNumberFields(context),
               ),
-              const SizedBox(width: 16),
+              const SizedBox(width: _columnGap),
               SizedBox(
-                width: columnWidth,
+                width: rightColumnWidth,
                 child: TeamParticipantNameInputCard(
                   participantNames: _participantNames,
                   participantCount: _participantCount,

--- a/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
+++ b/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
@@ -497,20 +497,30 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
   }
 
   Widget _buildOrderHeader(BuildContext context) {
-    final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         FilledButton.tonalIcon(
+          style: FilledButton.styleFrom(
+            minimumSize: const Size(0, 32),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            backgroundColor: _bocciaButtonBackgroundColor,
+            foregroundColor: _bocciaButtonForegroundColor,
+            disabledBackgroundColor:
+                _bocciaButtonBackgroundColor.withValues(alpha: 0.45),
+            disabledForegroundColor:
+                _bocciaButtonForegroundColor.withValues(alpha: 0.5),
+          ),
           onPressed: _isBusy || !_draftScore.canEditThrowingBoxAssignments
               ? null
               : _swapOrder,
-          icon: const Icon(Icons.swap_horiz),
+          icon: const Icon(Icons.swap_horiz, size: 18),
           label: Text(l10n.swapBocciaOrderButton),
         ),
-        const SizedBox(height: 12),
+        const SizedBox(height: 8),
         Row(
           children: [
             Expanded(
@@ -534,17 +544,6 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             ),
           ],
         ),
-        const SizedBox(height: 8),
-        Text(
-          l10n.bocciaScoreDialogMatchTitle(
-            redTeamName: _redTeamName(_draftScore),
-            blueTeamName: _blueTeamName(_draftScore),
-          ),
-          textAlign: TextAlign.center,
-          style: theme.textTheme.titleMedium?.copyWith(
-            fontWeight: FontWeight.bold,
-          ),
-        ),
       ],
     );
   }
@@ -559,23 +558,24 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     final theme = Theme.of(context);
 
     return Container(
-      padding: const EdgeInsets.all(12),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
       decoration: BoxDecoration(
         color: backgroundColor,
         border: Border.all(color: borderColor),
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(10),
       ),
       child: Column(
         children: [
           Text(
             label,
-            style: theme.textTheme.labelLarge,
+            style: theme.textTheme.labelSmall,
           ),
-          const SizedBox(height: 4),
+          const SizedBox(height: 2),
           Text(
             teamName,
             textAlign: TextAlign.center,
-            style: theme.textTheme.titleSmall?.copyWith(
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.bodyMedium?.copyWith(
               fontWeight: FontWeight.bold,
             ),
           ),
@@ -603,15 +603,15 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
       onTap: () {
         _selectEnd(endNo);
       },
-      borderRadius: BorderRadius.circular(8),
+      borderRadius: BorderRadius.circular(7),
       child: Container(
         padding: const EdgeInsets.symmetric(
-          horizontal: 10,
-          vertical: 6,
+          horizontal: 8,
+          vertical: 4,
         ),
         decoration: BoxDecoration(
           color: backgroundColor,
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(7),
           border: Border.all(
             color: borderColor,
             width: isSelected ? 2 : 1,
@@ -619,7 +619,8 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
         ),
         child: Text(
           l10n.bocciaEndLabel(endNo),
-          style: theme.textTheme.bodyMedium?.copyWith(
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodySmall?.copyWith(
             color: textColor,
             fontWeight: isSelected ? FontWeight.bold : null,
           ),
@@ -630,28 +631,33 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
 
   Widget _buildScoreTable(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
 
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: DataTable(
-        headingRowHeight: 44,
-        dataRowMinHeight: 52,
-        dataRowMaxHeight: 56,
+        horizontalMargin: 4,
+        columnSpacing: 8,
+        headingRowHeight: 34,
+        dataRowMinHeight: 40,
+        dataRowMaxHeight: 42,
         columns: [
-          const DataColumn(label: SizedBox(width: 56)),
           for (final endScore in _draftScore.endScores)
             DataColumn(
               label: _buildEndHeader(context, endScore.endNo),
             ),
           DataColumn(
-            label: Text(l10n.bocciaTotalLabel),
+            label: Text(
+              l10n.bocciaTotalLabel,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall,
+            ),
           ),
         ],
         rows: [
           DataRow(
             color: WidgetStatePropertyAll(Colors.red.shade50),
             cells: [
-              const DataCell(SizedBox.shrink()),
               for (final endScore in _draftScore.endScores)
                 DataCell(
                   _buildScoreDropdown(
@@ -669,9 +675,13 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
                   ),
                 ),
               DataCell(
-                Text(
-                  _draftScore.totalRedScore.toString(),
-                  style: const TextStyle(fontWeight: FontWeight.bold),
+                SizedBox(
+                  width: 32,
+                  child: Text(
+                    _draftScore.totalRedScore.toString(),
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
                 ),
               ),
             ],
@@ -679,7 +689,6 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           DataRow(
             color: WidgetStatePropertyAll(Colors.blue.shade50),
             cells: [
-              const DataCell(SizedBox.shrink()),
               for (final endScore in _draftScore.endScores)
                 DataCell(
                   _buildScoreDropdown(
@@ -697,9 +706,13 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
                   ),
                 ),
               DataCell(
-                Text(
-                  _draftScore.totalBlueScore.toString(),
-                  style: const TextStyle(fontWeight: FontWeight.bold),
+                SizedBox(
+                  width: 32,
+                  child: Text(
+                    _draftScore.totalBlueScore.toString(),
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
                 ),
               ),
             ],
@@ -713,17 +726,36 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
     required int value,
     required ValueChanged<int?> onChanged,
   }) {
-    return DropdownButton<int>(
-      value: value,
-      dropdownColor: _bocciaSectionBackgroundColor,
-      onChanged: _isBusy ? null : onChanged,
-      items: [
-        for (var score = 0; score <= 6; score += 1)
-          DropdownMenuItem<int>(
-            value: score,
-            child: Text(score.toString()),
-          ),
-      ],
+    return SizedBox(
+      width: 36,
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<int>(
+          value: value,
+          isDense: true,
+          isExpanded: true,
+          alignment: Alignment.center,
+          iconSize: 14,
+          dropdownColor: _bocciaSectionBackgroundColor,
+          onChanged: _isBusy ? null : onChanged,
+          selectedItemBuilder: (context) {
+            return [
+              for (var score = 0; score <= 6; score += 1)
+                Center(
+                  child: Text(score.toString()),
+                ),
+            ];
+          },
+          items: [
+            for (var score = 0; score <= 6; score += 1)
+              DropdownMenuItem<int>(
+                value: score,
+                child: Center(
+                  child: Text(score.toString()),
+                ),
+              ),
+          ],
+        ),
+      ),
     );
   }
 
@@ -1181,23 +1213,32 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
     final dialogWidth = MediaQuery.sizeOf(context).width * 0.95;
 
     return AlertDialog(
       insetPadding: const EdgeInsets.symmetric(
-        horizontal: 12,
-        vertical: 24,
+        horizontal: 8,
+        vertical: 12,
       ),
-      title: Text(l10n.bocciaScoreDialogTitle),
+      titlePadding: const EdgeInsets.fromLTRB(20, 14, 20, 6),
+      contentPadding: const EdgeInsets.fromLTRB(12, 0, 12, 0),
+      actionsPadding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
+      title: Text(
+        l10n.bocciaScoreDialogTitle,
+        style: theme.textTheme.titleLarge?.copyWith(
+          fontWeight: FontWeight.w700,
+        ),
+      ),
       backgroundColor: _bocciaDialogBackgroundColor,
       content: SizedBox(
         width: dialogWidth,
         child: SingleChildScrollView(
           child: Container(
-            padding: const EdgeInsets.all(12),
+            padding: const EdgeInsets.all(8),
             decoration: BoxDecoration(
               color: _bocciaSectionBackgroundColor,
-              borderRadius: BorderRadius.circular(16),
+              borderRadius: BorderRadius.circular(14),
               border: Border.all(color: _bocciaAccentBorderColor),
             ),
             child: Column(
@@ -1205,11 +1246,11 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 _buildConcurrentEditNotice(context),
-                const SizedBox(height: 12),
+                const SizedBox(height: 8),
                 _buildOrderHeader(context),
-                const SizedBox(height: 16),
+                const SizedBox(height: 10),
                 _buildScoreTable(context),
-                const SizedBox(height: 16),
+                const SizedBox(height: 12),
                 _buildThrowingBoxSection(context),
               ],
             ),
@@ -1229,21 +1270,43 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
               ),
               TextButton.icon(
                 style: TextButton.styleFrom(
+                  minimumSize: const Size(0, 32),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 6,
+                  ),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                   foregroundColor: _bocciaButtonForegroundColor,
                 ),
                 onPressed: _isBusy || widget.onRefresh == null
                     ? null
                     : _refreshLatestScore,
-                icon: const Icon(Icons.refresh),
+                icon: const Icon(Icons.refresh, size: 18),
                 label: Text(l10n.refreshLatestTeamScheduleButton),
               ),
-              const SizedBox(width: 8),
+              const SizedBox(width: 4),
               TextButton(
+                style: TextButton.styleFrom(
+                  minimumSize: const Size(0, 32),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 6,
+                  ),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
                 onPressed: _isBusy ? null : _close,
                 child: Text(l10n.closeBocciaScoreDialogButton),
               ),
-              const SizedBox(width: 8),
+              const SizedBox(width: 4),
               FilledButton(
+                style: FilledButton.styleFrom(
+                  minimumSize: const Size(0, 32),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 6,
+                  ),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
                 onPressed: _isBusy ? null : _save,
                 child: Text(l10n.saveBocciaScoreButton),
               ),

--- a/lib/features/team_scheduler/presentation/widgets/team_participant_name_input_card.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_participant_name_input_card.dart
@@ -147,9 +147,9 @@ class _TeamParticipantNameInputCardState
     return TextField(
       controller: _controller,
       keyboardType: TextInputType.multiline,
-      minLines: widget.expandToFillHeight ? null : 4,
-      maxLines: widget.expandToFillHeight ? null : 8,
-      expands: widget.expandToFillHeight,
+      minLines: 10,
+      maxLines: 10,
+      expands: false,
       textAlignVertical: TextAlignVertical.top,
       decoration: InputDecoration(
         border: const OutlineInputBorder(),

--- a/lib/features/team_scheduler/presentation/widgets/team_participant_name_input_card.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_participant_name_input_card.dart
@@ -133,6 +133,14 @@ class _TeamParticipantNameInputCardState
     );
   }
 
+  String _participantInputTitle(AppLocalizations l10n) {
+    if (l10n.localeName.startsWith('ja')) {
+      return '参加者入力';
+    }
+
+    return l10n.teamParticipantInputTitle;
+  }
+
   Widget _buildTextField(BuildContext context) {
     final l10n = AppLocalizations.of(context);
 
@@ -166,7 +174,7 @@ class _TeamParticipantNameInputCardState
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l10n.teamParticipantInputTitle,
+              _participantInputTitle(l10n),
               style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 8),

--- a/lib/features/team_scheduler/presentation/widgets/team_participant_name_input_card.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_participant_name_input_card.dart
@@ -8,12 +8,14 @@ class TeamParticipantNameInputCard extends StatefulWidget {
     required this.participantCount,
     required this.maxParticipantCount,
     required this.onApply,
+    this.expandToFillHeight = false,
   });
 
   final List<String> participantNames;
   final int participantCount;
   final int maxParticipantCount;
   final ValueChanged<List<String>> onApply;
+  final bool expandToFillHeight;
 
   @override
   State<TeamParticipantNameInputCard> createState() =>
@@ -131,9 +133,29 @@ class _TeamParticipantNameInputCardState
     );
   }
 
+  Widget _buildTextField(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return TextField(
+      controller: _controller,
+      keyboardType: TextInputType.multiline,
+      minLines: widget.expandToFillHeight ? null : 4,
+      maxLines: widget.expandToFillHeight ? null : 8,
+      expands: widget.expandToFillHeight,
+      textAlignVertical: TextAlignVertical.top,
+      decoration: InputDecoration(
+        border: const OutlineInputBorder(),
+        labelText: l10n.teamParticipantInputLabel,
+        hintText: l10n.teamParticipantInputHint,
+        alignLabelWithHint: true,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final textField = _buildTextField(context);
 
     return Card(
       elevation: 0,
@@ -150,18 +172,10 @@ class _TeamParticipantNameInputCardState
             const SizedBox(height: 8),
             Text(l10n.teamParticipantInputDescription),
             const SizedBox(height: 12),
-            TextField(
-              controller: _controller,
-              keyboardType: TextInputType.multiline,
-              minLines: 4,
-              maxLines: 8,
-              decoration: InputDecoration(
-                border: const OutlineInputBorder(),
-                labelText: l10n.teamParticipantInputLabel,
-                hintText: l10n.teamParticipantInputHint,
-                alignLabelWithHint: true,
-              ),
-            ),
+            if (widget.expandToFillHeight)
+              Expanded(child: textField)
+            else
+              textField,
             const SizedBox(height: 8),
             Text(
               l10n.participantNameCountStatus(

--- a/lib/features/team_scheduler/presentation/widgets/team_participant_name_input_card.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_participant_name_input_card.dart
@@ -184,7 +184,9 @@ class _TeamParticipantNameInputCardState
     return Text(
       message,
       style: theme.textTheme.bodySmall?.copyWith(
-        color: _isStatusError ? theme.colorScheme.error : theme.colorScheme.primary,
+        color: _isStatusError
+            ? theme.colorScheme.error
+            : theme.colorScheme.primary,
         fontWeight: FontWeight.w600,
       ),
     );

--- a/lib/features/team_scheduler/presentation/widgets/team_participant_name_input_card.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_participant_name_input_card.dart
@@ -25,10 +25,16 @@ class TeamParticipantNameInputCard extends StatefulWidget {
 class _TeamParticipantNameInputCardState
     extends State<TeamParticipantNameInputCard> {
   late final TextEditingController _controller;
+  late List<String> _appliedParticipantNames;
+  late int _appliedParticipantCount;
+  String? _statusMessage;
+  bool _isStatusError = false;
 
   @override
   void initState() {
     super.initState();
+    _appliedParticipantNames = widget.participantNames;
+    _appliedParticipantCount = widget.participantCount;
     _controller = TextEditingController(
       text: widget.participantNames.join('\n'),
     );
@@ -39,10 +45,15 @@ class _TeamParticipantNameInputCardState
     super.didUpdateWidget(oldWidget);
 
     if (oldWidget.participantNames != widget.participantNames) {
+      _appliedParticipantNames = widget.participantNames;
       final nextText = widget.participantNames.join('\n');
       if (_controller.text != nextText) {
         _controller.text = nextText;
       }
+    }
+
+    if (oldWidget.participantCount != widget.participantCount) {
+      _appliedParticipantCount = widget.participantCount;
     }
   }
 
@@ -101,24 +112,23 @@ class _TeamParticipantNameInputCardState
 
   void _applyParticipantNames() {
     final l10n = AppLocalizations.of(context);
-    final messenger = ScaffoldMessenger.of(context);
     final rawText = _controller.text;
     final parsedCountBeforeLimit = _parsedCountBeforeLimit(rawText);
     final names = _parseParticipantNames(rawText);
 
-    messenger.hideCurrentSnackBar();
-
     if (rawText.trim().isEmpty) {
-      messenger.showSnackBar(
-        SnackBar(content: Text(l10n.participantNamesEmptyMessage)),
-      );
+      setState(() {
+        _statusMessage = l10n.participantNamesEmptyMessage;
+        _isStatusError = true;
+      });
       return;
     }
 
     if (names.length < 2) {
-      messenger.showSnackBar(
-        SnackBar(content: Text(l10n.participantNamesTooFewMessage)),
-      );
+      setState(() {
+        _statusMessage = l10n.participantNamesTooFewMessage;
+        _isStatusError = true;
+      });
       return;
     }
 
@@ -128,9 +138,12 @@ class _TeamParticipantNameInputCardState
         ? l10n.participantNamesTrimmedMessage(widget.maxParticipantCount)
         : l10n.participantNamesAppliedMessage(names.length);
 
-    messenger.showSnackBar(
-      SnackBar(content: Text(message), duration: const Duration(seconds: 2)),
-    );
+    setState(() {
+      _appliedParticipantNames = names;
+      _appliedParticipantCount = names.length;
+      _statusMessage = message;
+      _isStatusError = false;
+    });
   }
 
   String _participantInputTitle(AppLocalizations l10n) {
@@ -156,6 +169,23 @@ class _TeamParticipantNameInputCardState
         labelText: l10n.teamParticipantInputLabel,
         hintText: l10n.teamParticipantInputHint,
         alignLabelWithHint: true,
+      ),
+    );
+  }
+
+  Widget _buildStatusMessage(BuildContext context) {
+    final message = _statusMessage;
+    if (message == null || message.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final theme = Theme.of(context);
+
+    return Text(
+      message,
+      style: theme.textTheme.bodySmall?.copyWith(
+        color: _isStatusError ? theme.colorScheme.error : theme.colorScheme.primary,
+        fontWeight: FontWeight.w600,
       ),
     );
   }
@@ -187,11 +217,15 @@ class _TeamParticipantNameInputCardState
             const SizedBox(height: 8),
             Text(
               l10n.participantNameCountStatus(
-                widget.participantNames.length,
-                widget.participantCount,
+                _appliedParticipantNames.length,
+                _appliedParticipantCount,
               ),
               style: Theme.of(context).textTheme.bodySmall,
             ),
+            if (_statusMessage != null) ...[
+              const SizedBox(height: 4),
+              _buildStatusMessage(context),
+            ],
             const SizedBox(height: 12),
             Align(
               alignment: Alignment.centerRight,

--- a/lib/features/team_scheduler/presentation/widgets/team_schedule_history_list_view.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_schedule_history_list_view.dart
@@ -20,7 +20,8 @@ class TeamScheduleHistoryListView extends StatefulWidget {
       _TeamScheduleHistoryListViewState();
 }
 
-class _TeamScheduleHistoryListViewState extends State<TeamScheduleHistoryListView> {
+class _TeamScheduleHistoryListViewState
+    extends State<TeamScheduleHistoryListView> {
   final LocalTeamScheduleHistoryStore _historyStore =
       LocalTeamScheduleHistoryStore();
 

--- a/lib/features/team_scheduler/presentation/widgets/team_schedule_history_list_view.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_schedule_history_list_view.dart
@@ -20,4 +20,286 @@ class TeamScheduleHistoryListView extends StatefulWidget {
       _TeamScheduleHistoryListViewState();
 }
 
-class _TeamScheduleHistoryListViewState
+class _TeamScheduleHistoryListViewState extends State<TeamScheduleHistoryListView> {
+  final LocalTeamScheduleHistoryStore _historyStore =
+      LocalTeamScheduleHistoryStore();
+
+  late Future<List<LocalTeamScheduleHistoryItem>> _itemsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _itemsFuture = _historyStore.loadItems();
+  }
+
+  Future<void> _reload() async {
+    setState(() {
+      _itemsFuture = _historyStore.loadItems();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return FutureBuilder<List<LocalTeamScheduleHistoryItem>>(
+      future: _itemsFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (snapshot.hasError) {
+          return _TeamScheduleListMessage(
+            icon: Icons.error_outline,
+            title: l10n.teamScheduleListLoadErrorTitle,
+            message: l10n.teamScheduleListLoadErrorMessage,
+            actionLabel: l10n.refreshLatestInfo,
+            onActionPressed: _reload,
+          );
+        }
+
+        final items = snapshot.data ?? const [];
+
+        if (items.isEmpty) {
+          return _TeamScheduleListMessage(
+            icon: Icons.list_alt_outlined,
+            title: l10n.teamScheduleListEmptyTitle,
+            message: l10n.teamScheduleListEmptyMessage,
+          );
+        }
+
+        return RefreshIndicator(
+          onRefresh: _reload,
+          child: ListView.separated(
+            padding: widget.padding,
+            itemCount: items.length,
+            separatorBuilder: (context, index) => const SizedBox(height: 12),
+            itemBuilder: (context, index) {
+              final item = items[index];
+
+              return _TeamScheduleListItem(
+                item: item,
+                onTap: () => widget.onOpenSchedule(item),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _TeamScheduleListItem extends StatelessWidget {
+  const _TeamScheduleListItem({
+    required this.item,
+    required this.onTap,
+  });
+
+  final LocalTeamScheduleHistoryItem item;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              CircleAvatar(
+                backgroundColor: colorScheme.primary.withValues(alpha: 0.12),
+                foregroundColor: colorScheme.primary,
+                child: const Icon(Icons.groups_outlined),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _TeamScheduleListItemBody(item: item),
+              ),
+              const SizedBox(width: 8),
+              Icon(
+                Icons.chevron_right,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TeamScheduleListItemBody extends StatelessWidget {
+  const _TeamScheduleListItemBody({required this.item});
+
+  final LocalTeamScheduleHistoryItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final title = item.eventTitle.trim().isEmpty
+        ? l10n.teamScheduleUntitledEvent
+        : item.eventTitle.trim();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(
+              child: Text(
+                title,
+                style: textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            if (item.hasMemo) ...[
+              const SizedBox(width: 8),
+              Tooltip(
+                message: l10n.teamScheduleHasMemoTooltip,
+                child: Icon(
+                  Icons.edit_note_outlined,
+                  size: 20,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ],
+        ),
+        const SizedBox(height: 4),
+        Text(
+          l10n.teamScheduleListShareId(item.shareId),
+          style: textTheme.bodySmall?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 4,
+          children: [
+            _TeamScheduleListChip(
+              icon: Icons.groups_2_outlined,
+              label: l10n.teamScheduleListTeamCount(item.teamCount),
+            ),
+            _TeamScheduleListChip(
+              icon: Icons.person_outline,
+              label: l10n.teamScheduleListMemberCount(item.memberCount),
+            ),
+            _TeamScheduleListChip(
+              icon: Icons.schedule_outlined,
+              label: l10n.teamScheduleListUpdatedAt(
+                _formatUpdatedAt(item.updatedAt),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  String _formatUpdatedAt(DateTime updatedAt) {
+    final local = updatedAt.toLocal();
+    final year = local.year.toString().padLeft(4, '0');
+    final month = local.month.toString().padLeft(2, '0');
+    final day = local.day.toString().padLeft(2, '0');
+    final hour = local.hour.toString().padLeft(2, '0');
+    final minute = local.minute.toString().padLeft(2, '0');
+
+    return '$year/$month/$day $hour:$minute';
+  }
+}
+
+class _TeamScheduleListChip extends StatelessWidget {
+  const _TeamScheduleListChip({
+    required this.icon,
+    required this.label,
+  });
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Chip(
+      avatar: Icon(icon, size: 16),
+      label: Text(label),
+      visualDensity: VisualDensity.compact,
+      backgroundColor: colorScheme.surfaceContainerHighest,
+      side: BorderSide.none,
+    );
+  }
+}
+
+class _TeamScheduleListMessage extends StatelessWidget {
+  const _TeamScheduleListMessage({
+    required this.icon,
+    required this.title,
+    required this.message,
+    this.actionLabel,
+    this.onActionPressed,
+  });
+
+  final IconData icon;
+  final String title;
+  final String message;
+  final String? actionLabel;
+  final VoidCallback? onActionPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 48, color: colorScheme.primary),
+              const SizedBox(height: 16),
+              Text(
+                title,
+                style: textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                message,
+                style: textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              if (actionLabel != null && onActionPressed != null) ...[
+                const SizedBox(height: 16),
+                FilledButton.icon(
+                  onPressed: onActionPressed,
+                  icon: const Icon(Icons.refresh),
+                  label: Text(actionLabel!),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/team_scheduler/presentation/widgets/team_schedule_history_list_view.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_schedule_history_list_view.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../../l10n/team_l10n.dart';
+import '../../data/local_team_schedule_history_item.dart';
+import '../../data/local_team_schedule_history_store.dart';
+
+class TeamScheduleHistoryListView extends StatefulWidget {
+  const TeamScheduleHistoryListView({
+    super.key,
+    required this.onOpenSchedule,
+    this.padding = const EdgeInsets.all(16),
+  });
+
+  final ValueChanged<LocalTeamScheduleHistoryItem> onOpenSchedule;
+  final EdgeInsetsGeometry padding;
+
+  @override
+  State<TeamScheduleHistoryListView> createState() =>
+      _TeamScheduleHistoryListViewState();
+}
+
+class _TeamScheduleHistoryListViewState

--- a/lib/features/team_scheduler/presentation/widgets/team_setup_number_field.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_setup_number_field.dart
@@ -87,16 +87,20 @@ class TeamSetupNumberField extends StatelessWidget {
                   ),
                   icon: const Icon(Icons.remove_circle_outline),
                 ),
-                const SizedBox(width: 6),
+                const SizedBox(width: 4),
                 Expanded(
                   child: DropdownButtonFormField<int>(
                     initialValue: value,
+                    isExpanded: true,
+                    alignment: Alignment.center,
                     icon: const SizedBox.shrink(),
+                    iconSize: 0,
                     items: values
                         .map(
                           (item) => DropdownMenuItem<int>(
                             value: item,
-                            child: Center(child: Text(item.toString())),
+                            alignment: Alignment.center,
+                            child: Text(item.toString()),
                           ),
                         )
                         .toList(growable: false),
@@ -109,13 +113,13 @@ class TeamSetupNumberField extends StatelessWidget {
                       isDense: true,
                       helperText: helperText,
                       contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 10,
+                        horizontal: 0,
                         vertical: 12,
                       ),
                     ),
                   ),
                 ),
-                const SizedBox(width: 6),
+                const SizedBox(width: 4),
                 IconButton(
                   onPressed: _canIncrement ? () => _setValue(value + 1) : null,
                   tooltip: tooltipIncrement,

--- a/lib/features/team_scheduler/presentation/widgets/team_setup_number_field.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_setup_number_field.dart
@@ -12,6 +12,7 @@ class TeamSetupNumberField extends StatelessWidget {
     required this.tooltipDecrement,
     required this.tooltipIncrement,
     this.helpText,
+    this.showRangeHelp = true,
   });
 
   final String label;
@@ -22,6 +23,7 @@ class TeamSetupNumberField extends StatelessWidget {
   final String tooltipDecrement;
   final String tooltipIncrement;
   final String? helpText;
+  final bool showRangeHelp;
 
   bool get _canDecrement => value > minValue;
   bool get _canIncrement => value < maxValue;
@@ -41,6 +43,8 @@ class TeamSetupNumberField extends StatelessWidget {
       maxValue - minValue + 1,
       (index) => minValue + index,
     );
+    final helperText = helpText ??
+        (showRangeHelp ? l10n.teamSetupRangeHelp(minValue, maxValue) : null);
 
     return Card(
       elevation: 0,
@@ -79,8 +83,7 @@ class TeamSetupNumberField extends StatelessWidget {
                     decoration: InputDecoration(
                       border: const OutlineInputBorder(),
                       isDense: true,
-                      helperText: helpText ??
-                          l10n.teamSetupRangeHelp(minValue, maxValue),
+                      helperText: helperText,
                     ),
                   ),
                 ),

--- a/lib/features/team_scheduler/presentation/widgets/team_setup_number_field.dart
+++ b/lib/features/team_scheduler/presentation/widgets/team_setup_number_field.dart
@@ -13,6 +13,7 @@ class TeamSetupNumberField extends StatelessWidget {
     required this.tooltipIncrement,
     this.helpText,
     this.showRangeHelp = true,
+    this.titleTrailing,
   });
 
   final String label;
@@ -24,6 +25,7 @@ class TeamSetupNumberField extends StatelessWidget {
   final String tooltipIncrement;
   final String? helpText;
   final bool showRangeHelp;
+  final Widget? titleTrailing;
 
   bool get _canDecrement => value > minValue;
   bool get _canIncrement => value < maxValue;
@@ -49,13 +51,27 @@ class TeamSetupNumberField extends StatelessWidget {
     return Card(
       elevation: 0,
       child: Padding(
-        padding: const EdgeInsets.all(12),
+        padding: const EdgeInsets.all(10),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              label,
-              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Expanded(
+                  child: Text(
+                    label,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                if (titleTrailing != null) ...[
+                  const SizedBox(width: 8),
+                  titleTrailing!,
+                ],
+              ],
             ),
             const SizedBox(height: 8),
             Row(
@@ -63,16 +79,24 @@ class TeamSetupNumberField extends StatelessWidget {
                 IconButton(
                   onPressed: _canDecrement ? () => _setValue(value - 1) : null,
                   tooltip: tooltipDecrement,
+                  visualDensity: VisualDensity.compact,
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(
+                    minWidth: 32,
+                    minHeight: 32,
+                  ),
                   icon: const Icon(Icons.remove_circle_outline),
                 ),
+                const SizedBox(width: 6),
                 Expanded(
                   child: DropdownButtonFormField<int>(
                     initialValue: value,
+                    icon: const SizedBox.shrink(),
                     items: values
                         .map(
                           (item) => DropdownMenuItem<int>(
                             value: item,
-                            child: Text(item.toString()),
+                            child: Center(child: Text(item.toString())),
                           ),
                         )
                         .toList(growable: false),
@@ -84,12 +108,23 @@ class TeamSetupNumberField extends StatelessWidget {
                       border: const OutlineInputBorder(),
                       isDense: true,
                       helperText: helperText,
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 12,
+                      ),
                     ),
                   ),
                 ),
+                const SizedBox(width: 6),
                 IconButton(
                   onPressed: _canIncrement ? () => _setValue(value + 1) : null,
                   tooltip: tooltipIncrement,
+                  visualDensity: VisualDensity.compact,
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(
+                    minWidth: 32,
+                    minHeight: 32,
+                  ),
                   icon: const Icon(Icons.add_circle_outline),
                 ),
               ],

--- a/lib/l10n/team_l10n.dart
+++ b/lib/l10n/team_l10n.dart
@@ -28,10 +28,10 @@ extension TeamL10n on AppLocalizations {
   String get participantCountLabel => _isJapanese ? '参加人数' : 'Participants';
 
   String get preferredTeamSizeLabel =>
-      _isJapanese ? '1チームの目安人数' : 'Preferred team size';
+      _isJapanese ? 'チームの人数' : 'Preferred team size';
 
   String get teamsPerMatchLabel =>
-      _isJapanese ? '1試合で対戦するチーム数' : 'Teams per match';
+      _isJapanese ? '1試合の対戦チーム数' : 'Teams per match';
 
   String get decrementConcurrentMatchCountTooltip =>
       _isJapanese ? '同時進行試合数を減らす' : 'Decrease simultaneous match count';


### PR DESCRIPTION
## Summary

Closes #103

らんすけ：チーム MVP の UI 微調整を行いました。

主な対応内容:

- チーム setup 画面の入力 UI を整理
  - 入力項目の表示順を調整
  - 参加者入力をダイアログ化
  - チーム数 / 内訳サマリー表示を安定化
- チーム対戦表画面の表示を調整
  - 上部カード、共有カード、ラウンドカードの表示を整理
  - 「次の対戦」カードを一旦非表示化
  - 対戦行をチーム名 / スコア / vs 表示に寄せて調整
- まとめて編集ダイアログをチーム単位表示に変更
- 対戦表一覧を共通 widget 化
  - `/team/schedules` 画面と Drawer 内一覧で同じ一覧表示を利用
  - Drawer 内で対戦表一覧へ切り替え表示できるように変更
- ボッチャスコア入力ダイアログの表示を調整
  - タイトル、スコア表、ボタン行の余白を圧縮
  - 不要な対戦名表示を削除
  - スマホ表示時の主要入力欄を見やすく調整

## Deferred

以下は MVP UI 微調整の範囲外として、後続 Issue に切り出しました。

- チーム画面の AppBar / ナビゲーション導線整理
- チーム対戦表生成後の URL を `/team/schedules/{shareId}` へ差し替える対応

## Checks

- [x] `dart format lib/`
- [x] `flutter analyze`
- [x] `flutter test`
- [x] ローカル起動で主要導線を確認