### PR TITLE
📚 Update web architecture docs for doubles, team, and shared infrastructure refs #134

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,16 @@ ver0.1 には、以下の制限があります。
 
 ```text
 lib/
-├─ app/                # アプリ全体設定
+├─ app/                                # アプリ全体設定
 ├─ features/
-│  └─ doubles_scheduler/
-└─ shared/             # 共通部品
+│  ├─ doubles_scheduler/               # ダブルス対戦表の作成・表示・保存
+│  └─ team_scheduler/                  # チーム分け・チーム対戦表の作成・表示・保存
+└─ shared/
+   ├─ infrastructure/                  # 複数featureから使う外部API client
+   └─ repositories/                    # repository実装のアプリ全体での選択・公開
 ```
+
+詳細な責務と依存方針は [Architecture](docs/architecture.md) を参照してください。
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,257 +2,362 @@
 
 ## 1. 概要
 
-本システムは、ダブルス組み合わせ生成アプリケーションである。
+本システムは、ダブルス対戦表とチーム対戦表の作成・表示・保存・共有を行う Flutter Web アプリケーションである。
 
-構成は以下の2層に分離する：
+責務は、大きく以下へ分離する。
 
-- アプリケーション層（公開）
-- スケジューリングアルゴリズム層（非公開）
+- `srp-lanske-web`
+  - UI、入力、表示、共有URL、保存状態などを扱う公開アプリケーション
+- `srp-lanske-core`
+  - 対戦表生成と評価を扱う別リポジトリの core API
+
+web 側には生成アルゴリズム本体を置かず、core API が返した生成結果を feature ごとに表示・保存できる形へ変換する。
 
 ---
 
 ## 2. 全体構成
 
+```text
+[ UI / Flutter Web ]
+          ↓
+[ feature application service ]
+      ├──→ [ shared infrastructure ] ──→ [ srp-lanske-core API ]
+      └──→ [ feature repository ] ─────→ [ Firestore / in-memory ]
 ```
-[ UI / Flutter App ]
-        ↓
-[ Application Layer ]
-        ↓
-[ Repository Interface ]
-        ↓
-[ Algorithm Core（別リポジトリ） ]
-```
+
+生成処理と、web 側の保存・共有状態は別の責務として扱う。
+
+- core API
+  - 生成条件を受け取る
+  - 対戦表を生成する
+  - generated schedule snapshot を返す
+- web
+  - 入力情報を管理する
+  - core API request を組み立てる
+  - response を feature 固有の表示モデルへ変換する
+  - event / view state、表示名、共有URLなどを保存する
 
 ---
 
-## 3. レイヤー構成（アプリ側）
+## 3. ディレクトリ構成
 
-```
+```text
 lib/
 ├─ app/
+│  └─ config/                         # アプリ全体の環境設定
 ├─ features/
-│  └─ doubles_scheduler/
-│     ├─ presentation/
-│     ├─ application/
-│     ├─ domain/
-│     └─ infrastructure/
-└─ shared/
+│  ├─ doubles_scheduler/
+│  │  ├─ presentation/                # ダブルス用画面・widget・画面入力モデル
+│  │  ├─ application/                 # request構築、ユースケース、repository interface
+│  │  ├─ domain/                      # ダブルス用ドメインモデル
+│  │  ├─ data/                        # Firestore / in-memory等のrepository実装
+│  │  └─ infrastructure/              # ダブルス固有の外部接続
+│  └─ team_scheduler/
+│     ├─ presentation/                # チーム用画面・widget・画面入力モデル
+│     ├─ application/                 # request構築、response変換、repository interface
+│     ├─ domain/                      # チーム用ドメインモデル
+│     └─ data/                        # Firestore / in-memory等のrepository実装
+├─ shared/
+│  ├─ infrastructure/                 # 複数featureから使う外部API client
+│  └─ repositories/                   # repository実装のアプリ全体での選択・公開
+└─ l10n/                              # Flutter l10n生成物と参照入口
 ```
 
