### PR TITLE
🧱 対戦進行状態・最終結果の共通モデルと保存基盤を追加する refs #143

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -10,12 +10,32 @@ service cloud.firestore {
     match /events/{publicId} {
       allow read, create, update: if true;
       allow delete: if false;
+
+      match /schedule_progress/{generatedScheduleId} {
+        allow read, create, update: if true;
+        allow delete: if false;
+
+        match /matches/{matchKey} {
+          allow read, create, update: if true;
+          allow delete: if false;
+        }
+      }
     }
 
     // Public share documents used by team schedules, including boccia data.
     match /team_schedules/{shareId} {
       allow read, create, update: if true;
       allow delete: if false;
+
+      match /schedule_progress/{generatedScheduleId} {
+        allow read, create, update: if true;
+        allow delete: if false;
+
+        match /matches/{matchKey} {
+          allow read, create, update: if true;
+          allow delete: if false;
+        }
+      }
     }
 
     // Existing core-generated data is readable from the client,

--- a/lib/features/schedule_progress/application/schedule_progress_repository.dart
+++ b/lib/features/schedule_progress/application/schedule_progress_repository.dart
@@ -1,0 +1,51 @@
+import '../domain/schedule_progress_models.dart';
+
+abstract class ScheduleProgressRepository {
+  Future<ScheduleProgressSummary> ensureSummary({
+    required ScheduleProgressScope scope,
+    required int totalMatchCount,
+  });
+
+  Future<ScheduleProgressSummary?> findSummary(
+    ScheduleProgressScope scope,
+  );
+
+  Future<List<ScheduleMatchProgress>> listMatches(
+    ScheduleProgressScope scope,
+  );
+
+  Future<ScheduleMatchProgress> findMatch({
+    required ScheduleProgressScope scope,
+    required int roundNo,
+    required int courtNo,
+    int? matchNo,
+  });
+
+  Future<ScheduleMatchProgress> saveMatch({
+    required ScheduleProgressScope scope,
+    required ScheduleMatchProgressUpdate update,
+    required int totalMatchCount,
+    required int expectedRevision,
+  });
+}
+
+class ScheduleProgressConflictException implements Exception {
+  const ScheduleProgressConflictException({
+    required this.matchKey,
+    required this.expectedRevision,
+    required this.actualRevision,
+  });
+
+  final ScheduleMatchKey matchKey;
+  final int expectedRevision;
+  final int actualRevision;
+
+  @override
+  String toString() {
+    return 'ScheduleProgressConflictException('
+        'matchKey: $matchKey, '
+        'expectedRevision: $expectedRevision, '
+        'actualRevision: $actualRevision'
+        ')';
+  }
+}

--- a/lib/features/schedule_progress/data/firestore_schedule_progress_repository.dart
+++ b/lib/features/schedule_progress/data/firestore_schedule_progress_repository.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 import '../application/schedule_progress_repository.dart';
 import '../domain/schedule_progress_models.dart';
+import '../domain/schedule_progress_transition.dart';
 
 class FirestoreScheduleProgressRepository
     implements ScheduleProgressRepository {
@@ -19,7 +20,7 @@ class FirestoreScheduleProgressRepository
     required ScheduleProgressScope scope,
     required int totalMatchCount,
   }) async {
-    _validateTotalMatchCount(totalMatchCount);
+    validateScheduleProgressTotalMatchCount(totalMatchCount);
 
     final progressReference = _progressDocument(scope);
     return _firestore.runTransaction((transaction) async {
@@ -27,24 +28,17 @@ class FirestoreScheduleProgressRepository
       final data = snapshot.data();
       if (snapshot.exists && data != null) {
         final current = ScheduleProgressSummary.fromJson(data);
-        _ensureTotalMatchCount(
+        ensureScheduleProgressTotalMatchCount(
           summary: current,
           totalMatchCount: totalMatchCount,
         );
         return current;
       }
 
-      final now = _clock();
-      final summary = ScheduleProgressSummary(
-        schemaVersion: ScheduleProgressSummary.currentSchemaVersion,
-        scheduleType: scope.scheduleType,
-        generatedScheduleId: scope.generatedScheduleId,
+      final summary = createInitialScheduleProgressSummary(
+        scope: scope,
         totalMatchCount: totalMatchCount,
-        completedMatchCount: 0,
-        inProgressMatchCount: 0,
-        createdAt: now,
-        updatedAt: now,
-        revision: 1,
+        now: _clock(),
       );
       transaction.set(progressReference, summary.toJson());
       return summary;
@@ -105,7 +99,7 @@ class FirestoreScheduleProgressRepository
     required int totalMatchCount,
     required int expectedRevision,
   }) async {
-    _validateSaveArguments(
+    validateScheduleProgressSaveArguments(
       totalMatchCount: totalMatchCount,
       expectedRevision: expectedRevision,
     );
@@ -135,29 +129,19 @@ class FirestoreScheduleProgressRepository
           progressSnapshot.exists && currentSummaryData != null
               ? ScheduleProgressSummary.fromJson(currentSummaryData)
               : null;
-      _ensureTotalMatchCount(
+      ensureScheduleProgressTotalMatchCount(
         summary: currentSummary,
         totalMatchCount: totalMatchCount,
       );
 
       final now = _clock();
-      final nextMatch = ScheduleMatchProgress(
-        schemaVersion: ScheduleMatchProgress.currentSchemaVersion,
-        scheduleType: scope.scheduleType,
-        generatedScheduleId: scope.generatedScheduleId,
-        roundNo: update.roundNo,
-        courtNo: update.courtNo,
-        matchNo: update.matchNo ?? currentMatch?.matchNo,
-        status: update.status,
-        result: update.result,
-        note: update.note,
-        startedAt: update.startedAt,
-        finishedAt: update.finishedAt,
-        createdAt: currentMatch?.createdAt ?? now,
-        updatedAt: now,
-        revision: actualRevision + 1,
+      final nextMatch = buildSavedScheduleMatchProgress(
+        scope: scope,
+        update: update,
+        current: currentMatch,
+        now: now,
       );
-      final nextSummary = _buildNextSummary(
+      final nextSummary = buildUpdatedScheduleProgressSummary(
         scope: scope,
         currentSummary: currentSummary,
         previousStatus:
@@ -198,77 +182,4 @@ String _rootCollectionPath(ScheduleProgressScheduleType scheduleType) {
     case ScheduleProgressScheduleType.team:
       return 'team_schedules';
   }
-}
-
-void _validateTotalMatchCount(int totalMatchCount) {
-  if (totalMatchCount <= 0) {
-    throw ArgumentError.value(
-      totalMatchCount,
-      'totalMatchCount',
-      'must be positive',
-    );
-  }
-}
-
-void _validateSaveArguments({
-  required int totalMatchCount,
-  required int expectedRevision,
-}) {
-  _validateTotalMatchCount(totalMatchCount);
-  if (expectedRevision < 0) {
-    throw ArgumentError.value(
-      expectedRevision,
-      'expectedRevision',
-      'must not be negative',
-    );
-  }
-}
-
-void _ensureTotalMatchCount({
-  required ScheduleProgressSummary? summary,
-  required int totalMatchCount,
-}) {
-  if (summary != null && summary.totalMatchCount != totalMatchCount) {
-    throw StateError(
-      'total match count mismatch: '
-      'expected ${summary.totalMatchCount}, actual $totalMatchCount',
-    );
-  }
-}
-
-ScheduleProgressSummary _buildNextSummary({
-  required ScheduleProgressScope scope,
-  required ScheduleProgressSummary? currentSummary,
-  required ScheduleMatchStatus previousStatus,
-  required ScheduleMatchStatus nextStatus,
-  required int totalMatchCount,
-  required DateTime now,
-}) {
-  final completedMatchCount =
-      (currentSummary?.completedMatchCount ?? 0) -
-          _statusCount(previousStatus, ScheduleMatchStatus.completed) +
-          _statusCount(nextStatus, ScheduleMatchStatus.completed);
-  final inProgressMatchCount =
-      (currentSummary?.inProgressMatchCount ?? 0) -
-          _statusCount(previousStatus, ScheduleMatchStatus.inProgress) +
-          _statusCount(nextStatus, ScheduleMatchStatus.inProgress);
-
-  return ScheduleProgressSummary(
-    schemaVersion: ScheduleProgressSummary.currentSchemaVersion,
-    scheduleType: scope.scheduleType,
-    generatedScheduleId: scope.generatedScheduleId,
-    totalMatchCount: totalMatchCount,
-    completedMatchCount: completedMatchCount,
-    inProgressMatchCount: inProgressMatchCount,
-    createdAt: currentSummary?.createdAt ?? now,
-    updatedAt: now,
-    revision: (currentSummary?.revision ?? 0) + 1,
-  );
-}
-
-int _statusCount(
-  ScheduleMatchStatus actual,
-  ScheduleMatchStatus target,
-) {
-  return actual == target ? 1 : 0;
 }

--- a/lib/features/schedule_progress/data/firestore_schedule_progress_repository.dart
+++ b/lib/features/schedule_progress/data/firestore_schedule_progress_repository.dart
@@ -144,8 +144,7 @@ class FirestoreScheduleProgressRepository
       final nextSummary = buildUpdatedScheduleProgressSummary(
         scope: scope,
         currentSummary: currentSummary,
-        previousStatus:
-            currentMatch?.status ?? ScheduleMatchStatus.scheduled,
+        previousStatus: currentMatch?.status ?? ScheduleMatchStatus.scheduled,
         nextStatus: nextMatch.status,
         totalMatchCount: totalMatchCount,
         now: now,

--- a/lib/features/schedule_progress/data/firestore_schedule_progress_repository.dart
+++ b/lib/features/schedule_progress/data/firestore_schedule_progress_repository.dart
@@ -1,0 +1,274 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../application/schedule_progress_repository.dart';
+import '../domain/schedule_progress_models.dart';
+
+class FirestoreScheduleProgressRepository
+    implements ScheduleProgressRepository {
+  FirestoreScheduleProgressRepository({
+    FirebaseFirestore? firestore,
+    DateTime Function()? clock,
+  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+        _clock = clock ?? DateTime.now;
+
+  final FirebaseFirestore _firestore;
+  final DateTime Function() _clock;
+
+  @override
+  Future<ScheduleProgressSummary> ensureSummary({
+    required ScheduleProgressScope scope,
+    required int totalMatchCount,
+  }) async {
+    _validateTotalMatchCount(totalMatchCount);
+
+    final progressReference = _progressDocument(scope);
+    return _firestore.runTransaction((transaction) async {
+      final snapshot = await transaction.get(progressReference);
+      final data = snapshot.data();
+      if (snapshot.exists && data != null) {
+        final current = ScheduleProgressSummary.fromJson(data);
+        _ensureTotalMatchCount(
+          summary: current,
+          totalMatchCount: totalMatchCount,
+        );
+        return current;
+      }
+
+      final now = _clock();
+      final summary = ScheduleProgressSummary(
+        schemaVersion: ScheduleProgressSummary.currentSchemaVersion,
+        scheduleType: scope.scheduleType,
+        generatedScheduleId: scope.generatedScheduleId,
+        totalMatchCount: totalMatchCount,
+        completedMatchCount: 0,
+        inProgressMatchCount: 0,
+        createdAt: now,
+        updatedAt: now,
+        revision: 1,
+      );
+      transaction.set(progressReference, summary.toJson());
+      return summary;
+    });
+  }
+
+  @override
+  Future<ScheduleProgressSummary?> findSummary(
+    ScheduleProgressScope scope,
+  ) async {
+    final snapshot = await _progressDocument(scope).get();
+    final data = snapshot.data();
+    if (!snapshot.exists || data == null) {
+      return null;
+    }
+
+    return ScheduleProgressSummary.fromJson(data);
+  }
+
+  @override
+  Future<List<ScheduleMatchProgress>> listMatches(
+    ScheduleProgressScope scope,
+  ) async {
+    final snapshot = await _matchesCollection(scope).get();
+    final matches = snapshot.docs
+        .map((document) => ScheduleMatchProgress.fromJson(document.data()))
+        .toList();
+    matches.sort((left, right) => left.key.compareTo(right.key));
+    return List<ScheduleMatchProgress>.unmodifiable(matches);
+  }
+
+  @override
+  Future<ScheduleMatchProgress> findMatch({
+    required ScheduleProgressScope scope,
+    required int roundNo,
+    required int courtNo,
+    int? matchNo,
+  }) async {
+    final key = ScheduleMatchKey(roundNo: roundNo, courtNo: courtNo);
+    final snapshot = await _matchesCollection(scope).doc(key.value).get();
+    final data = snapshot.data();
+    if (!snapshot.exists || data == null) {
+      return ScheduleMatchProgress.scheduledPlaceholder(
+        scope: scope,
+        roundNo: roundNo,
+        courtNo: courtNo,
+        matchNo: matchNo,
+      );
+    }
+
+    return ScheduleMatchProgress.fromJson(data);
+  }
+
+  @override
+  Future<ScheduleMatchProgress> saveMatch({
+    required ScheduleProgressScope scope,
+    required ScheduleMatchProgressUpdate update,
+    required int totalMatchCount,
+    required int expectedRevision,
+  }) async {
+    _validateSaveArguments(
+      totalMatchCount: totalMatchCount,
+      expectedRevision: expectedRevision,
+    );
+
+    final progressReference = _progressDocument(scope);
+    final matchReference = _matchesCollection(scope).doc(update.key.value);
+
+    return _firestore.runTransaction((transaction) async {
+      final matchSnapshot = await transaction.get(matchReference);
+      final progressSnapshot = await transaction.get(progressReference);
+
+      final currentMatchData = matchSnapshot.data();
+      final currentMatch = matchSnapshot.exists && currentMatchData != null
+          ? ScheduleMatchProgress.fromJson(currentMatchData)
+          : null;
+      final actualRevision = currentMatch?.revision ?? 0;
+      if (actualRevision != expectedRevision) {
+        throw ScheduleProgressConflictException(
+          matchKey: update.key,
+          expectedRevision: expectedRevision,
+          actualRevision: actualRevision,
+        );
+      }
+
+      final currentSummaryData = progressSnapshot.data();
+      final currentSummary =
+          progressSnapshot.exists && currentSummaryData != null
+              ? ScheduleProgressSummary.fromJson(currentSummaryData)
+              : null;
+      _ensureTotalMatchCount(
+        summary: currentSummary,
+        totalMatchCount: totalMatchCount,
+      );
+
+      final now = _clock();
+      final nextMatch = ScheduleMatchProgress(
+        schemaVersion: ScheduleMatchProgress.currentSchemaVersion,
+        scheduleType: scope.scheduleType,
+        generatedScheduleId: scope.generatedScheduleId,
+        roundNo: update.roundNo,
+        courtNo: update.courtNo,
+        matchNo: update.matchNo ?? currentMatch?.matchNo,
+        status: update.status,
+        result: update.result,
+        note: update.note,
+        startedAt: update.startedAt,
+        finishedAt: update.finishedAt,
+        createdAt: currentMatch?.createdAt ?? now,
+        updatedAt: now,
+        revision: actualRevision + 1,
+      );
+      final nextSummary = _buildNextSummary(
+        scope: scope,
+        currentSummary: currentSummary,
+        previousStatus:
+            currentMatch?.status ?? ScheduleMatchStatus.scheduled,
+        nextStatus: nextMatch.status,
+        totalMatchCount: totalMatchCount,
+        now: now,
+      );
+
+      transaction.set(matchReference, nextMatch.toJson());
+      transaction.set(progressReference, nextSummary.toJson());
+
+      return nextMatch;
+    });
+  }
+
+  DocumentReference<Map<String, dynamic>> _progressDocument(
+    ScheduleProgressScope scope,
+  ) {
+    return _firestore
+        .collection(_rootCollectionPath(scope.scheduleType))
+        .doc(scope.shareId)
+        .collection('schedule_progress')
+        .doc(scope.generatedScheduleId);
+  }
+
+  CollectionReference<Map<String, dynamic>> _matchesCollection(
+    ScheduleProgressScope scope,
+  ) {
+    return _progressDocument(scope).collection('matches');
+  }
+}
+
+String _rootCollectionPath(ScheduleProgressScheduleType scheduleType) {
+  switch (scheduleType) {
+    case ScheduleProgressScheduleType.doubles:
+      return 'events';
+    case ScheduleProgressScheduleType.team:
+      return 'team_schedules';
+  }
+}
+
+void _validateTotalMatchCount(int totalMatchCount) {
+  if (totalMatchCount <= 0) {
+    throw ArgumentError.value(
+      totalMatchCount,
+      'totalMatchCount',
+      'must be positive',
+    );
+  }
+}
+
+void _validateSaveArguments({
+  required int totalMatchCount,
+  required int expectedRevision,
+}) {
+  _validateTotalMatchCount(totalMatchCount);
+  if (expectedRevision < 0) {
+    throw ArgumentError.value(
+      expectedRevision,
+      'expectedRevision',
+      'must not be negative',
+    );
+  }
+}
+
+void _ensureTotalMatchCount({
+  required ScheduleProgressSummary? summary,
+  required int totalMatchCount,
+}) {
+  if (summary != null && summary.totalMatchCount != totalMatchCount) {
+    throw StateError(
+      'total match count mismatch: '
+      'expected ${summary.totalMatchCount}, actual $totalMatchCount',
+    );
+  }
+}
+
+ScheduleProgressSummary _buildNextSummary({
+  required ScheduleProgressScope scope,
+  required ScheduleProgressSummary? currentSummary,
+  required ScheduleMatchStatus previousStatus,
+  required ScheduleMatchStatus nextStatus,
+  required int totalMatchCount,
+  required DateTime now,
+}) {
+  final completedMatchCount =
+      (currentSummary?.completedMatchCount ?? 0) -
+          _statusCount(previousStatus, ScheduleMatchStatus.completed) +
+          _statusCount(nextStatus, ScheduleMatchStatus.completed);
+  final inProgressMatchCount =
+      (currentSummary?.inProgressMatchCount ?? 0) -
+          _statusCount(previousStatus, ScheduleMatchStatus.inProgress) +
+          _statusCount(nextStatus, ScheduleMatchStatus.inProgress);
+
+  return ScheduleProgressSummary(
+    schemaVersion: ScheduleProgressSummary.currentSchemaVersion,
+    scheduleType: scope.scheduleType,
+    generatedScheduleId: scope.generatedScheduleId,
+    totalMatchCount: totalMatchCount,
+    completedMatchCount: completedMatchCount,
+    inProgressMatchCount: inProgressMatchCount,
+    createdAt: currentSummary?.createdAt ?? now,
+    updatedAt: now,
+    revision: (currentSummary?.revision ?? 0) + 1,
+  );
+}
+
+int _statusCount(
+  ScheduleMatchStatus actual,
+  ScheduleMatchStatus target,
+) {
+  return actual == target ? 1 : 0;
+}

--- a/lib/features/schedule_progress/data/in_memory_schedule_progress_repository.dart
+++ b/lib/features/schedule_progress/data/in_memory_schedule_progress_repository.dart
@@ -1,0 +1,221 @@
+import '../application/schedule_progress_repository.dart';
+import '../domain/schedule_progress_models.dart';
+
+class InMemoryScheduleProgressRepository
+    implements ScheduleProgressRepository {
+  InMemoryScheduleProgressRepository({
+    DateTime Function()? clock,
+  }) : _clock = clock ?? DateTime.now;
+
+  final DateTime Function() _clock;
+  final Map<String, ScheduleProgressSummary> _summaries = {};
+  final Map<String, Map<String, ScheduleMatchProgress>> _matchesByScope = {};
+
+  @override
+  Future<ScheduleProgressSummary> ensureSummary({
+    required ScheduleProgressScope scope,
+    required int totalMatchCount,
+  }) async {
+    _validateTotalMatchCount(totalMatchCount);
+
+    final current = _summaries[scope.storageKey];
+    _ensureTotalMatchCount(
+      summary: current,
+      totalMatchCount: totalMatchCount,
+    );
+    if (current != null) {
+      return current;
+    }
+
+    final now = _clock();
+    final summary = ScheduleProgressSummary(
+      schemaVersion: ScheduleProgressSummary.currentSchemaVersion,
+      scheduleType: scope.scheduleType,
+      generatedScheduleId: scope.generatedScheduleId,
+      totalMatchCount: totalMatchCount,
+      completedMatchCount: 0,
+      inProgressMatchCount: 0,
+      createdAt: now,
+      updatedAt: now,
+      revision: 1,
+    );
+    _summaries[scope.storageKey] = summary;
+    return summary;
+  }
+
+  @override
+  Future<ScheduleProgressSummary?> findSummary(
+    ScheduleProgressScope scope,
+  ) async {
+    return _summaries[scope.storageKey];
+  }
+
+  @override
+  Future<List<ScheduleMatchProgress>> listMatches(
+    ScheduleProgressScope scope,
+  ) async {
+    final matches = _matchesByScope[scope.storageKey]?.values.toList() ??
+        <ScheduleMatchProgress>[];
+    matches.sort((left, right) => left.key.compareTo(right.key));
+    return List<ScheduleMatchProgress>.unmodifiable(matches);
+  }
+
+  @override
+  Future<ScheduleMatchProgress> findMatch({
+    required ScheduleProgressScope scope,
+    required int roundNo,
+    required int courtNo,
+    int? matchNo,
+  }) async {
+    final key = ScheduleMatchKey(roundNo: roundNo, courtNo: courtNo);
+    final existing = _matchesByScope[scope.storageKey]?[key.value];
+    if (existing != null) {
+      return existing;
+    }
+
+    return ScheduleMatchProgress.scheduledPlaceholder(
+      scope: scope,
+      roundNo: roundNo,
+      courtNo: courtNo,
+      matchNo: matchNo,
+    );
+  }
+
+  @override
+  Future<ScheduleMatchProgress> saveMatch({
+    required ScheduleProgressScope scope,
+    required ScheduleMatchProgressUpdate update,
+    required int totalMatchCount,
+    required int expectedRevision,
+  }) async {
+    _validateSaveArguments(
+      totalMatchCount: totalMatchCount,
+      expectedRevision: expectedRevision,
+    );
+
+    final scopeMatches = _matchesByScope.putIfAbsent(
+      scope.storageKey,
+      () => <String, ScheduleMatchProgress>{},
+    );
+    final current = scopeMatches[update.key.value];
+    final actualRevision = current?.revision ?? 0;
+    if (actualRevision != expectedRevision) {
+      throw ScheduleProgressConflictException(
+        matchKey: update.key,
+        expectedRevision: expectedRevision,
+        actualRevision: actualRevision,
+      );
+    }
+
+    final currentSummary = _summaries[scope.storageKey];
+    _ensureTotalMatchCount(
+      summary: currentSummary,
+      totalMatchCount: totalMatchCount,
+    );
+
+    final now = _clock();
+    final nextMatch = ScheduleMatchProgress(
+      schemaVersion: ScheduleMatchProgress.currentSchemaVersion,
+      scheduleType: scope.scheduleType,
+      generatedScheduleId: scope.generatedScheduleId,
+      roundNo: update.roundNo,
+      courtNo: update.courtNo,
+      matchNo: update.matchNo ?? current?.matchNo,
+      status: update.status,
+      result: update.result,
+      note: update.note,
+      startedAt: update.startedAt,
+      finishedAt: update.finishedAt,
+      createdAt: current?.createdAt ?? now,
+      updatedAt: now,
+      revision: actualRevision + 1,
+    );
+
+    final nextSummary = _buildNextSummary(
+      scope: scope,
+      currentSummary: currentSummary,
+      previousStatus: current?.status ?? ScheduleMatchStatus.scheduled,
+      nextStatus: nextMatch.status,
+      totalMatchCount: totalMatchCount,
+      now: now,
+    );
+
+    scopeMatches[update.key.value] = nextMatch;
+    _summaries[scope.storageKey] = nextSummary;
+
+    return nextMatch;
+  }
+}
+
+void _validateTotalMatchCount(int totalMatchCount) {
+  if (totalMatchCount <= 0) {
+    throw ArgumentError.value(
+      totalMatchCount,
+      'totalMatchCount',
+      'must be positive',
+    );
+  }
+}
+
+void _validateSaveArguments({
+  required int totalMatchCount,
+  required int expectedRevision,
+}) {
+  _validateTotalMatchCount(totalMatchCount);
+  if (expectedRevision < 0) {
+    throw ArgumentError.value(
+      expectedRevision,
+      'expectedRevision',
+      'must not be negative',
+    );
+  }
+}
+
+void _ensureTotalMatchCount({
+  required ScheduleProgressSummary? summary,
+  required int totalMatchCount,
+}) {
+  if (summary != null && summary.totalMatchCount != totalMatchCount) {
+    throw StateError(
+      'total match count mismatch: '
+      'expected ${summary.totalMatchCount}, actual $totalMatchCount',
+    );
+  }
+}
+
+ScheduleProgressSummary _buildNextSummary({
+  required ScheduleProgressScope scope,
+  required ScheduleProgressSummary? currentSummary,
+  required ScheduleMatchStatus previousStatus,
+  required ScheduleMatchStatus nextStatus,
+  required int totalMatchCount,
+  required DateTime now,
+}) {
+  final completedMatchCount =
+      (currentSummary?.completedMatchCount ?? 0) -
+          _statusCount(previousStatus, ScheduleMatchStatus.completed) +
+          _statusCount(nextStatus, ScheduleMatchStatus.completed);
+  final inProgressMatchCount =
+      (currentSummary?.inProgressMatchCount ?? 0) -
+          _statusCount(previousStatus, ScheduleMatchStatus.inProgress) +
+          _statusCount(nextStatus, ScheduleMatchStatus.inProgress);
+
+  return ScheduleProgressSummary(
+    schemaVersion: ScheduleProgressSummary.currentSchemaVersion,
+    scheduleType: scope.scheduleType,
+    generatedScheduleId: scope.generatedScheduleId,
+    totalMatchCount: totalMatchCount,
+    completedMatchCount: completedMatchCount,
+    inProgressMatchCount: inProgressMatchCount,
+    createdAt: currentSummary?.createdAt ?? now,
+    updatedAt: now,
+    revision: (currentSummary?.revision ?? 0) + 1,
+  );
+}
+
+int _statusCount(
+  ScheduleMatchStatus actual,
+  ScheduleMatchStatus target,
+) {
+  return actual == target ? 1 : 0;
+}

--- a/lib/features/schedule_progress/data/in_memory_schedule_progress_repository.dart
+++ b/lib/features/schedule_progress/data/in_memory_schedule_progress_repository.dart
@@ -1,5 +1,6 @@
 import '../application/schedule_progress_repository.dart';
 import '../domain/schedule_progress_models.dart';
+import '../domain/schedule_progress_transition.dart';
 
 class InMemoryScheduleProgressRepository
     implements ScheduleProgressRepository {
@@ -16,10 +17,10 @@ class InMemoryScheduleProgressRepository
     required ScheduleProgressScope scope,
     required int totalMatchCount,
   }) async {
-    _validateTotalMatchCount(totalMatchCount);
+    validateScheduleProgressTotalMatchCount(totalMatchCount);
 
     final current = _summaries[scope.storageKey];
-    _ensureTotalMatchCount(
+    ensureScheduleProgressTotalMatchCount(
       summary: current,
       totalMatchCount: totalMatchCount,
     );
@@ -27,17 +28,10 @@ class InMemoryScheduleProgressRepository
       return current;
     }
 
-    final now = _clock();
-    final summary = ScheduleProgressSummary(
-      schemaVersion: ScheduleProgressSummary.currentSchemaVersion,
-      scheduleType: scope.scheduleType,
-      generatedScheduleId: scope.generatedScheduleId,
+    final summary = createInitialScheduleProgressSummary(
+      scope: scope,
       totalMatchCount: totalMatchCount,
-      completedMatchCount: 0,
-      inProgressMatchCount: 0,
-      createdAt: now,
-      updatedAt: now,
-      revision: 1,
+      now: _clock(),
     );
     _summaries[scope.storageKey] = summary;
     return summary;
@@ -88,7 +82,7 @@ class InMemoryScheduleProgressRepository
     required int totalMatchCount,
     required int expectedRevision,
   }) async {
-    _validateSaveArguments(
+    validateScheduleProgressSaveArguments(
       totalMatchCount: totalMatchCount,
       expectedRevision: expectedRevision,
     );
@@ -108,30 +102,19 @@ class InMemoryScheduleProgressRepository
     }
 
     final currentSummary = _summaries[scope.storageKey];
-    _ensureTotalMatchCount(
+    ensureScheduleProgressTotalMatchCount(
       summary: currentSummary,
       totalMatchCount: totalMatchCount,
     );
 
     final now = _clock();
-    final nextMatch = ScheduleMatchProgress(
-      schemaVersion: ScheduleMatchProgress.currentSchemaVersion,
-      scheduleType: scope.scheduleType,
-      generatedScheduleId: scope.generatedScheduleId,
-      roundNo: update.roundNo,
-      courtNo: update.courtNo,
-      matchNo: update.matchNo ?? current?.matchNo,
-      status: update.status,
-      result: update.result,
-      note: update.note,
-      startedAt: update.startedAt,
-      finishedAt: update.finishedAt,
-      createdAt: current?.createdAt ?? now,
-      updatedAt: now,
-      revision: actualRevision + 1,
+    final nextMatch = buildSavedScheduleMatchProgress(
+      scope: scope,
+      update: update,
+      current: current,
+      now: now,
     );
-
-    final nextSummary = _buildNextSummary(
+    final nextSummary = buildUpdatedScheduleProgressSummary(
       scope: scope,
       currentSummary: currentSummary,
       previousStatus: current?.status ?? ScheduleMatchStatus.scheduled,
@@ -145,77 +128,4 @@ class InMemoryScheduleProgressRepository
 
     return nextMatch;
   }
-}
-
-void _validateTotalMatchCount(int totalMatchCount) {
-  if (totalMatchCount <= 0) {
-    throw ArgumentError.value(
-      totalMatchCount,
-      'totalMatchCount',
-      'must be positive',
-    );
-  }
-}
-
-void _validateSaveArguments({
-  required int totalMatchCount,
-  required int expectedRevision,
-}) {
-  _validateTotalMatchCount(totalMatchCount);
-  if (expectedRevision < 0) {
-    throw ArgumentError.value(
-      expectedRevision,
-      'expectedRevision',
-      'must not be negative',
-    );
-  }
-}
-
-void _ensureTotalMatchCount({
-  required ScheduleProgressSummary? summary,
-  required int totalMatchCount,
-}) {
-  if (summary != null && summary.totalMatchCount != totalMatchCount) {
-    throw StateError(
-      'total match count mismatch: '
-      'expected ${summary.totalMatchCount}, actual $totalMatchCount',
-    );
-  }
-}
-
-ScheduleProgressSummary _buildNextSummary({
-  required ScheduleProgressScope scope,
-  required ScheduleProgressSummary? currentSummary,
-  required ScheduleMatchStatus previousStatus,
-  required ScheduleMatchStatus nextStatus,
-  required int totalMatchCount,
-  required DateTime now,
-}) {
-  final completedMatchCount =
-      (currentSummary?.completedMatchCount ?? 0) -
-          _statusCount(previousStatus, ScheduleMatchStatus.completed) +
-          _statusCount(nextStatus, ScheduleMatchStatus.completed);
-  final inProgressMatchCount =
-      (currentSummary?.inProgressMatchCount ?? 0) -
-          _statusCount(previousStatus, ScheduleMatchStatus.inProgress) +
-          _statusCount(nextStatus, ScheduleMatchStatus.inProgress);
-
-  return ScheduleProgressSummary(
-    schemaVersion: ScheduleProgressSummary.currentSchemaVersion,
-    scheduleType: scope.scheduleType,
-    generatedScheduleId: scope.generatedScheduleId,
-    totalMatchCount: totalMatchCount,
-    completedMatchCount: completedMatchCount,
-    inProgressMatchCount: inProgressMatchCount,
-    createdAt: currentSummary?.createdAt ?? now,
-    updatedAt: now,
-    revision: (currentSummary?.revision ?? 0) + 1,
-  );
-}
-
-int _statusCount(
-  ScheduleMatchStatus actual,
-  ScheduleMatchStatus target,
-) {
-  return actual == target ? 1 : 0;
 }

--- a/lib/features/schedule_progress/data/in_memory_schedule_progress_repository.dart
+++ b/lib/features/schedule_progress/data/in_memory_schedule_progress_repository.dart
@@ -2,8 +2,7 @@ import '../application/schedule_progress_repository.dart';
 import '../domain/schedule_progress_models.dart';
 import '../domain/schedule_progress_transition.dart';
 
-class InMemoryScheduleProgressRepository
-    implements ScheduleProgressRepository {
+class InMemoryScheduleProgressRepository implements ScheduleProgressRepository {
   InMemoryScheduleProgressRepository({
     DateTime Function()? clock,
   }) : _clock = clock ?? DateTime.now;

--- a/lib/features/schedule_progress/domain/schedule_progress_models.dart
+++ b/lib/features/schedule_progress/domain/schedule_progress_models.dart
@@ -1,0 +1,574 @@
+enum ScheduleProgressScheduleType {
+  doubles('doubles'),
+  team('team');
+
+  const ScheduleProgressScheduleType(this.value);
+
+  final String value;
+
+  static ScheduleProgressScheduleType fromValue(String value) {
+    return ScheduleProgressScheduleType.values.firstWhere(
+      (candidate) => candidate.value == value,
+      orElse: () => throw FormatException(
+        'invalid schedule progress schedule type: $value',
+      ),
+    );
+  }
+}
+
+enum ScheduleMatchStatus {
+  scheduled('scheduled'),
+  inProgress('in_progress'),
+  completed('completed');
+
+  const ScheduleMatchStatus(this.value);
+
+  final String value;
+
+  static ScheduleMatchStatus fromValue(String value) {
+    return ScheduleMatchStatus.values.firstWhere(
+      (candidate) => candidate.value == value,
+      orElse: () => throw FormatException(
+        'invalid schedule match status: $value',
+      ),
+    );
+  }
+}
+
+enum ScheduleOverallProgressStatus {
+  notStarted,
+  inProgress,
+  completed,
+}
+
+class ScheduleProgressScope {
+  ScheduleProgressScope({
+    required this.scheduleType,
+    required this.shareId,
+    required this.generatedScheduleId,
+  }) {
+    if (shareId.isEmpty) {
+      throw ArgumentError.value(shareId, 'shareId', 'must not be empty');
+    }
+    if (generatedScheduleId.isEmpty) {
+      throw ArgumentError.value(
+        generatedScheduleId,
+        'generatedScheduleId',
+        'must not be empty',
+      );
+    }
+  }
+
+  final ScheduleProgressScheduleType scheduleType;
+  final String shareId;
+  final String generatedScheduleId;
+
+  String get storageKey {
+    return '${scheduleType.value}:$shareId:$generatedScheduleId';
+  }
+}
+
+class ScheduleMatchKey implements Comparable<ScheduleMatchKey> {
+  ScheduleMatchKey({
+    required this.roundNo,
+    required this.courtNo,
+  }) {
+    if (roundNo <= 0) {
+      throw ArgumentError.value(roundNo, 'roundNo', 'must be positive');
+    }
+    if (courtNo <= 0) {
+      throw ArgumentError.value(courtNo, 'courtNo', 'must be positive');
+    }
+  }
+
+  final int roundNo;
+  final int courtNo;
+
+  String get value => 'r${roundNo}_c$courtNo';
+
+  @override
+  int compareTo(ScheduleMatchKey other) {
+    final roundComparison = roundNo.compareTo(other.roundNo);
+    if (roundComparison != 0) {
+      return roundComparison;
+    }
+
+    return courtNo.compareTo(other.courtNo);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ScheduleMatchKey &&
+        other.roundNo == roundNo &&
+        other.courtNo == courtNo;
+  }
+
+  @override
+  int get hashCode => Object.hash(roundNo, courtNo);
+
+  @override
+  String toString() => value;
+}
+
+class ScheduleMatchResultSummary {
+  ScheduleMatchResultSummary({
+    required this.type,
+    required List<int> sideScores,
+  }) : sideScores = List<int>.unmodifiable(sideScores) {
+    if (type.isEmpty) {
+      throw ArgumentError.value(type, 'type', 'must not be empty');
+    }
+    if (sideScores.length < 2) {
+      throw ArgumentError.value(
+        sideScores,
+        'sideScores',
+        'must contain at least two scores',
+      );
+    }
+    if (sideScores.any((score) => score < 0)) {
+      throw ArgumentError.value(
+        sideScores,
+        'sideScores',
+        'must not contain negative scores',
+      );
+    }
+  }
+
+  static const String simpleScoreType = 'simple_score';
+
+  factory ScheduleMatchResultSummary.simpleScore(List<int> sideScores) {
+    return ScheduleMatchResultSummary(
+      type: simpleScoreType,
+      sideScores: sideScores,
+    );
+  }
+
+  factory ScheduleMatchResultSummary.fromJson(Map<String, dynamic> json) {
+    return ScheduleMatchResultSummary(
+      type: _readString(json, 'type'),
+      sideScores: _readIntList(json, 'side_scores'),
+    );
+  }
+
+  final String type;
+  final List<int> sideScores;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'type': type,
+      'side_scores': List<int>.from(sideScores),
+    };
+  }
+}
+
+class ScheduleMatchProgress {
+  ScheduleMatchProgress({
+    required this.schemaVersion,
+    required this.scheduleType,
+    required this.generatedScheduleId,
+    required this.roundNo,
+    required this.courtNo,
+    required this.matchNo,
+    required this.status,
+    required this.result,
+    required this.note,
+    required this.startedAt,
+    required this.finishedAt,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.revision,
+  }) {
+    ScheduleMatchKey(roundNo: roundNo, courtNo: courtNo);
+    if (generatedScheduleId.isEmpty) {
+      throw ArgumentError.value(
+        generatedScheduleId,
+        'generatedScheduleId',
+        'must not be empty',
+      );
+    }
+    if (matchNo != null && matchNo! <= 0) {
+      throw ArgumentError.value(matchNo, 'matchNo', 'must be positive');
+    }
+    if (revision < 0) {
+      throw ArgumentError.value(revision, 'revision', 'must not be negative');
+    }
+    if (revision == 0 && (createdAt != null || updatedAt != null)) {
+      throw ArgumentError('unpersisted match must not have timestamps');
+    }
+    if (revision > 0 && (createdAt == null || updatedAt == null)) {
+      throw ArgumentError('persisted match must have timestamps');
+    }
+  }
+
+  static const int currentSchemaVersion = 1;
+
+  factory ScheduleMatchProgress.scheduledPlaceholder({
+    required ScheduleProgressScope scope,
+    required int roundNo,
+    required int courtNo,
+    int? matchNo,
+  }) {
+    return ScheduleMatchProgress(
+      schemaVersion: currentSchemaVersion,
+      scheduleType: scope.scheduleType,
+      generatedScheduleId: scope.generatedScheduleId,
+      roundNo: roundNo,
+      courtNo: courtNo,
+      matchNo: matchNo,
+      status: ScheduleMatchStatus.scheduled,
+      result: null,
+      note: '',
+      startedAt: null,
+      finishedAt: null,
+      createdAt: null,
+      updatedAt: null,
+      revision: 0,
+    );
+  }
+
+  factory ScheduleMatchProgress.fromJson(Map<String, dynamic> json) {
+    final resultJson = _readOptionalObject(json, 'result');
+
+    return ScheduleMatchProgress(
+      schemaVersion: _readInt(
+        json,
+        'schema_version',
+        defaultValue: currentSchemaVersion,
+      ),
+      scheduleType: ScheduleProgressScheduleType.fromValue(
+        _readString(json, 'schedule_type'),
+      ),
+      generatedScheduleId: _readString(json, 'generated_schedule_id'),
+      roundNo: _readInt(json, 'round_no'),
+      courtNo: _readInt(json, 'court_no'),
+      matchNo: _readOptionalInt(json, 'match_no'),
+      status: ScheduleMatchStatus.fromValue(_readString(json, 'status')),
+      result: resultJson == null
+          ? null
+          : ScheduleMatchResultSummary.fromJson(resultJson),
+      note: _readString(json, 'note', defaultValue: ''),
+      startedAt: _readOptionalDateTime(json, 'started_at'),
+      finishedAt: _readOptionalDateTime(json, 'finished_at'),
+      createdAt: _readDateTime(json, 'created_at'),
+      updatedAt: _readDateTime(json, 'updated_at'),
+      revision: _readInt(json, 'revision'),
+    );
+  }
+
+  final int schemaVersion;
+  final ScheduleProgressScheduleType scheduleType;
+  final String generatedScheduleId;
+  final int roundNo;
+  final int courtNo;
+  final int? matchNo;
+  final ScheduleMatchStatus status;
+  final ScheduleMatchResultSummary? result;
+  final String note;
+  final DateTime? startedAt;
+  final DateTime? finishedAt;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final int revision;
+
+  ScheduleMatchKey get key {
+    return ScheduleMatchKey(roundNo: roundNo, courtNo: courtNo);
+  }
+
+  bool get isPersisted => revision > 0;
+
+  Map<String, dynamic> toJson() {
+    final persistedCreatedAt = createdAt;
+    final persistedUpdatedAt = updatedAt;
+    if (!isPersisted ||
+        persistedCreatedAt == null ||
+        persistedUpdatedAt == null) {
+      throw StateError('unpersisted match progress cannot be serialized');
+    }
+
+    return <String, dynamic>{
+      'schema_version': schemaVersion,
+      'schedule_type': scheduleType.value,
+      'generated_schedule_id': generatedScheduleId,
+      'round_no': roundNo,
+      'court_no': courtNo,
+      'match_no': matchNo,
+      'status': status.value,
+      'result': result?.toJson(),
+      'note': note,
+      'started_at': startedAt?.toIso8601String(),
+      'finished_at': finishedAt?.toIso8601String(),
+      'created_at': persistedCreatedAt.toIso8601String(),
+      'updated_at': persistedUpdatedAt.toIso8601String(),
+      'revision': revision,
+    };
+  }
+}
+
+class ScheduleMatchProgressUpdate {
+  ScheduleMatchProgressUpdate({
+    required this.roundNo,
+    required this.courtNo,
+    this.matchNo,
+    required this.status,
+    this.result,
+    this.note = '',
+    this.startedAt,
+    this.finishedAt,
+  }) {
+    ScheduleMatchKey(roundNo: roundNo, courtNo: courtNo);
+    if (matchNo != null && matchNo! <= 0) {
+      throw ArgumentError.value(matchNo, 'matchNo', 'must be positive');
+    }
+  }
+
+  final int roundNo;
+  final int courtNo;
+  final int? matchNo;
+  final ScheduleMatchStatus status;
+  final ScheduleMatchResultSummary? result;
+  final String note;
+  final DateTime? startedAt;
+  final DateTime? finishedAt;
+
+  ScheduleMatchKey get key {
+    return ScheduleMatchKey(roundNo: roundNo, courtNo: courtNo);
+  }
+}
+
+class ScheduleProgressSummary {
+  ScheduleProgressSummary({
+    required this.schemaVersion,
+    required this.scheduleType,
+    required this.generatedScheduleId,
+    required this.totalMatchCount,
+    required this.completedMatchCount,
+    required this.inProgressMatchCount,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.revision,
+  }) {
+    if (generatedScheduleId.isEmpty) {
+      throw ArgumentError.value(
+        generatedScheduleId,
+        'generatedScheduleId',
+        'must not be empty',
+      );
+    }
+    if (totalMatchCount <= 0) {
+      throw ArgumentError.value(
+        totalMatchCount,
+        'totalMatchCount',
+        'must be positive',
+      );
+    }
+    if (completedMatchCount < 0) {
+      throw ArgumentError.value(
+        completedMatchCount,
+        'completedMatchCount',
+        'must not be negative',
+      );
+    }
+    if (inProgressMatchCount < 0) {
+      throw ArgumentError.value(
+        inProgressMatchCount,
+        'inProgressMatchCount',
+        'must not be negative',
+      );
+    }
+    if (completedMatchCount + inProgressMatchCount > totalMatchCount) {
+      throw ArgumentError(
+        'completed and in-progress counts must not exceed total count',
+      );
+    }
+    if (revision <= 0) {
+      throw ArgumentError.value(revision, 'revision', 'must be positive');
+    }
+  }
+
+  static const int currentSchemaVersion = 1;
+
+  factory ScheduleProgressSummary.fromJson(Map<String, dynamic> json) {
+    return ScheduleProgressSummary(
+      schemaVersion: _readInt(
+        json,
+        'schema_version',
+        defaultValue: currentSchemaVersion,
+      ),
+      scheduleType: ScheduleProgressScheduleType.fromValue(
+        _readString(json, 'schedule_type'),
+      ),
+      generatedScheduleId: _readString(json, 'generated_schedule_id'),
+      totalMatchCount: _readInt(json, 'total_match_count'),
+      completedMatchCount: _readInt(json, 'completed_match_count'),
+      inProgressMatchCount: _readInt(json, 'in_progress_match_count'),
+      createdAt: _readDateTime(json, 'created_at'),
+      updatedAt: _readDateTime(json, 'updated_at'),
+      revision: _readInt(json, 'revision'),
+    );
+  }
+
+  final int schemaVersion;
+  final ScheduleProgressScheduleType scheduleType;
+  final String generatedScheduleId;
+  final int totalMatchCount;
+  final int completedMatchCount;
+  final int inProgressMatchCount;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final int revision;
+
+  int get scheduledMatchCount {
+    return totalMatchCount - completedMatchCount - inProgressMatchCount;
+  }
+
+  ScheduleOverallProgressStatus get overallStatus {
+    if (completedMatchCount == totalMatchCount) {
+      return ScheduleOverallProgressStatus.completed;
+    }
+    if (completedMatchCount == 0 && inProgressMatchCount == 0) {
+      return ScheduleOverallProgressStatus.notStarted;
+    }
+
+    return ScheduleOverallProgressStatus.inProgress;
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'schema_version': schemaVersion,
+      'schedule_type': scheduleType.value,
+      'generated_schedule_id': generatedScheduleId,
+      'total_match_count': totalMatchCount,
+      'completed_match_count': completedMatchCount,
+      'in_progress_match_count': inProgressMatchCount,
+      'created_at': createdAt.toIso8601String(),
+      'updated_at': updatedAt.toIso8601String(),
+      'revision': revision,
+    };
+  }
+}
+
+String _readString(
+  Map<String, dynamic> json,
+  String key, {
+  String? defaultValue,
+}) {
+  final value = json[key];
+  if (value == null) {
+    if (defaultValue != null) {
+      return defaultValue;
+    }
+    throw FormatException('missing string: $key');
+  }
+
+  return value.toString();
+}
+
+int _readInt(
+  Map<String, dynamic> json,
+  String key, {
+  int? defaultValue,
+}) {
+  final value = _tryReadInt(json[key]);
+  if (value != null) {
+    return value;
+  }
+  if (defaultValue != null) {
+    return defaultValue;
+  }
+
+  throw FormatException('invalid integer: $key');
+}
+
+int? _readOptionalInt(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value == null) {
+    return null;
+  }
+
+  final parsed = _tryReadInt(value);
+  if (parsed == null) {
+    throw FormatException('invalid integer: $key');
+  }
+
+  return parsed;
+}
+
+int? _tryReadInt(dynamic value) {
+  if (value is int) {
+    return value;
+  }
+  if (value is num) {
+    return value.toInt();
+  }
+  if (value is String) {
+    return int.tryParse(value);
+  }
+
+  return null;
+}
+
+List<int> _readIntList(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value is! List) {
+    throw FormatException('invalid integer list: $key');
+  }
+
+  final result = <int>[];
+  for (final item in value) {
+    final parsed = _tryReadInt(item);
+    if (parsed == null) {
+      throw FormatException('invalid integer list item: $key');
+    }
+    result.add(parsed);
+  }
+
+  return result;
+}
+
+DateTime _readDateTime(Map<String, dynamic> json, String key) {
+  final value = _readOptionalDateTime(json, key);
+  if (value == null) {
+    throw FormatException('invalid datetime: $key');
+  }
+
+  return value;
+}
+
+DateTime? _readOptionalDateTime(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value == null) {
+    return null;
+  }
+  if (value is DateTime) {
+    return value;
+  }
+  if (value is String && value.isNotEmpty) {
+    return DateTime.parse(value);
+  }
+
+  try {
+    final dynamic converted = value.toDate();
+    if (converted is DateTime) {
+      return converted;
+    }
+  } catch (_) {
+    // Ignore non-Firestore timestamp-like values.
+  }
+
+  throw FormatException('invalid datetime: $key');
+}
+
+Map<String, dynamic>? _readOptionalObject(
+  Map<String, dynamic> json,
+  String key,
+) {
+  final value = json[key];
+  if (value == null) {
+    return null;
+  }
+  if (value is Map) {
+    return Map<String, dynamic>.from(value);
+  }
+
+  throw FormatException('invalid object: $key');
+}

--- a/lib/features/schedule_progress/domain/schedule_progress_transition.dart
+++ b/lib/features/schedule_progress/domain/schedule_progress_transition.dart
@@ -88,14 +88,12 @@ ScheduleProgressSummary buildUpdatedScheduleProgressSummary({
   required int totalMatchCount,
   required DateTime now,
 }) {
-  final completedMatchCount =
-      (currentSummary?.completedMatchCount ?? 0) -
-          _statusCount(previousStatus, ScheduleMatchStatus.completed) +
-          _statusCount(nextStatus, ScheduleMatchStatus.completed);
-  final inProgressMatchCount =
-      (currentSummary?.inProgressMatchCount ?? 0) -
-          _statusCount(previousStatus, ScheduleMatchStatus.inProgress) +
-          _statusCount(nextStatus, ScheduleMatchStatus.inProgress);
+  final completedMatchCount = (currentSummary?.completedMatchCount ?? 0) -
+      _statusCount(previousStatus, ScheduleMatchStatus.completed) +
+      _statusCount(nextStatus, ScheduleMatchStatus.completed);
+  final inProgressMatchCount = (currentSummary?.inProgressMatchCount ?? 0) -
+      _statusCount(previousStatus, ScheduleMatchStatus.inProgress) +
+      _statusCount(nextStatus, ScheduleMatchStatus.inProgress);
 
   return ScheduleProgressSummary(
     schemaVersion: ScheduleProgressSummary.currentSchemaVersion,

--- a/lib/features/schedule_progress/domain/schedule_progress_transition.dart
+++ b/lib/features/schedule_progress/domain/schedule_progress_transition.dart
@@ -1,0 +1,118 @@
+import 'schedule_progress_models.dart';
+
+void validateScheduleProgressTotalMatchCount(int totalMatchCount) {
+  if (totalMatchCount <= 0) {
+    throw ArgumentError.value(
+      totalMatchCount,
+      'totalMatchCount',
+      'must be positive',
+    );
+  }
+}
+
+void validateScheduleProgressSaveArguments({
+  required int totalMatchCount,
+  required int expectedRevision,
+}) {
+  validateScheduleProgressTotalMatchCount(totalMatchCount);
+  if (expectedRevision < 0) {
+    throw ArgumentError.value(
+      expectedRevision,
+      'expectedRevision',
+      'must not be negative',
+    );
+  }
+}
+
+void ensureScheduleProgressTotalMatchCount({
+  required ScheduleProgressSummary? summary,
+  required int totalMatchCount,
+}) {
+  if (summary != null && summary.totalMatchCount != totalMatchCount) {
+    throw StateError(
+      'total match count mismatch: '
+      'expected ${summary.totalMatchCount}, actual $totalMatchCount',
+    );
+  }
+}
+
+ScheduleProgressSummary createInitialScheduleProgressSummary({
+  required ScheduleProgressScope scope,
+  required int totalMatchCount,
+  required DateTime now,
+}) {
+  validateScheduleProgressTotalMatchCount(totalMatchCount);
+
+  return ScheduleProgressSummary(
+    schemaVersion: ScheduleProgressSummary.currentSchemaVersion,
+    scheduleType: scope.scheduleType,
+    generatedScheduleId: scope.generatedScheduleId,
+    totalMatchCount: totalMatchCount,
+    completedMatchCount: 0,
+    inProgressMatchCount: 0,
+    createdAt: now,
+    updatedAt: now,
+    revision: 1,
+  );
+}
+
+ScheduleMatchProgress buildSavedScheduleMatchProgress({
+  required ScheduleProgressScope scope,
+  required ScheduleMatchProgressUpdate update,
+  required ScheduleMatchProgress? current,
+  required DateTime now,
+}) {
+  return ScheduleMatchProgress(
+    schemaVersion: ScheduleMatchProgress.currentSchemaVersion,
+    scheduleType: scope.scheduleType,
+    generatedScheduleId: scope.generatedScheduleId,
+    roundNo: update.roundNo,
+    courtNo: update.courtNo,
+    matchNo: update.matchNo ?? current?.matchNo,
+    status: update.status,
+    result: update.result,
+    note: update.note,
+    startedAt: update.startedAt,
+    finishedAt: update.finishedAt,
+    createdAt: current?.createdAt ?? now,
+    updatedAt: now,
+    revision: (current?.revision ?? 0) + 1,
+  );
+}
+
+ScheduleProgressSummary buildUpdatedScheduleProgressSummary({
+  required ScheduleProgressScope scope,
+  required ScheduleProgressSummary? currentSummary,
+  required ScheduleMatchStatus previousStatus,
+  required ScheduleMatchStatus nextStatus,
+  required int totalMatchCount,
+  required DateTime now,
+}) {
+  final completedMatchCount =
+      (currentSummary?.completedMatchCount ?? 0) -
+          _statusCount(previousStatus, ScheduleMatchStatus.completed) +
+          _statusCount(nextStatus, ScheduleMatchStatus.completed);
+  final inProgressMatchCount =
+      (currentSummary?.inProgressMatchCount ?? 0) -
+          _statusCount(previousStatus, ScheduleMatchStatus.inProgress) +
+          _statusCount(nextStatus, ScheduleMatchStatus.inProgress);
+
+  return ScheduleProgressSummary(
+    schemaVersion: ScheduleProgressSummary.currentSchemaVersion,
+    scheduleType: scope.scheduleType,
+    generatedScheduleId: scope.generatedScheduleId,
+    totalMatchCount: totalMatchCount,
+    completedMatchCount: completedMatchCount,
+    inProgressMatchCount: inProgressMatchCount,
+    createdAt: currentSummary?.createdAt ?? now,
+    updatedAt: now,
+    revision: (currentSummary?.revision ?? 0) + 1,
+  );
+}
+
+int _statusCount(
+  ScheduleMatchStatus actual,
+  ScheduleMatchStatus target,
+) {
+  return actual == target ? 1 : 0;
+}

--- a/lib/shared/repositories/app_repositories.dart
+++ b/lib/shared/repositories/app_repositories.dart
@@ -4,6 +4,9 @@ import 'package:srp_lanske/app/config/app_config.dart';
 import 'package:srp_lanske/features/doubles_scheduler/application/event_repository.dart';
 import 'package:srp_lanske/features/doubles_scheduler/data/firestore_event_repository.dart';
 import 'package:srp_lanske/features/doubles_scheduler/data/in_memory_event_repository.dart';
+import 'package:srp_lanske/features/schedule_progress/application/schedule_progress_repository.dart';
+import 'package:srp_lanske/features/schedule_progress/data/firestore_schedule_progress_repository.dart';
+import 'package:srp_lanske/features/schedule_progress/data/in_memory_schedule_progress_repository.dart';
 import 'package:srp_lanske/features/team_scheduler/application/team_schedule_repository.dart';
 import 'package:srp_lanske/features/team_scheduler/data/firestore_team_schedule_repository.dart';
 import 'package:srp_lanske/features/team_scheduler/data/in_memory_team_schedule_repository.dart';
@@ -12,6 +15,9 @@ final EventRepository appEventRepository = _createEventRepository();
 
 final TeamScheduleRepository appTeamScheduleRepository =
     _createTeamScheduleRepository();
+
+final ScheduleProgressRepository appScheduleProgressRepository =
+    _createScheduleProgressRepository();
 
 EventRepository _createEventRepository() {
   if (AppConfig.usesFirestoreEventRepository) {
@@ -27,4 +33,12 @@ TeamScheduleRepository _createTeamScheduleRepository() {
   }
 
   return InMemoryTeamScheduleRepository();
+}
+
+ScheduleProgressRepository _createScheduleProgressRepository() {
+  if (AppConfig.usesFirestoreEventRepository) {
+    return FirestoreScheduleProgressRepository();
+  }
+
+  return InMemoryScheduleProgressRepository();
 }

--- a/test/features/schedule_progress/application/schedule_progress_repository_contract.dart
+++ b/test/features/schedule_progress/application/schedule_progress_repository_contract.dart
@@ -1,0 +1,288 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:srp_lanske/features/schedule_progress/application/schedule_progress_repository.dart';
+import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_models.dart';
+
+typedef ScheduleProgressRepositoryFactory = ScheduleProgressRepository Function();
+
+void runScheduleProgressRepositoryContractTests({
+  required String name,
+  required ScheduleProgressRepositoryFactory createRepository,
+}) {
+  group(name, () {
+    ScheduleProgressScope buildScope({
+      ScheduleProgressScheduleType scheduleType =
+          ScheduleProgressScheduleType.doubles,
+      String shareId = 'PUBLIC01',
+      String generatedScheduleId = 'generated-1',
+    }) {
+      return ScheduleProgressScope(
+        scheduleType: scheduleType,
+        shareId: shareId,
+        generatedScheduleId: generatedScheduleId,
+      );
+    }
+
+    ScheduleMatchProgressUpdate buildUpdate({
+      int roundNo = 1,
+      int courtNo = 1,
+      int? matchNo,
+      ScheduleMatchStatus status = ScheduleMatchStatus.inProgress,
+      ScheduleMatchResultSummary? result,
+      String note = '',
+    }) {
+      return ScheduleMatchProgressUpdate(
+        roundNo: roundNo,
+        courtNo: courtNo,
+        matchNo: matchNo,
+        status: status,
+        result: result,
+        note: note,
+      );
+    }
+
+    test('initializes not-started progress summary', () async {
+      final repository = createRepository();
+      final scope = buildScope();
+
+      final summary = await repository.ensureSummary(
+        scope: scope,
+        totalMatchCount: 10,
+      );
+      final repeated = await repository.ensureSummary(
+        scope: scope,
+        totalMatchCount: 10,
+      );
+
+      expect(summary.totalMatchCount, 10);
+      expect(summary.completedMatchCount, 0);
+      expect(summary.inProgressMatchCount, 0);
+      expect(summary.scheduledMatchCount, 10);
+      expect(summary.overallStatus, ScheduleOverallProgressStatus.notStarted);
+      expect(summary.revision, 1);
+      expect(repeated.revision, 1);
+    });
+
+    test('returns scheduled placeholder when match is not saved', () async {
+      final repository = createRepository();
+      final scope = buildScope();
+
+      final match = await repository.findMatch(
+        scope: scope,
+        roundNo: 2,
+        courtNo: 1,
+      );
+
+      expect(match.status, ScheduleMatchStatus.scheduled);
+      expect(match.revision, 0);
+      expect(match.isPersisted, isFalse);
+      expect(match.key.value, 'r2_c1');
+      expect(await repository.findSummary(scope), isNull);
+    });
+
+    test('saves match and creates progress summary', () async {
+      final repository = createRepository();
+      final scope = buildScope();
+
+      final saved = await repository.saveMatch(
+        scope: scope,
+        update: buildUpdate(note: '開始'),
+        totalMatchCount: 10,
+        expectedRevision: 0,
+      );
+
+      expect(saved.status, ScheduleMatchStatus.inProgress);
+      expect(saved.note, '開始');
+      expect(saved.revision, 1);
+      expect(saved.isPersisted, isTrue);
+
+      final summary = await repository.findSummary(scope);
+      expect(summary, isNotNull);
+      expect(summary!.totalMatchCount, 10);
+      expect(summary.completedMatchCount, 0);
+      expect(summary.inProgressMatchCount, 1);
+      expect(summary.scheduledMatchCount, 9);
+      expect(summary.overallStatus, ScheduleOverallProgressStatus.inProgress);
+      expect(summary.revision, 1);
+    });
+
+    test('updates match and summary counts', () async {
+      final repository = createRepository();
+      final scope = buildScope();
+
+      final started = await repository.saveMatch(
+        scope: scope,
+        update: buildUpdate(),
+        totalMatchCount: 10,
+        expectedRevision: 0,
+      );
+      final completed = await repository.saveMatch(
+        scope: scope,
+        update: buildUpdate(
+          status: ScheduleMatchStatus.completed,
+          result: ScheduleMatchResultSummary.simpleScore([4, 2]),
+        ),
+        totalMatchCount: 10,
+        expectedRevision: started.revision,
+      );
+
+      expect(completed.status, ScheduleMatchStatus.completed);
+      expect(completed.result!.sideScores, [4, 2]);
+      expect(completed.revision, 2);
+      expect(completed.createdAt, started.createdAt);
+
+      final summary = await repository.findSummary(scope);
+      expect(summary!.completedMatchCount, 1);
+      expect(summary.inProgressMatchCount, 0);
+      expect(summary.scheduledMatchCount, 9);
+      expect(summary.revision, 2);
+    });
+
+    test('rejects stale revision without overwriting match', () async {
+      final repository = createRepository();
+      final scope = buildScope();
+
+      final saved = await repository.saveMatch(
+        scope: scope,
+        update: buildUpdate(),
+        totalMatchCount: 10,
+        expectedRevision: 0,
+      );
+
+      expect(
+        () => repository.saveMatch(
+          scope: scope,
+          update: buildUpdate(
+            status: ScheduleMatchStatus.completed,
+          ),
+          totalMatchCount: 10,
+          expectedRevision: 0,
+        ),
+        throwsA(
+          isA<ScheduleProgressConflictException>()
+              .having(
+                (error) => error.expectedRevision,
+                'expectedRevision',
+                0,
+              )
+              .having(
+                (error) => error.actualRevision,
+                'actualRevision',
+                saved.revision,
+              ),
+        ),
+      );
+
+      final found = await repository.findMatch(
+        scope: scope,
+        roundNo: 1,
+        courtNo: 1,
+      );
+      expect(found.status, ScheduleMatchStatus.inProgress);
+      expect(found.revision, 1);
+    });
+
+    test('tracks multiple matches and lists them in display order', () async {
+      final repository = createRepository();
+      final scope = buildScope();
+
+      await repository.saveMatch(
+        scope: scope,
+        update: buildUpdate(
+          roundNo: 2,
+          courtNo: 1,
+          status: ScheduleMatchStatus.completed,
+        ),
+        totalMatchCount: 4,
+        expectedRevision: 0,
+      );
+      await repository.saveMatch(
+        scope: scope,
+        update: buildUpdate(
+          roundNo: 1,
+          courtNo: 2,
+          status: ScheduleMatchStatus.inProgress,
+        ),
+        totalMatchCount: 4,
+        expectedRevision: 0,
+      );
+      await repository.saveMatch(
+        scope: scope,
+        update: buildUpdate(
+          roundNo: 1,
+          courtNo: 1,
+          status: ScheduleMatchStatus.completed,
+        ),
+        totalMatchCount: 4,
+        expectedRevision: 0,
+      );
+
+      final matches = await repository.listMatches(scope);
+      expect(matches.map((match) => match.key.value), [
+        'r1_c1',
+        'r1_c2',
+        'r2_c1',
+      ]);
+
+      final summary = await repository.findSummary(scope);
+      expect(summary!.completedMatchCount, 2);
+      expect(summary.inProgressMatchCount, 1);
+      expect(summary.scheduledMatchCount, 1);
+    });
+
+    test('keeps doubles, team, and generated schedules separated', () async {
+      final repository = createRepository();
+      final doublesScope = buildScope();
+      final teamScope = buildScope(
+        scheduleType: ScheduleProgressScheduleType.team,
+      );
+      final regeneratedScope = buildScope(
+        generatedScheduleId: 'generated-2',
+      );
+
+      await repository.saveMatch(
+        scope: doublesScope,
+        update: buildUpdate(status: ScheduleMatchStatus.completed),
+        totalMatchCount: 5,
+        expectedRevision: 0,
+      );
+
+      final teamMatch = await repository.findMatch(
+        scope: teamScope,
+        roundNo: 1,
+        courtNo: 1,
+      );
+      final regeneratedMatch = await repository.findMatch(
+        scope: regeneratedScope,
+        roundNo: 1,
+        courtNo: 1,
+      );
+
+      expect(teamMatch.revision, 0);
+      expect(regeneratedMatch.revision, 0);
+      expect(await repository.findSummary(teamScope), isNull);
+      expect(await repository.findSummary(regeneratedScope), isNull);
+    });
+
+    test('rejects a changed total match count for the same schedule', () async {
+      final repository = createRepository();
+      final scope = buildScope();
+
+      await repository.saveMatch(
+        scope: scope,
+        update: buildUpdate(),
+        totalMatchCount: 10,
+        expectedRevision: 0,
+      );
+
+      expect(
+        () => repository.saveMatch(
+          scope: scope,
+          update: buildUpdate(roundNo: 1, courtNo: 2),
+          totalMatchCount: 11,
+          expectedRevision: 0,
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+}

--- a/test/features/schedule_progress/application/schedule_progress_repository_contract.dart
+++ b/test/features/schedule_progress/application/schedule_progress_repository_contract.dart
@@ -2,7 +2,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:srp_lanske/features/schedule_progress/application/schedule_progress_repository.dart';
 import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_models.dart';
 
-typedef ScheduleProgressRepositoryFactory = ScheduleProgressRepository Function();
+typedef ScheduleProgressRepositoryFactory = ScheduleProgressRepository
+    Function();
 
 void runScheduleProgressRepositoryContractTests({
   required String name,

--- a/test/features/schedule_progress/data/in_memory_schedule_progress_repository_test.dart
+++ b/test/features/schedule_progress/data/in_memory_schedule_progress_repository_test.dart
@@ -1,0 +1,10 @@
+import 'package:srp_lanske/features/schedule_progress/data/in_memory_schedule_progress_repository.dart';
+
+import '../application/schedule_progress_repository_contract.dart';
+
+void main() {
+  runScheduleProgressRepositoryContractTests(
+    name: 'InMemoryScheduleProgressRepository',
+    createRepository: InMemoryScheduleProgressRepository.new,
+  );
+}

--- a/test/features/schedule_progress/domain/schedule_progress_models_test.dart
+++ b/test/features/schedule_progress/domain/schedule_progress_models_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_models.dart';
+
+void main() {
+  group('ScheduleMatchResultSummary', () {
+    test('round-trips simple score json', () {
+      final result = ScheduleMatchResultSummary.simpleScore([4, 2]);
+
+      final restored = ScheduleMatchResultSummary.fromJson(result.toJson());
+
+      expect(restored.type, ScheduleMatchResultSummary.simpleScoreType);
+      expect(restored.sideScores, [4, 2]);
+    });
+
+    test('supports more than two sides for future team schedules', () {
+      final result = ScheduleMatchResultSummary.simpleScore([3, 2, 1]);
+
+      expect(result.sideScores, [3, 2, 1]);
+    });
+
+    test('rejects negative scores', () {
+      expect(
+        () => ScheduleMatchResultSummary.simpleScore([4, -1]),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('ScheduleMatchProgress', () {
+    test('creates unpersisted scheduled placeholder', () {
+      final scope = ScheduleProgressScope(
+        scheduleType: ScheduleProgressScheduleType.doubles,
+        shareId: 'PUBLIC01',
+        generatedScheduleId: 'generated-1',
+      );
+
+      final match = ScheduleMatchProgress.scheduledPlaceholder(
+        scope: scope,
+        roundNo: 2,
+        courtNo: 3,
+      );
+
+      expect(match.status, ScheduleMatchStatus.scheduled);
+      expect(match.key.value, 'r2_c3');
+      expect(match.revision, 0);
+      expect(match.createdAt, isNull);
+      expect(match.updatedAt, isNull);
+      expect(match.isPersisted, isFalse);
+      expect(match.toJson, throwsStateError);
+    });
+
+    test('round-trips persisted match json', () {
+      final createdAt = DateTime.utc(2026, 7, 30, 1);
+      final updatedAt = DateTime.utc(2026, 7, 30, 2);
+      final match = ScheduleMatchProgress(
+        schemaVersion: ScheduleMatchProgress.currentSchemaVersion,
+        scheduleType: ScheduleProgressScheduleType.team,
+        generatedScheduleId: 'generated-1',
+        roundNo: 1,
+        courtNo: 2,
+        matchNo: 7,
+        status: ScheduleMatchStatus.completed,
+        result: ScheduleMatchResultSummary.simpleScore([5, 3]),
+        note: '決勝',
+        startedAt: createdAt,
+        finishedAt: updatedAt,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+        revision: 2,
+      );
+
+      final restored = ScheduleMatchProgress.fromJson(match.toJson());
+
+      expect(restored.scheduleType, ScheduleProgressScheduleType.team);
+      expect(restored.generatedScheduleId, 'generated-1');
+      expect(restored.key.value, 'r1_c2');
+      expect(restored.matchNo, 7);
+      expect(restored.status, ScheduleMatchStatus.completed);
+      expect(restored.result!.sideScores, [5, 3]);
+      expect(restored.note, '決勝');
+      expect(restored.startedAt, createdAt);
+      expect(restored.finishedAt, updatedAt);
+      expect(restored.createdAt, createdAt);
+      expect(restored.updatedAt, updatedAt);
+      expect(restored.revision, 2);
+    });
+  });
+
+  group('ScheduleProgressSummary', () {
+    ScheduleProgressSummary buildSummary({
+      int total = 10,
+      int completed = 0,
+      int inProgress = 0,
+    }) {
+      final now = DateTime.utc(2026, 7, 30);
+      return ScheduleProgressSummary(
+        schemaVersion: ScheduleProgressSummary.currentSchemaVersion,
+        scheduleType: ScheduleProgressScheduleType.doubles,
+        generatedScheduleId: 'generated-1',
+        totalMatchCount: total,
+        completedMatchCount: completed,
+        inProgressMatchCount: inProgress,
+        createdAt: now,
+        updatedAt: now,
+        revision: 1,
+      );
+    }
+
+    test('derives overall status and scheduled count', () {
+      final notStarted = buildSummary();
+      final inProgress = buildSummary(completed: 2, inProgress: 1);
+      final completed = buildSummary(completed: 10);
+
+      expect(
+        notStarted.overallStatus,
+        ScheduleOverallProgressStatus.notStarted,
+      );
+      expect(notStarted.scheduledMatchCount, 10);
+      expect(
+        inProgress.overallStatus,
+        ScheduleOverallProgressStatus.inProgress,
+      );
+      expect(inProgress.scheduledMatchCount, 7);
+      expect(
+        completed.overallStatus,
+        ScheduleOverallProgressStatus.completed,
+      );
+      expect(completed.scheduledMatchCount, 0);
+    });
+
+    test('round-trips summary json', () {
+      final summary = buildSummary(completed: 4, inProgress: 2);
+
+      final restored = ScheduleProgressSummary.fromJson(summary.toJson());
+
+      expect(restored.totalMatchCount, 10);
+      expect(restored.completedMatchCount, 4);
+      expect(restored.inProgressMatchCount, 2);
+      expect(restored.revision, 1);
+    });
+  });
+}

--- a/test/features/schedule_progress/domain/schedule_progress_transition_test.dart
+++ b/test/features/schedule_progress/domain/schedule_progress_transition_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_models.dart';
+import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_transition.dart';
+
+void main() {
+  final scope = ScheduleProgressScope(
+    scheduleType: ScheduleProgressScheduleType.doubles,
+    shareId: 'PUBLIC01',
+    generatedScheduleId: 'generated-1',
+  );
+
+  test('creates initial not-started summary', () {
+    final now = DateTime.utc(2026, 7, 30);
+
+    final summary = createInitialScheduleProgressSummary(
+      scope: scope,
+      totalMatchCount: 10,
+      now: now,
+    );
+
+    expect(summary.completedMatchCount, 0);
+    expect(summary.inProgressMatchCount, 0);
+    expect(summary.scheduledMatchCount, 10);
+    expect(summary.overallStatus, ScheduleOverallProgressStatus.notStarted);
+    expect(summary.createdAt, now);
+    expect(summary.updatedAt, now);
+    expect(summary.revision, 1);
+  });
+
+  test('preserves match identity data and increments revision', () {
+    final createdAt = DateTime.utc(2026, 7, 30, 1);
+    final updatedAt = DateTime.utc(2026, 7, 30, 2);
+    final current = ScheduleMatchProgress(
+      schemaVersion: ScheduleMatchProgress.currentSchemaVersion,
+      scheduleType: ScheduleProgressScheduleType.team,
+      generatedScheduleId: 'generated-1',
+      roundNo: 1,
+      courtNo: 1,
+      matchNo: 5,
+      status: ScheduleMatchStatus.inProgress,
+      result: null,
+      note: '',
+      startedAt: createdAt,
+      finishedAt: null,
+      createdAt: createdAt,
+      updatedAt: createdAt,
+      revision: 1,
+    );
+
+    final next = buildSavedScheduleMatchProgress(
+      scope: ScheduleProgressScope(
+        scheduleType: ScheduleProgressScheduleType.team,
+        shareId: 'TEAM0001',
+        generatedScheduleId: 'generated-1',
+      ),
+      update: ScheduleMatchProgressUpdate(
+        roundNo: 1,
+        courtNo: 1,
+        status: ScheduleMatchStatus.completed,
+        result: ScheduleMatchResultSummary.simpleScore([4, 2]),
+        finishedAt: updatedAt,
+      ),
+      current: current,
+      now: updatedAt,
+    );
+
+    expect(next.matchNo, 5);
+    expect(next.createdAt, createdAt);
+    expect(next.updatedAt, updatedAt);
+    expect(next.revision, 2);
+  });
+
+  test('decrements completed count when match returns to scheduled', () {
+    final createdAt = DateTime.utc(2026, 7, 30, 1);
+    final now = DateTime.utc(2026, 7, 30, 2);
+    final currentSummary = ScheduleProgressSummary(
+      schemaVersion: ScheduleProgressSummary.currentSchemaVersion,
+      scheduleType: scope.scheduleType,
+      generatedScheduleId: scope.generatedScheduleId,
+      totalMatchCount: 10,
+      completedMatchCount: 3,
+      inProgressMatchCount: 1,
+      createdAt: createdAt,
+      updatedAt: createdAt,
+      revision: 4,
+    );
+
+    final next = buildUpdatedScheduleProgressSummary(
+      scope: scope,
+      currentSummary: currentSummary,
+      previousStatus: ScheduleMatchStatus.completed,
+      nextStatus: ScheduleMatchStatus.scheduled,
+      totalMatchCount: 10,
+      now: now,
+    );
+
+    expect(next.completedMatchCount, 2);
+    expect(next.inProgressMatchCount, 1);
+    expect(next.scheduledMatchCount, 7);
+    expect(next.createdAt, createdAt);
+    expect(next.updatedAt, now);
+    expect(next.revision, 5);
+  });
+}


### PR DESCRIPTION
## 概要

ダブルス／チームの双方で利用する、試合単位の進行状態・最終結果要約・進行summaryの共通モデルと保存基盤を追加しました。

競技固有の詳細結果は共通化せず、以下のみを共通領域として扱います。

* 試合状態
* 最終スコアなどの結果要約
* 終了済み／進行中試合数のsummary
* 試合を識別するround／court情報
* 同一試合の古い情報による上書き防止

Closes #143

## 変更内容

### 共通モデル

`schedule_progress` featureを追加し、以下のモデルを定義しました。

* `ScheduleProgressScope`
* `ScheduleMatchKey`
* `ScheduleMatchStatus`
* `ScheduleMatchResultSummary`
* `ScheduleMatchProgress`
* `ScheduleMatchProgressUpdate`
* `ScheduleProgressSummary`

MVPの試合状態は以下です。

```txt
scheduled
in_progress
completed
```

試合documentが存在しない場合は、`scheduled / revision: 0` の未保存プレースホルダーとして扱います。

最終結果要約は、以下の形式を扱います。

```yaml
result:
  type: simple_score
  side_scores: [4, 2]
```

### 保存先

ダブルスとチームの親documentを直接更新せず、生成済み対戦表単位のsubcollectionへ保存します。

```txt
events/{publicId}/schedule_progress/{generatedScheduleId}
events/{publicId}/schedule_progress/{generatedScheduleId}/matches/{matchKey}

team_schedules/{shareId}/schedule_progress/{generatedScheduleId}
team_schedules/{shareId}/schedule_progress/{generatedScheduleId}/matches/{matchKey}
```

試合キーは以下の形式です。

```txt
r{roundNo}_c{courtNo}
```

### Repository

共通の `ScheduleProgressRepository` を追加し、以下の実装を用意しました。

* `FirestoreScheduleProgressRepository`
* `InMemoryScheduleProgressRepository`

以下の操作に対応しています。

* 進行summaryの初期化
* 進行summaryの取得
* 保存済み試合状態の一覧取得
* 試合状態の取得
* 試合状態・最終結果要約の保存

アプリ設定に応じてFirestore／in-memory実装を切り替えるよう、`app_repositories.dart`へ登録しました。

### 進行summary

対戦表単位で以下を保存します。

* 総試合数
* 完了済み試合数
* 進行中試合数
* revision
* 作成日時／更新日時

試合状態の変更時に、試合documentとsummaryを同時に更新します。

全体状態はsummaryから以下のように導出します。

* 未開始
* 進行中
* 全試合終了

### 複数端末編集

Firestoreではtransactionを使用し、試合documentとsummaryを同時に更新します。

同一試合の更新には `revision` による楽観ロックを使用し、古いrevisionからの保存は `ScheduleProgressConflictException` として拒否します。

異なる試合の同時更新は、Firestore transactionの再試行によって処理します。

### Firestore Rules

以下のsubcollectionについて、read／create／updateを許可しました。

* `events/*/schedule_progress/*`
* `events/*/schedule_progress/*/matches/*`
* `team_schedules/*/schedule_progress/*`
* `team_schedules/*/schedule_progress/*/matches/*`

deleteは既存方針と同様に許可していません。

## テスト

以下を確認するテストを追加しました。

* モデルのJSON変換
* 試合キーの生成と並び順
* 未保存試合の `scheduled` 扱い
* summaryの初期化
* 状態変更に伴う完了数／進行中数の更新
* 完了済みから未開始へ戻した場合のsummary更新
* 古いrevisionからの上書き拒否
* 総試合数不一致の拒否
* ダブルス／チーム間のデータ分離
* generated scheduleごとのデータ分離
* 複数試合の一覧取得

実行結果:

```txt
dart format lib/ test/ : OK
flutter analyze        : OK
flutter test           : OK
```

アプリを起動し、既存画面に影響がないことも確認済みです。

## 今回扱わないもの

* ダブルス画面への状態・スコア入力UI
* チーム画面への共通進行モデル接続
* ボッチャのエンド別スコアや投球順ログの移行
* 進行中・次対戦の画面表示
* リアルタイム同期
* 高度な試合状態
* 勝率・ランキングなどの集計

これらは後続Issueで対応します。

## Docs

ユーザー向けの操作や画面に変更がないため、ユーザー向けdocsは更新していません。

共通進行基盤の具体的な利用方法は、後続の画面接続Issueで実装と合わせて整理します。