----
-
-## 4. 各レイヤーの責務
-
-### 4.1 presentation
-
-役割：
-
-* UI描画
-* ユーザー入力の受付
-* 状態の表示
-
-含むもの：
-
-* pages
-* widgets
-* controllers
-
-責務外：
-
-* アルゴリズムロジック
-* 複雑なビジネスルール
+feature 固有の処理は各 feature 配下へ置き、複数 feature に共通する外部接続のみ `shared/infrastructure` へ置く。
 
 ---
 
-### 4.2 application
+## 4. 各領域の責務
 
-役割：
+### 4.1 `app`
 
-* ユースケースの実行
-* 処理の流れの制御
+アプリ全体で共通する環境設定を扱う。
 
-例：
+例:
 
-* generate_doubles_schedule
+- core API base URL
+- Firestore repositoryを使うかどうか
+- `dart-define` から受け取る実行環境設定
 
-責務：
+feature 固有の画面状態や生成条件は置かない。
 
-* request生成
-* repository呼び出し
-* result返却
+### 4.2 `features/*/presentation`
 
-責務外：
+役割:
 
-* スケジューリングの詳細ロジック
+- UI描画
+- ユーザー入力の受付
+- 画面状態の管理
+- application serviceやrepositoryを呼び出す操作の起点
+
+含むもの:
+
+- pages
+- widgets
+- dialogs
+- 画面入力用model
+
+対戦表生成アルゴリズムや汎用HTTP通信処理は持たない。
+
+### 4.3 `features/*/application`
+
+役割:
+
+- feature固有のユースケースを実行する
+- UI入力からcore API requestを構築する
+- core API responseをfeature固有のmodelへ変換する
+- repository interfaceを定義する
+
+例:
+
+- `GeneratedScheduleService`
+- `TeamGeneratedScheduleService`
+- `EventRepository`
+- `TeamScheduleRepository`
+
+ダブルスとチームで異なる生成条件・request shape・response変換は、この層を中心に各 feature 側で扱う。
+
+### 4.4 `features/*/domain`
+
+役割:
+
+- feature固有のデータ構造を定義する
+- 保存・表示・変換で利用するmodelを保持する
+
+生成アルゴリズム本体は持たない。
+
+### 4.5 `features/*/data`
+
+役割:
+
+- applicationで定義したrepository interfaceの具体実装
+- Firestoreへの保存・取得
+- local確認用のin-memory実装
+- 保存形式とdomain modelの変換
+
+Firestoreとin-memoryの選択はアプリ設定に応じて行う。
+
+### 4.6 `features/*/infrastructure`
+
+feature固有の外部接続を扱う。
+
+その接続が他のfeatureでも必要になった場合は、feature間で直接importせず、責務を確認した上で `shared/infrastructure` への移動を検討する。
+
+### 4.7 `shared/infrastructure`
+
+複数featureから利用する外部接続の共通処理を扱う。
+
+現在は `GeneratedScheduleApiClient` を配置し、以下に責務を限定する。
+
+- core API endpointへのHTTP request
+- JSONのencode / decode
+- HTTP statusとAPI errorの共通処理
+- base URLからrequest URLを構築する処理
+
+以下は持たない。
+
+- doubles / team固有のrequest構築
+- feature固有のdomain model
+- feature固有のresponse変換
+- UI状態
+
+### 4.8 `shared/repositories`
+
+アプリ全体で利用するrepository実装の選択と公開を行う。
+
+現在は `AppConfig` を参照し、各featureのFirestore実装またはin-memory実装を選択する。
+
+この領域は汎用domain層ではなく、アプリ全体の構成を組み立てるcomposition寄りの責務として扱う。
 
 ---
 
-### 4.3 domain
+## 5. featureごとの責務
 
-役割：
+### 5.1 `doubles_scheduler`
 
-* データ構造の定義
+- ダブルス用イベント・参加者入力
+- ダブルス生成requestの構築
+- ダブルス対戦表の表示
+- 採用状態・共有URL・表示名の管理
+- ダブルス用イベントの保存・復元
 
-含むもの：
+`GeneratedScheduleService` は、ダブルス用requestを構築して共通API clientへ渡す。
 
-* request
-* result
-* モデル
+### 5.2 `team_scheduler`
 
-注意：
+- チーム用参加者・チーム条件入力
+- チーム生成requestの構築
+- team responseのdomain model変換
+- チームカード・対戦表・スコア等の表示
+- チーム用scheduleの保存・復元
 
-* ロジックは極力持たない
-* 計算処理はcore側へ寄せる
+`TeamGeneratedScheduleService` は、チーム固有のrequest構築とresponse変換を担当し、HTTP通信は共通API clientへ委譲する。
 
----
+### 5.3 `shared`
 
-### 4.4 infrastructure
+- 複数featureで共通利用する外部API client
+- アプリ全体で利用するrepository実装の選択
 
-役割：
-
-* 外部との接続
-
-例：
-
-* API呼び出し
-* mock実装
-
-責務：
-
-* repositoryの具体実装
+「共通に見える」という理由だけでfeature固有のmodelや処理を移さず、複数featureに共通する責務であることを確認して配置する。
 
 ---
 
-## 5. Core（非公開）の責務
+## 6. Core（非公開）の責務
 
-別リポジトリ（srp-lanske-core）で管理する。
+`srp-lanske-core` で管理する。
 
-含むもの：
+含むもの:
 
-* 組み合わせ生成
-* 評価関数
-* 制約判定
-* 最適化ロジック
+- ダブルス対戦表生成
+- チーム分け・チーム対戦表生成
+- 評価関数
+- 制約判定
+- 最適化ロジック
+- generated schedule snapshotの保存・返却
 
-非公開とする理由：
+非公開とする理由:
 
-* アルゴリズムは本サービスの価値の中核であるため
-* 営業秘密として保護する
+- アルゴリズムは本サービスの価値の中核であるため
+- 営業秘密として保護するため
+
+web はcoreの内部実装へ依存せず、公開されたAPI request / responseを通じて利用する。
 
 ---
 
-## 6. データフロー
+## 7. データフロー
 
-```
-UI入力
- ↓
-Controller
- ↓
-UseCase
- ↓
-Repository
- ↓
-Core（生成）
- ↓
-Result
- ↓
+### 7.1 generated schedule生成
+
+```text
+ユーザー入力
+  ↓
+feature presentation
+  ↓
+feature application service
+  ├─ feature固有requestを構築
+  ↓
+shared/infrastructure
+  ├─ HTTP / JSON処理
+  ↓
+srp-lanske-core API
+  ├─ 生成・保存・response返却
+  ↓
+feature application / domain
+  ├─ feature固有modelへ変換
+  ↓
 UI表示
 ```
 
----
+### 7.2 web側の保存・復元
 
-## 7. 設計方針
-
-### 7.1 関心の分離
-
-* UIとロジックを分離する
-* ロジックとアルゴリズムを分離する
-
----
-
-### 7.2 依存方向
-
-依存は常に内側へ向かう：
-
-```
-presentation → application → domain
-presentation → infrastructure
+```text
+UI操作
+  ↓
+feature repository interface
+  ↓
+Firestoreまたはin-memory repository
+  ↓
+web側 event / schedule document
 ```
 
-coreには直接依存しない（interface経由）
+core generated schedule snapshotと、web側のevent / view stateは別に管理する。
 
 ---
 
-### 7.3 アルゴリズムの隔離
+## 8. 依存方針
 
-* アプリ側にアルゴリズムを持たせない
-* repository経由でのみ呼び出す
+### 8.1 feature固有処理をfeature内に保つ
+
+- doubles用requestは `doubles_scheduler` で構築する
+- team用request / response変換は `team_scheduler` で扱う
+- 表示名、選択状態、画面固有modelは各featureに置く
+
+### 8.2 feature間でinfrastructureを共有しない
+
+`team_scheduler` がAPI接続のために `doubles_scheduler/infrastructure` をimportする、といった依存は作らない。
+
+複数featureから利用する外部接続は、共通部分だけを `shared/infrastructure` へ配置する。
+
+### 8.3 共通clientをfeature非依存に保つ
+
+`GeneratedScheduleApiClient` は `Map<String, dynamic>` のJSON入出力と通信処理に集中し、doubles / teamのmodelへ依存しない。
+
+これにより、新しいschedule typeを追加する場合も、共通通信処理を複製せず、feature側でrequest / response責務を追加できる。
+
+### 8.4 sharedへの移動を過剰に行わない
+
+単一featureでしか使わない処理は、そのfeature内へ置く。
+
+複数featureから参照されるようになった時点で、共通化する責務と依存方向を確認してからsharedへの移動を判断する。
 
 ---
 
-## 8. 現在の実装状態
+## 9. 現在の実装状態
 
-* mock repository による動作確認
-* アルゴリズムは暫定的にアプリ内に存在（後に分離予定）
+- Flutter Webでdoubles / teamの画面を実装済み
+- doubles / teamの双方が同じgenerated schedule API endpointを利用する
+- 共通API clientは `shared/infrastructure/generated_schedule_api_client.dart` に配置済み
+- doubles固有requestは `GeneratedScheduleService` で構築する
+- team固有requestとresponse変換は `TeamGeneratedScheduleService` で扱う
+- 対戦表生成アルゴリズムは `srp-lanske-core` へ分離済み
+- web側のevent / schedule保存はFirestore repositoryで行える
+- local確認用としてin-memory repositoryも維持する
+- 採用状態はweb側のevent / view stateとして扱う
 
-```id="v1m8zx"
-TODO: move algorithm to srp-lanske-core
-```
+mock / in-memory実装は開発・確認用の代替経路であり、生成アルゴリズムをweb内へ置くためのものではない。
 
 ---
 
-## 9. 今後の拡張
+## 10. 今後の拡張
 
-予定機能：
+新しい競技・schedule typeを追加する場合は、原則としてfeature単位で追加する。
 
-* round_robin
-* knockout
-* score
-
-拡張方法：
-
-```
+```text
 features/
 ├─ doubles_scheduler/
+├─ team_scheduler/
 ├─ round_robin/
 ├─ knockout/
-└─ score/
+└─ ...
 ```
+
+追加時の方針:
+
+- feature固有のUI・application・domain・dataをfeature内へ置く
+- core APIの共通通信処理は `shared/infrastructure` を再利用する
+- request / response shapeの差は各featureで吸収する
+- feature間の直接依存が必要になった場合は、共通責務として切り出せるか先に検討する
 
 ---
 
-## 10. 技術的判断メモ
+## 11. 技術的判断メモ
 
-* Flutter Webでの開発を前提
-* Codespacesでの開発を想定
-* 将来的にバックエンド化（Cloud Functions等）
+- Flutter Webでの開発を前提とする
+- GitHub Codespacesまたはlocal環境で開発する
+- 対戦表生成backendとして `srp-lanske-core` APIを利用する
+- web側の保存にはFirestoreを利用し、local確認用にin-memory実装を残す
 
-### 10.1 core API URL の環境切り替え
+### 11.1 core API URL の環境切り替え
 
-web から接続する core API の base URL は、`AppConfig.coreApiBaseUrl` から参照する。
+web から接続するcore APIのbase URLは、`AppConfig.coreApiBaseUrl` から参照する。
 
-`AppConfig.coreApiBaseUrl` は Flutter の `String.fromEnvironment` を使い、`LANSKE_CORE_API_BASE_URL` で指定する。
+`AppConfig.coreApiBaseUrl` はFlutterの `String.fromEnvironment` を使い、`LANSKE_CORE_API_BASE_URL` で指定する。
 
-未指定の場合は local 開発用として `http://localhost:8080` を使用する。
+未指定の場合はlocal開発用として `http://localhost:8080` を使用する。
 
-この設定値は以下の core API 呼び出しで共通利用する。
+この設定値は、doubles / team双方のgenerated schedule API呼び出しで共通利用する。
 
-- generate
-- get
+ver0.1では、環境別設定ファイルやsecret管理を過度に増やさず、`dart-define` による明示的な切り替えを優先する。
 
-採用状態は、web 側の event / view state として扱う。
-backend 側の generated schedule snapshot は、通常の採用操作では更新しない。
-
-ver0.1 では、環境別設定ファイルや secret 管理の本格化は行わず、`dart-define` による明示的な切り替えを優先する。
-
-### 10.2 共有URLと採用状態
+### 11.2 共有URLと採用状態
 
 共有URLは `publicId` を入口にする。
-web 側の `events/{publicId}` 相当の document に、現在表示・採用する backend 側 generated schedule snapshot の ID を保存する。
 
-最小 schema 方針：
+web側のevent / schedule documentに、現在表示・採用するcore generated schedule snapshotのIDを保存する。
 
-```txt
+最小schema方針:
+
+```text
 events/{publicId}
   event.publicId
   event.currentGeneratedScheduleId
@@ -267,21 +372,21 @@ events/{publicId}
 ```
 
 `expiresAt` は作成から10日後を初期値として持つ。
-ただし、ver0.1.x では期限切れによる非表示処理はまだ行わない。
+ただし、ver0.1.xでは期限切れによる非表示処理はまだ行わない。
 
-将来の試合カード進行状況・対戦成績は、event 本体ではなく、試合カード単位の subcollection で扱う想定とする。
-`events/{publicId}/matchCards/{roundNo}_{courtNo}` のような形を候補にし、document が存在しない場合は既定で「試合前」とみなせるようにする。
+将来の試合カード進行状況・対戦成績は、event本体ではなく、試合カード単位のsubcollectionで扱う想定とする。
 
 ---
 
-## 11. 設計思想
+## 12. 設計思想
 
-本システムは以下の思想に基づいて設計する：
+本システムは以下の思想に基づいて設計する。
 
 > ランダムではなく、納得できる組み合わせを
 
-この思想は以下に影響する：
+この思想は以下に影響する。
 
 - 評価関数の設計
 - 制約条件の定義
 - アルゴリズムの最適化方針
+- UI上で生成条件と結果を確認しやすくする設計


### PR DESCRIPTION
## Summary

web repository の README / architecture を、現在の doubles scheduler・team scheduler・shared infrastructure 構成に合わせて更新しました。

Closes #134

## Changes

- `README.md` のプロジェクト構成を更新
  - `doubles_scheduler`
  - `team_scheduler`
  - `shared/infrastructure`
  - `shared/repositories`
- `docs/architecture.md` を現行実装に合わせて整理
- doubles / team / shared の責務を明記
- 共通 generated schedule API client を `shared/infrastructure` に配置する方針を明記
- feature 固有の request 構築・response 変換は各 feature 側で扱う方針を明記
- doubles / team が互いの infrastructure に直接依存しない方針を明記
- Core API と Firestore / in-memory repository の現在のデータフローを反映
- mock 中心・アルゴリズムが web 内にあるという古い記述を削除

## Scope

- Dart コードの変更なし
- API client の仕様変更なし
- doubles / team 画面の変更なし
- `/team` 公開導線の変更なし
- 利用者向け機能説明の大幅変更なし

## Verification

- [x] 変更対象が `README.md` と `docs/architecture.md` のみであることを確認
- [x] 現在のディレクトリ構成・依存関係と記述が一致していることを確認
- [x] Markdown の表示内容を確認
- [x] コード変更がないため `dart format` / `flutter analyze` / `flutter test` は省略