### PR TITLE
feat: refresh doubles schedule state during user operations refs #144

### DIFF
--- a/lib/features/doubles_scheduler/application/doubles_schedule_refresh_service.dart
+++ b/lib/features/doubles_scheduler/application/doubles_schedule_refresh_service.dart
@@ -36,14 +36,14 @@ class DoublesScheduleRefreshSnapshot {
     required List<ScheduleMatchProgress> matches,
   }) {
     final generatedScheduleId = aggregate.event.displayGeneratedScheduleId;
-    final progressScope = generatedScheduleId == null ||
-            generatedScheduleId.isEmpty
-        ? null
-        : ScheduleProgressScope(
-            scheduleType: ScheduleProgressScheduleType.doubles,
-            shareId: aggregate.event.publicId,
-            generatedScheduleId: generatedScheduleId,
-          );
+    final progressScope =
+        generatedScheduleId == null || generatedScheduleId.isEmpty
+            ? null
+            : ScheduleProgressScope(
+                scheduleType: ScheduleProgressScheduleType.doubles,
+                shareId: aggregate.event.publicId,
+                generatedScheduleId: generatedScheduleId,
+              );
 
     return DoublesScheduleRefreshSnapshot(
       aggregate: aggregate,

--- a/lib/features/doubles_scheduler/application/doubles_schedule_refresh_service.dart
+++ b/lib/features/doubles_scheduler/application/doubles_schedule_refresh_service.dart
@@ -118,8 +118,12 @@ class DoublesScheduleRefreshService {
     final currentProgressRevision = current?.progressSummary?.revision;
     final eventChanged = current == null ||
         current.aggregate.event.revision != aggregate.event.revision;
+    final scheduleResponseMissing = generatedScheduleId != null &&
+        generatedScheduleId.isNotEmpty &&
+        currentScheduleResponse == null;
     final scheduleChanged = current == null ||
-        currentGeneratedScheduleId != generatedScheduleId;
+        currentGeneratedScheduleId != generatedScheduleId ||
+        scheduleResponseMissing;
 
     Map<String, dynamic>? scheduleResponse;
     ScheduleProgressScope? progressScope;

--- a/lib/features/doubles_scheduler/application/doubles_schedule_refresh_service.dart
+++ b/lib/features/doubles_scheduler/application/doubles_schedule_refresh_service.dart
@@ -114,6 +114,8 @@ class DoublesScheduleRefreshService {
 
     final generatedScheduleId = aggregate.event.displayGeneratedScheduleId;
     final currentGeneratedScheduleId = current?.generatedScheduleId;
+    final currentScheduleResponse = current?.scheduleResponse;
+    final currentProgressRevision = current?.progressSummary?.revision;
     final eventChanged = current == null ||
         current.aggregate.event.revision != aggregate.event.revision;
     final scheduleChanged = current == null ||
@@ -126,8 +128,8 @@ class DoublesScheduleRefreshService {
     var progressChanged = false;
 
     if (generatedScheduleId != null && generatedScheduleId.isNotEmpty) {
-      scheduleResponse = !scheduleChanged && current?.scheduleResponse != null
-          ? current!.scheduleResponse
+      scheduleResponse = !scheduleChanged && currentScheduleResponse != null
+          ? currentScheduleResponse
           : await _loadGeneratedSchedule(generatedScheduleId);
 
       progressScope = ScheduleProgressScope(
@@ -140,7 +142,7 @@ class DoublesScheduleRefreshService {
       final sameProgressScope =
           current?.progressScope?.storageKey == progressScope.storageKey;
       final sameProgressRevision = sameProgressScope &&
-          current?.progressSummary?.revision == progressSummary?.revision;
+          currentProgressRevision == progressSummary?.revision;
 
       if (progressSummary == null) {
         matches = const [];
@@ -152,7 +154,7 @@ class DoublesScheduleRefreshService {
 
       progressChanged = current == null ||
           !sameProgressScope ||
-          current.progressSummary?.revision != progressSummary?.revision;
+          currentProgressRevision != progressSummary?.revision;
     } else {
       progressChanged = current?.progressSummary != null ||
           (current?.matches.isNotEmpty ?? false);

--- a/lib/features/doubles_scheduler/application/doubles_schedule_refresh_service.dart
+++ b/lib/features/doubles_scheduler/application/doubles_schedule_refresh_service.dart
@@ -1,0 +1,186 @@
+import 'package:srp_lanske/features/schedule_progress/application/schedule_progress_repository.dart';
+import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_models.dart';
+
+import '../domain/saved_event_models.dart';
+import 'event_repository.dart';
+
+typedef GeneratedScheduleByIdLoader = Future<Map<String, dynamic>> Function(
+  String generatedScheduleId,
+);
+
+class DoublesScheduleNotFoundException implements Exception {
+  const DoublesScheduleNotFoundException(this.publicId);
+
+  final String publicId;
+
+  @override
+  String toString() => 'DoublesScheduleNotFoundException($publicId)';
+}
+
+class DoublesScheduleRefreshSnapshot {
+  DoublesScheduleRefreshSnapshot({
+    required this.aggregate,
+    required this.scheduleResponse,
+    required this.progressScope,
+    required this.progressSummary,
+    required List<ScheduleMatchProgress> matches,
+    required this.eventChanged,
+    required this.scheduleChanged,
+    required this.progressChanged,
+  }) : matches = List<ScheduleMatchProgress>.unmodifiable(matches);
+
+  factory DoublesScheduleRefreshSnapshot.fromCurrentState({
+    required SavedEventAggregate aggregate,
+    required Map<String, dynamic>? scheduleResponse,
+    required ScheduleProgressSummary? progressSummary,
+    required List<ScheduleMatchProgress> matches,
+  }) {
+    final generatedScheduleId = aggregate.event.displayGeneratedScheduleId;
+    final progressScope = generatedScheduleId == null ||
+            generatedScheduleId.isEmpty
+        ? null
+        : ScheduleProgressScope(
+            scheduleType: ScheduleProgressScheduleType.doubles,
+            shareId: aggregate.event.publicId,
+            generatedScheduleId: generatedScheduleId,
+          );
+
+    return DoublesScheduleRefreshSnapshot(
+      aggregate: aggregate,
+      scheduleResponse: scheduleResponse,
+      progressScope: progressScope,
+      progressSummary: progressSummary,
+      matches: matches,
+      eventChanged: false,
+      scheduleChanged: false,
+      progressChanged: false,
+    );
+  }
+
+  final SavedEventAggregate aggregate;
+  final Map<String, dynamic>? scheduleResponse;
+  final ScheduleProgressScope? progressScope;
+  final ScheduleProgressSummary? progressSummary;
+  final List<ScheduleMatchProgress> matches;
+  final bool eventChanged;
+  final bool scheduleChanged;
+  final bool progressChanged;
+
+  String? get generatedScheduleId {
+    return aggregate.event.displayGeneratedScheduleId;
+  }
+
+  bool get hasChanges {
+    return eventChanged || scheduleChanged || progressChanged;
+  }
+
+  String get progressText {
+    final summary = progressSummary;
+    if (summary == null) {
+      return '- / -';
+    }
+
+    return '${summary.completedMatchCount} / ${summary.totalMatchCount}';
+  }
+
+  Map<String, ScheduleMatchProgress> get matchesByKey {
+    return Map<String, ScheduleMatchProgress>.unmodifiable({
+      for (final match in matches) match.key.value: match,
+    });
+  }
+}
+
+class DoublesScheduleRefreshService {
+  DoublesScheduleRefreshService({
+    required EventRepository eventRepository,
+    required ScheduleProgressRepository progressRepository,
+    required GeneratedScheduleByIdLoader loadGeneratedSchedule,
+  })  : _eventRepository = eventRepository,
+        _progressRepository = progressRepository,
+        _loadGeneratedSchedule = loadGeneratedSchedule;
+
+  final EventRepository _eventRepository;
+  final ScheduleProgressRepository _progressRepository;
+  final GeneratedScheduleByIdLoader _loadGeneratedSchedule;
+
+  Future<DoublesScheduleRefreshSnapshot> loadLatestByPublicId({
+    required String publicId,
+    DoublesScheduleRefreshSnapshot? current,
+  }) async {
+    final aggregate = await _eventRepository.findByPublicId(publicId);
+    if (aggregate == null) {
+      throw DoublesScheduleNotFoundException(publicId);
+    }
+
+    final generatedScheduleId = aggregate.event.displayGeneratedScheduleId;
+    final currentGeneratedScheduleId = current?.generatedScheduleId;
+    final eventChanged = current == null ||
+        current.aggregate.event.revision != aggregate.event.revision;
+    final scheduleChanged = current == null ||
+        currentGeneratedScheduleId != generatedScheduleId;
+
+    Map<String, dynamic>? scheduleResponse;
+    ScheduleProgressScope? progressScope;
+    ScheduleProgressSummary? progressSummary;
+    List<ScheduleMatchProgress> matches = const [];
+    var progressChanged = false;
+
+    if (generatedScheduleId != null && generatedScheduleId.isNotEmpty) {
+      scheduleResponse = !scheduleChanged && current?.scheduleResponse != null
+          ? current!.scheduleResponse
+          : await _loadGeneratedSchedule(generatedScheduleId);
+
+      progressScope = ScheduleProgressScope(
+        scheduleType: ScheduleProgressScheduleType.doubles,
+        shareId: aggregate.event.publicId,
+        generatedScheduleId: generatedScheduleId,
+      );
+      progressSummary = await _progressRepository.findSummary(progressScope);
+
+      final sameProgressScope =
+          current?.progressScope?.storageKey == progressScope.storageKey;
+      final sameProgressRevision = sameProgressScope &&
+          current?.progressSummary?.revision == progressSummary?.revision;
+
+      if (progressSummary == null) {
+        matches = const [];
+      } else if (sameProgressRevision) {
+        matches = current!.matches;
+      } else {
+        matches = await _progressRepository.listMatches(progressScope);
+      }
+
+      progressChanged = current == null ||
+          !sameProgressScope ||
+          current.progressSummary?.revision != progressSummary?.revision;
+    } else {
+      progressChanged = current?.progressSummary != null ||
+          (current?.matches.isNotEmpty ?? false);
+    }
+
+    return DoublesScheduleRefreshSnapshot(
+      aggregate: aggregate,
+      scheduleResponse: scheduleResponse,
+      progressScope: progressScope,
+      progressSummary: progressSummary,
+      matches: matches,
+      eventChanged: eventChanged,
+      scheduleChanged: scheduleChanged,
+      progressChanged: progressChanged,
+    );
+  }
+
+  Future<ScheduleMatchProgress> findLatestMatch({
+    required ScheduleProgressScope scope,
+    required int roundNo,
+    required int courtNo,
+    int? matchNo,
+  }) {
+    return _progressRepository.findMatch(
+      scope: scope,
+      roundNo: roundNo,
+      courtNo: courtNo,
+      matchNo: matchNo,
+    );
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -2,11 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:srp_lanske/app/config/app_config.dart';
 import 'package:srp_lanske/features/doubles_scheduler/presentation/event_setup_page.dart';
+import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_models.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
+import 'package:srp_lanske/shared/infrastructure/generated_schedule_api_client.dart';
+import 'package:srp_lanske/shared/presentation/app_message_type.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 import 'package:srp_lanske/shared/utils/browser_url.dart';
 import 'package:srp_lanske/shared/utils/external_link.dart';
 
+import '../application/doubles_schedule_refresh_service.dart';
 import '../application/generated_schedule_service.dart';
 import '../application/local_schedule_history_mapper.dart';
 import '../application/saved_event_aggregate_helpers.dart';
@@ -15,7 +19,6 @@ import '../data/local_schedule_history_store.dart';
 import '../domain/player_draft.dart';
 import '../domain/public_id.dart';
 import '../domain/saved_event_models.dart';
-import 'package:srp_lanske/shared/infrastructure/generated_schedule_api_client.dart';
 import 'event_list_page.dart';
 import 'models/event_draft.dart';
 import 'widgets/court_display_settings_dialog.dart';
@@ -44,15 +47,21 @@ enum _ScheduleMenuAction { top, list, support }
 
 class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   late final GeneratedScheduleService _service;
+  late final DoublesScheduleRefreshService _refreshService;
 
   bool _isLoading = true;
   bool _isAdopting = false;
+  bool _isRefreshing = false;
+  bool _isOpeningSharedDataDialog = false;
+  int _refreshRequestSequence = 0;
   String? _errorMessage;
 
   SavedEventAggregate? _savedEvent;
   String? _generatedScheduleId;
   String? _selectedPlayerId;
   Map<String, dynamic>? _scheduleResponse;
+  ScheduleProgressSummary? _progressSummary;
+  List<ScheduleMatchProgress> _matchProgresses = const [];
 
   @override
   void initState() {
@@ -62,6 +71,11 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       GeneratedScheduleApiClient(
         baseUrl: AppConfig.coreApiBaseUrl,
       ),
+    );
+    _refreshService = DoublesScheduleRefreshService(
+      eventRepository: appEventRepository,
+      progressRepository: appScheduleProgressRepository,
+      loadGeneratedSchedule: _service.getById,
     );
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -99,7 +113,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     final players = _savedEvent?.players.toList() ?? const [];
     if (players.isEmpty) return const [];
 
-    return players.toList()..sort((a, b) => a.orderNo.compareTo(b.orderNo));
+    return players..sort((a, b) => a.orderNo.compareTo(b.orderNo));
   }
 
   Map<String, String> get _playerNameById {
@@ -120,9 +134,9 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
 
   List<SavedEventCourtSetting> get _courtSettings {
     return _savedEvent?.courtSettings ??
-        buildDefaultCourtSettings(_savedEvent?.courtSettings.length ??
-            _savedEvent?.event.courtCount ??
-            0);
+        buildDefaultCourtSettings(
+          _savedEvent?.event.courtCount ?? 0,
+        );
   }
 
   Map<int, String> get _courtLabelByNumber {
@@ -139,6 +153,29 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     return settings.map((setting) => setting.displayLabel).join(' / ');
   }
 
+  String get _progressText {
+    final summary = _progressSummary;
+    if (summary == null) {
+      return '- / -';
+    }
+
+    return '${summary.completedMatchCount} / ${summary.totalMatchCount}';
+  }
+
+  DoublesScheduleRefreshSnapshot? get _currentRefreshSnapshot {
+    final aggregate = _savedEvent;
+    if (aggregate == null) {
+      return null;
+    }
+
+    return DoublesScheduleRefreshSnapshot.fromCurrentState(
+      aggregate: aggregate,
+      scheduleResponse: _scheduleResponse,
+      progressSummary: _progressSummary,
+      matches: _matchProgresses,
+    );
+  }
+
   void _toggleSelectedPlayer(String playerId) {
     setState(() {
       _selectedPlayerId = _selectedPlayerId == playerId ? null : playerId;
@@ -151,8 +188,11 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     if (!mounted) return;
 
     if (latestEvent?.event.hasAdoptedSchedule == true) {
-      _showMessage(l10n.cannotRegenerateAdoptedScheduleMessage);
-      await _reloadSchedule();
+      _showMessage(
+        l10n.cannotRegenerateAdoptedScheduleMessage,
+        type: AppMessageType.warning,
+      );
+      await _reloadSchedule(showSuccess: false);
       return;
     }
 
@@ -187,8 +227,11 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     if (!mounted) return;
 
     if (latestBeforeGenerate?.event.hasAdoptedSchedule == true) {
-      _showMessage(l10n.cannotRegenerateAdoptedScheduleMessage);
-      await _reloadSchedule();
+      _showMessage(
+        l10n.cannotRegenerateAdoptedScheduleMessage,
+        type: AppMessageType.warning,
+      );
+      await _reloadSchedule(showSuccess: false);
       return;
     }
 
@@ -216,6 +259,8 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         _scheduleResponse = null;
         _generatedScheduleId = null;
         _selectedPlayerId = null;
+        _progressSummary = null;
+        _matchProgresses = const [];
         _errorMessage = l10n.scheduleNotFoundMessage;
       });
       return null;
@@ -230,18 +275,10 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   }
 
   Future<void> _restore() async {
+    final publicId = widget.publicId.trim().toUpperCase();
     final l10n = AppLocalizations.of(context);
 
-    setState(() {
-      _isLoading = true;
-      _errorMessage = null;
-    });
-
-    final publicId = widget.publicId.trim().toUpperCase();
-
     if (!isValidPublicId(publicId)) {
-      if (!mounted) return;
-
       setState(() {
         _isLoading = false;
         _errorMessage = l10n.scheduleNotFoundMessage;
@@ -249,171 +286,175 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       return;
     }
 
-    try {
-      final aggregate = await appEventRepository.findByPublicId(publicId);
-      if (!mounted) return;
+    await _refreshLatestAll(
+      publicId: publicId,
+      initialLoad: true,
+      showSuccess: false,
+    );
+  }
 
-      if (aggregate == null) {
+  Future<bool> _refreshLatestAll({
+    String? publicId,
+    bool showSuccess = false,
+    bool initialLoad = false,
+  }) async {
+    final normalizedPublicId = (publicId ??
+            _savedEvent?.event.publicId ??
+            widget.publicId)
+        .trim()
+        .toUpperCase();
+    final l10n = AppLocalizations.of(context);
+
+    if (!isValidPublicId(normalizedPublicId)) {
+      if (initialLoad || _savedEvent == null) {
         setState(() {
-          _savedEvent = null;
-          _scheduleResponse = null;
-          _generatedScheduleId = null;
-          _selectedPlayerId = null;
-          _errorMessage = l10n.scheduleNotFoundMessage;
           _isLoading = false;
+          _errorMessage = l10n.scheduleNotFoundMessage;
         });
-        return;
+      } else {
+        _showMessage(
+          l10n.scheduleNotFoundMessage,
+          type: AppMessageType.error,
+        );
+      }
+      return false;
+    }
+
+    final requestSequence = ++_refreshRequestSequence;
+    final previousGeneratedScheduleId = _generatedScheduleId;
+    final hadExistingDisplay = _scheduleResponse != null;
+
+    setState(() {
+      _isRefreshing = true;
+      if (initialLoad && !hadExistingDisplay) {
+        _isLoading = true;
+      }
+      _errorMessage = null;
+    });
+
+    try {
+      final snapshot = await _refreshService.loadLatestByPublicId(
+        publicId: normalizedPublicId,
+        current: _currentRefreshSnapshot,
+      );
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return false;
       }
 
-      final generatedScheduleId = aggregate.event.displayGeneratedScheduleId;
+      final latestPlayerIds =
+          snapshot.aggregate.players.map((player) => player.id).toSet();
+      final selectedPlayerId = _selectedPlayerId;
 
       setState(() {
-        _savedEvent = aggregate;
-        _generatedScheduleId = generatedScheduleId;
+        _savedEvent = snapshot.aggregate;
+        _scheduleResponse = snapshot.scheduleResponse;
+        _generatedScheduleId = snapshot.generatedScheduleId;
+        _progressSummary = snapshot.progressSummary;
+        _matchProgresses = snapshot.matches;
+        if (selectedPlayerId != null &&
+            !latestPlayerIds.contains(selectedPlayerId)) {
+          _selectedPlayerId = null;
+        }
+        if (snapshot.aggregate.players.isEmpty) {
+          _errorMessage = l10n.noPlayersMessage;
+        } else if (snapshot.generatedScheduleId == null ||
+            snapshot.generatedScheduleId!.isEmpty) {
+          _errorMessage = l10n.scheduleNotLoadedMessage;
+        }
+        _isRefreshing = false;
+        _isLoading = false;
       });
 
-      if (aggregate.players.isEmpty) {
-        setState(() {
-          _selectedPlayerId = null;
-          _errorMessage = l10n.noPlayersMessage;
-          _isLoading = false;
-        });
-        return;
+      await _saveScheduleHistory(snapshot.aggregate);
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return true;
       }
 
-      if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
-        setState(() {
-          _errorMessage = l10n.scheduleNotLoadedMessage;
-          _isLoading = false;
-        });
-        return;
+      final latestGeneratedScheduleId = snapshot.generatedScheduleId;
+      final scheduleWasReplaced = previousGeneratedScheduleId != null &&
+          previousGeneratedScheduleId.isNotEmpty &&
+          latestGeneratedScheduleId != previousGeneratedScheduleId;
+
+      if (scheduleWasReplaced) {
+        _showMessage(
+          l10n.scheduleUpdatedReloadMessage,
+          type: AppMessageType.info,
+        );
+      } else if (showSuccess) {
+        _showMessage(
+          l10n.eventInfoLoadedMessage,
+          type: AppMessageType.success,
+        );
       }
 
-      await _fetchSchedule(generatedScheduleId);
-    } catch (e, stackTrace) {
-      debugPrint('Failed to restore schedule: $e');
-      debugPrintStack(stackTrace: stackTrace);
-
-      if (!mounted) return;
+      return true;
+    } on DoublesScheduleNotFoundException {
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return false;
+      }
 
       setState(() {
         _savedEvent = null;
         _scheduleResponse = null;
         _generatedScheduleId = null;
         _selectedPlayerId = null;
-        _errorMessage = l10n.reloadScheduleFailedMessage(e.toString());
+        _progressSummary = null;
+        _matchProgresses = const [];
+        _errorMessage = l10n.scheduleNotFoundMessage;
+        _isRefreshing = false;
         _isLoading = false;
       });
+      _showMessage(
+        l10n.scheduleNotFoundMessage,
+        type: AppMessageType.error,
+      );
+      return false;
+    } catch (e, stackTrace) {
+      debugPrint('Failed to refresh restored schedule: $e');
+      debugPrintStack(stackTrace: stackTrace);
+
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return false;
+      }
+
+      final message = l10n.reloadScheduleFailedMessage(e.toString());
+      setState(() {
+        _errorMessage = message;
+        _isRefreshing = false;
+        _isLoading = false;
+      });
+      _showMessage(message, type: AppMessageType.error);
+      return false;
     }
   }
 
-  Future<void> _fetchSchedule(String generatedScheduleId) async {
-    final l10n = AppLocalizations.of(context);
-
-    setState(() {
-      _isLoading = true;
-      _errorMessage = null;
-    });
-
-    try {
-      final response = await _service.getById(generatedScheduleId);
-      if (!mounted) return;
-
-      setState(() {
-        _scheduleResponse = response;
-        _generatedScheduleId = response['generated_schedule_id']?.toString() ??
-            generatedScheduleId;
-        _isLoading = false;
-      });
-
-      final aggregate = _savedEvent;
-      if (aggregate != null) {
-        await _saveScheduleHistory(aggregate);
-      }
-    } catch (e) {
-      if (!mounted) return;
-
-      setState(() {
-        _scheduleResponse = null;
-        _errorMessage = l10n.reloadScheduleFailedMessage(e.toString());
-        _isLoading = false;
-      });
-    }
-  }
-
-  Future<void> _reloadSchedule() async {
-    final l10n = AppLocalizations.of(context);
-    final publicId =
-        (_savedEvent?.event.publicId ?? widget.publicId).trim().toUpperCase();
-
-    if (!isValidPublicId(publicId)) {
-      _showMessage(l10n.scheduleNotFoundMessage);
-      return;
-    }
-
-    setState(() {
-      _isLoading = true;
-      _errorMessage = null;
-    });
-
-    try {
-      final aggregate = await appEventRepository.findByPublicId(publicId);
-      if (!mounted) return;
-
-      if (aggregate == null) {
-        setState(() {
-          _savedEvent = null;
-          _scheduleResponse = null;
-          _generatedScheduleId = null;
-          _selectedPlayerId = null;
-          _errorMessage = l10n.scheduleNotFoundMessage;
-          _isLoading = false;
-        });
-        return;
-      }
-
-      final generatedScheduleId = aggregate.event.displayGeneratedScheduleId;
-
-      setState(() {
-        _savedEvent = aggregate;
-        _generatedScheduleId = generatedScheduleId;
-      });
-
-      if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
-        setState(() {
-          _scheduleResponse = null;
-          _errorMessage = l10n.scheduleNotLoadedMessage;
-          _isLoading = false;
-        });
-        return;
-      }
-
-      await _fetchSchedule(generatedScheduleId);
-    } catch (e) {
-      if (!mounted) return;
-
-      setState(() {
-        _errorMessage = l10n.reloadScheduleFailedMessage(e.toString());
-        _isLoading = false;
-      });
-    }
+  Future<void> _reloadSchedule({bool showSuccess = true}) async {
+    await _refreshLatestAll(showSuccess: showSuccess);
   }
 
   Future<void> _generateSchedule() async {
     final l10n = AppLocalizations.of(context);
     final savedEvent = _savedEvent;
     if (savedEvent == null) {
-      _showMessage(l10n.adoptEventMissingMessage);
+      _showMessage(
+        l10n.adoptEventMissingMessage,
+        type: AppMessageType.error,
+      );
       return;
     }
 
     if (_hasAdoptedSchedule) {
-      _showMessage(l10n.cannotRegenerateAdoptedScheduleMessage);
+      _showMessage(
+        l10n.cannotRegenerateAdoptedScheduleMessage,
+        type: AppMessageType.warning,
+      );
       return;
     }
 
+    _refreshRequestSequence += 1;
     setState(() {
       _isLoading = true;
+      _isRefreshing = false;
       _errorMessage = null;
     });
 
@@ -441,6 +482,8 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         _savedEvent = nextSavedEvent;
         _scheduleResponse = response;
         _generatedScheduleId = generatedScheduleId;
+        _progressSummary = null;
+        _matchProgresses = const [];
         _isLoading = false;
       });
 
@@ -461,7 +504,10 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
 
     if (displayedGeneratedScheduleId == null ||
         displayedGeneratedScheduleId.isEmpty) {
-      _showMessage(l10n.adoptScheduleMissingIdMessage);
+      _showMessage(
+        l10n.adoptScheduleMissingIdMessage,
+        type: AppMessageType.warning,
+      );
       return;
     }
 
@@ -477,13 +523,19 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       if (!mounted) return;
 
       if (latestEvent == null) {
-        _showMessage(l10n.adoptEventMissingMessage);
+        _showMessage(
+          l10n.adoptEventMissingMessage,
+          type: AppMessageType.error,
+        );
         return;
       }
 
       if (latestEvent.event.hasAdoptedSchedule) {
-        _showMessage(l10n.alreadyAdoptedScheduleMessage);
-        await _reloadSchedule();
+        _showMessage(
+          l10n.alreadyAdoptedScheduleMessage,
+          type: AppMessageType.info,
+        );
+        await _reloadSchedule(showSuccess: false);
         return;
       }
 
@@ -491,8 +543,11 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           latestEvent.event.currentGeneratedScheduleId;
 
       if (latestCurrentGeneratedScheduleId != displayedGeneratedScheduleId) {
-        _showMessage(l10n.scheduleUpdatedReloadMessage);
-        await _reloadSchedule();
+        _showMessage(
+          l10n.scheduleUpdatedReloadMessage,
+          type: AppMessageType.info,
+        );
+        await _reloadSchedule(showSuccess: false);
         return;
       }
 
@@ -515,8 +570,11 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       });
       await _saveScheduleHistory(nextSavedEvent);
 
-      _showMessage(l10n.adoptScheduleCompletedMessage);
-      await _reloadSchedule();
+      _showMessage(
+        l10n.adoptScheduleCompletedMessage,
+        type: AppMessageType.success,
+      );
+      await _reloadSchedule(showSuccess: false);
     } catch (e) {
       if (!mounted) return;
 
@@ -542,33 +600,70 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   }
 
   Future<void> _changeCourtDisplay() async {
-    final savedEvent = _savedEvent;
-    if (savedEvent == null || _hasAdoptedSchedule) return;
+    if (_isOpeningSharedDataDialog || _isRefreshing) {
+      return;
+    }
 
-    final nextSettings = await showDialog<List<SavedEventCourtSetting>>(
-      context: context,
-      builder: (context) {
-        return CourtDisplaySettingsDialog(
-          courtCount: savedEvent.event.courtCount,
-          initialSettings: _courtSettings,
-        );
-      },
-    );
-
-    if (!mounted || nextSettings == null) return;
-
-    final updatedAggregate = await appEventRepository.updateCourtSettings(
-      eventId: savedEvent.event.id,
-      courtSettings: nextSettings,
-    );
-
-    if (!mounted) return;
-
+    var dialogOpened = false;
     setState(() {
-      _savedEvent = updatedAggregate;
+      _isOpeningSharedDataDialog = true;
     });
 
-    await _saveScheduleHistory(updatedAggregate);
+    try {
+      final refreshed = await _refreshLatestAll(showSuccess: false);
+      if (!mounted || !refreshed) {
+        return;
+      }
+
+      final savedEvent = _savedEvent;
+      if (savedEvent == null || _hasAdoptedSchedule) {
+        return;
+      }
+
+      dialogOpened = true;
+      final nextSettings = await showDialog<List<SavedEventCourtSetting>>(
+        context: context,
+        builder: (context) {
+          return CourtDisplaySettingsDialog(
+            courtCount: savedEvent.event.courtCount,
+            initialSettings: _courtSettings,
+          );
+        },
+      );
+
+      if (!mounted || nextSettings == null) return;
+
+      final updatedAggregate = await appEventRepository.updateCourtSettings(
+        eventId: savedEvent.event.id,
+        courtSettings: nextSettings,
+      );
+
+      if (!mounted) return;
+
+      setState(() {
+        _savedEvent = updatedAggregate;
+      });
+
+      await _saveScheduleHistory(updatedAggregate);
+    } catch (e) {
+      if (!mounted) return;
+
+      final message =
+          AppLocalizations.of(context).reloadScheduleFailedMessage(e.toString());
+      setState(() {
+        _errorMessage = message;
+      });
+      _showMessage(message, type: AppMessageType.error);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isOpeningSharedDataDialog = false;
+        });
+      }
+      if (mounted && dialogOpened) {
+        await _refreshLatestAll(showSuccess: false);
+      }
+    }
   }
 
   void _handleMenu(_ScheduleMenuAction action) {
@@ -627,7 +722,10 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   Future<void> _copyShareUrl() async {
     final l10n = AppLocalizations.of(context);
     await Clipboard.setData(ClipboardData(text: _buildShareUrl()));
-    _showMessage(l10n.shareUrlCopiedMessage);
+    _showMessage(
+      l10n.shareUrlCopiedMessage,
+      type: AppMessageType.success,
+    );
   }
 
   void _showShareDialog() {
@@ -642,13 +740,23 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     );
   }
 
-  void _showMessage(String message) {
+  void _showMessage(
+    String message, {
+    AppMessageType type = AppMessageType.info,
+  }) {
+    var duration = const Duration(seconds: 2);
+    if (type == AppMessageType.warning) {
+      duration = const Duration(seconds: 3);
+    } else if (type == AppMessageType.error) {
+      duration = const Duration(seconds: 4);
+    }
+
     final messenger = ScaffoldMessenger.of(context);
     messenger.hideCurrentSnackBar();
     messenger.showSnackBar(
       SnackBar(
         content: Text(message),
-        duration: const Duration(seconds: 2),
+        duration: duration,
       ),
     );
   }
@@ -682,8 +790,12 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         else ...[
           ScheduleEventSummaryCard(
             onShareUrl: _showShareDialog,
-            onRefresh: _reloadSchedule,
-            canRefresh: _generatedScheduleId != null,
+            onRefresh: () => _reloadSchedule(),
+            canRefresh: _generatedScheduleId != null &&
+                !_isLoading &&
+                !_isOpeningSharedDataDialog,
+            isRefreshing: _isRefreshing,
+            progressText: _progressText,
           ),
           const SizedBox(height: 12),
           SchedulePlayersCard(
@@ -699,11 +811,13 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           ScheduleSectionCard(
             child: ScheduleOperationPanel(
               courtDisplaySummary: _courtDisplaySummary,
-              canChangeCourtDisplay:
-                  !_hasAdoptedSchedule && _savedEvent != null,
+              canChangeCourtDisplay: !_hasAdoptedSchedule &&
+                  !_isRefreshing &&
+                  !_isOpeningSharedDataDialog,
               onChangeCourtDisplay: _changeCourtDisplay,
               showActionButtons: !_hasAdoptedSchedule,
-              isLoading: _isLoading,
+              isLoading:
+                  _isLoading || _isRefreshing || _isOpeningSharedDataDialog,
               isAdopting: _isAdopting,
               generateButtonLabel: _generateButtonLabel(l10n),
               canAdopt:

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -184,15 +184,20 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
 
   Future<void> _requestGenerateSchedule() async {
     final l10n = AppLocalizations.of(context);
-    final latestEvent = await _refreshSavedEventForAction();
-    if (!mounted) return;
+    final displayedGeneratedScheduleId = _generatedScheduleId;
 
-    if (latestEvent?.event.hasAdoptedSchedule == true) {
+    final refreshed = await _refreshLatestAll(showSuccess: false);
+    if (!mounted || !refreshed) return;
+
+    if (_hasAdoptedSchedule) {
       _showMessage(
         l10n.cannotRegenerateAdoptedScheduleMessage,
         type: AppMessageType.warning,
       );
-      await _reloadSchedule(showSuccess: false);
+      return;
+    }
+
+    if (_generatedScheduleId != displayedGeneratedScheduleId) {
       return;
     }
 
@@ -201,6 +206,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       return;
     }
 
+    final expectedGeneratedScheduleId = _generatedScheduleId;
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) {
@@ -223,15 +229,19 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
 
     if (!mounted || confirmed != true) return;
 
-    final latestBeforeGenerate = await _refreshSavedEventForAction();
-    if (!mounted) return;
+    final refreshedBeforeGenerate =
+        await _refreshLatestAll(showSuccess: false);
+    if (!mounted || !refreshedBeforeGenerate) return;
 
-    if (latestBeforeGenerate?.event.hasAdoptedSchedule == true) {
+    if (_hasAdoptedSchedule) {
       _showMessage(
         l10n.cannotRegenerateAdoptedScheduleMessage,
         type: AppMessageType.warning,
       );
-      await _reloadSchedule(showSuccess: false);
+      return;
+    }
+
+    if (_generatedScheduleId != expectedGeneratedScheduleId) {
       return;
     }
 

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -321,6 +321,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     }
 
     final requestSequence = ++_refreshRequestSequence;
+    final currentSnapshot = _currentRefreshSnapshot;
     final previousGeneratedScheduleId = _generatedScheduleId;
     final hadExistingDisplay = _scheduleResponse != null;
 
@@ -335,25 +336,29 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     try {
       final snapshot = await _refreshService.loadLatestByPublicId(
         publicId: normalizedPublicId,
-        current: _currentRefreshSnapshot,
+        current: currentSnapshot,
       );
       if (!mounted || requestSequence != _refreshRequestSequence) {
         return false;
       }
 
+      final shouldApplySnapshot =
+          currentSnapshot == null || snapshot.hasChanges;
       final latestPlayerIds =
           snapshot.aggregate.players.map((player) => player.id).toSet();
       final selectedPlayerId = _selectedPlayerId;
 
       setState(() {
-        _savedEvent = snapshot.aggregate;
-        _scheduleResponse = snapshot.scheduleResponse;
-        _generatedScheduleId = snapshot.generatedScheduleId;
-        _progressSummary = snapshot.progressSummary;
-        _matchProgresses = snapshot.matches;
-        if (selectedPlayerId != null &&
-            !latestPlayerIds.contains(selectedPlayerId)) {
-          _selectedPlayerId = null;
+        if (shouldApplySnapshot) {
+          _savedEvent = snapshot.aggregate;
+          _scheduleResponse = snapshot.scheduleResponse;
+          _generatedScheduleId = snapshot.generatedScheduleId;
+          _progressSummary = snapshot.progressSummary;
+          _matchProgresses = snapshot.matches;
+          if (selectedPlayerId != null &&
+              !latestPlayerIds.contains(selectedPlayerId)) {
+            _selectedPlayerId = null;
+          }
         }
         if (snapshot.aggregate.players.isEmpty) {
           _errorMessage = l10n.noPlayersMessage;
@@ -382,7 +387,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         );
       } else if (showSuccess) {
         _showMessage(
-          l10n.eventInfoLoadedMessage,
+          l10n.bocciaScoreRefreshedMessage,
           type: AppMessageType.success,
         );
       }

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -52,6 +52,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   bool _isLoading = true;
   bool _isAdopting = false;
   bool _isRefreshing = false;
+  bool _isCheckingRegenerate = false;
   bool _isOpeningSharedDataDialog = false;
   int _refreshRequestSequence = 0;
   String? _errorMessage;
@@ -183,30 +184,21 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   }
 
   Future<void> _requestGenerateSchedule() async {
-    final l10n = AppLocalizations.of(context);
-    final displayedGeneratedScheduleId = _generatedScheduleId;
-
-    final refreshed = await _refreshLatestAll(showSuccess: false);
-    if (!mounted || !refreshed) return;
-
-    if (_hasAdoptedSchedule) {
-      _showMessage(
-        l10n.cannotRegenerateAdoptedScheduleMessage,
-        type: AppMessageType.warning,
-      );
-      return;
-    }
-
-    if (_generatedScheduleId != displayedGeneratedScheduleId) {
-      return;
-    }
+    if (_isCheckingRegenerate || _isLoading || _isAdopting) return;
 
     if (!_hasGeneratedSchedule) {
       await _generateSchedule();
       return;
     }
 
+    final l10n = AppLocalizations.of(context);
     final expectedGeneratedScheduleId = _generatedScheduleId;
+    if (expectedGeneratedScheduleId == null ||
+        expectedGeneratedScheduleId.isEmpty) {
+      await _generateSchedule();
+      return;
+    }
+
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) {
@@ -229,23 +221,117 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
 
     if (!mounted || confirmed != true) return;
 
-    final refreshedBeforeGenerate =
-        await _refreshLatestAll(showSuccess: false);
-    if (!mounted || !refreshedBeforeGenerate) return;
-
-    if (_hasAdoptedSchedule) {
-      _showMessage(
-        l10n.cannotRegenerateAdoptedScheduleMessage,
-        type: AppMessageType.warning,
-      );
-      return;
-    }
-
-    if (_generatedScheduleId != expectedGeneratedScheduleId) {
-      return;
-    }
+    final canGenerate = await _refreshBeforeRegenerate(
+      expectedGeneratedScheduleId: expectedGeneratedScheduleId,
+    );
+    if (!mounted || !canGenerate) return;
 
     await _generateSchedule();
+  }
+
+  Future<bool> _refreshBeforeRegenerate({
+    required String expectedGeneratedScheduleId,
+  }) async {
+    final aggregate = _savedEvent;
+    if (aggregate == null) return false;
+
+    final l10n = AppLocalizations.of(context);
+    final requestSequence = ++_refreshRequestSequence;
+    final currentSnapshot = _currentRefreshSnapshot;
+
+    setState(() {
+      _isCheckingRegenerate = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final snapshot = await _refreshService.loadLatestByPublicId(
+        publicId: aggregate.event.publicId,
+        current: currentSnapshot,
+      );
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return false;
+      }
+
+      final shouldApplySnapshot =
+          currentSnapshot == null || snapshot.hasChanges;
+      final latestPlayerIds =
+          snapshot.aggregate.players.map((player) => player.id).toSet();
+      final selectedPlayerId = _selectedPlayerId;
+
+      setState(() {
+        if (shouldApplySnapshot) {
+          _savedEvent = snapshot.aggregate;
+          _scheduleResponse = snapshot.scheduleResponse;
+          _generatedScheduleId = snapshot.generatedScheduleId;
+          _progressSummary = snapshot.progressSummary;
+          _matchProgresses = snapshot.matches;
+          if (selectedPlayerId != null &&
+              !latestPlayerIds.contains(selectedPlayerId)) {
+            _selectedPlayerId = null;
+          }
+        }
+      });
+
+      await _saveScheduleHistory(snapshot.aggregate);
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return false;
+      }
+
+      if (snapshot.aggregate.event.hasAdoptedSchedule) {
+        _showMessage(
+          l10n.cannotRegenerateAdoptedScheduleMessage,
+          type: AppMessageType.warning,
+        );
+        return false;
+      }
+
+      if (snapshot.generatedScheduleId != expectedGeneratedScheduleId) {
+        _showMessage(
+          l10n.scheduleUpdatedReloadMessage,
+          type: AppMessageType.info,
+        );
+        return false;
+      }
+
+      return true;
+    } on DoublesScheduleNotFoundException {
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return false;
+      }
+
+      setState(() {
+        _savedEvent = null;
+        _scheduleResponse = null;
+        _generatedScheduleId = null;
+        _selectedPlayerId = null;
+        _progressSummary = null;
+        _matchProgresses = const [];
+        _errorMessage = l10n.scheduleNotFoundMessage;
+      });
+      _showMessage(
+        l10n.scheduleNotFoundMessage,
+        type: AppMessageType.error,
+      );
+      return false;
+    } catch (e) {
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return false;
+      }
+
+      final message = l10n.reloadScheduleFailedMessage(e.toString());
+      setState(() {
+        _errorMessage = message;
+      });
+      _showMessage(message, type: AppMessageType.error);
+      return false;
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isCheckingRegenerate = false;
+        });
+      }
+    }
   }
 
   Future<SavedEventAggregate?> _refreshSavedEventForAction() async {
@@ -828,11 +914,14 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
               courtDisplaySummary: _courtDisplaySummary,
               canChangeCourtDisplay: !_hasAdoptedSchedule &&
                   !_isRefreshing &&
+                  !_isCheckingRegenerate &&
                   !_isOpeningSharedDataDialog,
               onChangeCourtDisplay: _changeCourtDisplay,
               showActionButtons: !_hasAdoptedSchedule,
-              isLoading:
-                  _isLoading || _isRefreshing || _isOpeningSharedDataDialog,
+              isLoading: _isLoading ||
+                  _isRefreshing ||
+                  _isCheckingRegenerate ||
+                  _isOpeningSharedDataDialog,
               isAdopting: _isAdopting,
               generateButtonLabel: _generateButtonLabel(l10n),
               canAdopt:

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -394,11 +394,10 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     bool showSuccess = false,
     bool initialLoad = false,
   }) async {
-    final normalizedPublicId = (publicId ??
-            _savedEvent?.event.publicId ??
-            widget.publicId)
-        .trim()
-        .toUpperCase();
+    final normalizedPublicId =
+        (publicId ?? _savedEvent?.event.publicId ?? widget.publicId)
+            .trim()
+            .toUpperCase();
     final l10n = AppLocalizations.of(context);
 
     if (!isValidPublicId(normalizedPublicId)) {
@@ -749,8 +748,8 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     } catch (e) {
       if (!mounted) return;
 
-      final message =
-          AppLocalizations.of(context).reloadScheduleFailedMessage(e.toString());
+      final message = AppLocalizations.of(context)
+          .reloadScheduleFailedMessage(e.toString());
       setState(() {
         _errorMessage = message;
       });

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -1,18 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:srp_lanske/app/config/app_config.dart';
+import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_models.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
+import 'package:srp_lanske/shared/infrastructure/generated_schedule_api_client.dart';
+import 'package:srp_lanske/shared/presentation/app_message_type.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 import 'package:srp_lanske/shared/utils/browser_url.dart';
 import 'package:srp_lanske/shared/utils/external_link.dart';
 
+import '../application/doubles_schedule_refresh_service.dart';
 import '../application/generated_schedule_service.dart';
 import '../application/local_schedule_history_mapper.dart';
 import '../application/saved_event_aggregate_helpers.dart';
 import '../application/schedule_share_url.dart';
 import '../data/local_schedule_history_store.dart';
 import '../domain/saved_event_models.dart';
-import 'package:srp_lanske/shared/infrastructure/generated_schedule_api_client.dart';
 import 'event_list_page.dart';
 import 'event_setup_page.dart';
 import 'models/event_draft.dart';
@@ -39,13 +42,19 @@ enum _ScheduleMenuAction { top, list, support }
 
 class _SchedulePageState extends State<SchedulePage> {
   late final GeneratedScheduleService _service;
+  late final DoublesScheduleRefreshService _refreshService;
 
   bool _isLoading = true;
   bool _isAdopting = false;
+  bool _isRefreshing = false;
+  bool _isOpeningSharedDataDialog = false;
+  int _refreshRequestSequence = 0;
   String? _errorMessage;
   String? _generatedScheduleId;
   String? _selectedPlayerId;
   Map<String, dynamic>? _scheduleResponse;
+  ScheduleProgressSummary? _progressSummary;
+  List<ScheduleMatchProgress> _matchProgresses = const [];
 
   SavedEventAggregate? _savedEvent;
 
@@ -57,6 +66,11 @@ class _SchedulePageState extends State<SchedulePage> {
       GeneratedScheduleApiClient(
         baseUrl: AppConfig.coreApiBaseUrl,
       ),
+    );
+    _refreshService = DoublesScheduleRefreshService(
+      eventRepository: appEventRepository,
+      progressRepository: appScheduleProgressRepository,
+      loadGeneratedSchedule: _service.getById,
     );
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -70,6 +84,10 @@ class _SchedulePageState extends State<SchedulePage> {
 
   bool get _hasAdoptedSchedule {
     return _isAdopted || (_savedEvent?.event.hasAdoptedSchedule ?? false);
+  }
+
+  String get _pageTitle {
+    return _savedEvent?.event.title ?? widget.draft.eventName;
   }
 
   String _generateButtonLabel(AppLocalizations l10n) {
@@ -88,13 +106,40 @@ class _SchedulePageState extends State<SchedulePage> {
     return generatedScheduleId != null && generatedScheduleId.isNotEmpty;
   }
 
+  List<SavedEventPlayer> get _orderedSavedPlayers {
+    final players = _savedEvent?.players.toList() ?? const [];
+    if (players.isEmpty) {
+      return const [];
+    }
+
+    return players..sort((a, b) => a.orderNo.compareTo(b.orderNo));
+  }
+
   Map<String, String> get _playerNameById {
+    final savedPlayers = _orderedSavedPlayers;
+    if (savedPlayers.isNotEmpty) {
+      return {
+        for (final player in savedPlayers) player.id: player.displayName,
+      };
+    }
+
     return {
       for (final player in widget.draft.players) player.id: player.displayName,
     };
   }
 
   List<SchedulePlayerViewModel> get _playerViewModels {
+    final savedPlayers = _orderedSavedPlayers;
+    if (savedPlayers.isNotEmpty) {
+      return savedPlayers.map((player) {
+        return SchedulePlayerViewModel(
+          orderNo: player.orderNo,
+          displayName: player.displayName,
+          playerId: player.id,
+        );
+      }).toList(growable: false);
+    }
+
     return widget.draft.players.asMap().entries.map((entry) {
       return SchedulePlayerViewModel(
         orderNo: entry.key + 1,
@@ -102,6 +147,15 @@ class _SchedulePageState extends State<SchedulePage> {
         playerId: entry.value.id,
       );
     }).toList(growable: false);
+  }
+
+  int get _displayCourtCount {
+    return _savedEvent?.event.courtCount ?? widget.draft.courts;
+  }
+
+  int get _displayPlayerCount {
+    final savedPlayers = _orderedSavedPlayers;
+    return savedPlayers.isEmpty ? widget.draft.playerCount : savedPlayers.length;
   }
 
   List<SavedEventCourtSetting> get _courtSettings {
@@ -123,6 +177,29 @@ class _SchedulePageState extends State<SchedulePage> {
     return settings.map((setting) => setting.displayLabel).join(' / ');
   }
 
+  String get _progressText {
+    final summary = _progressSummary;
+    if (summary == null) {
+      return '- / -';
+    }
+
+    return '${summary.completedMatchCount} / ${summary.totalMatchCount}';
+  }
+
+  DoublesScheduleRefreshSnapshot? get _currentRefreshSnapshot {
+    final aggregate = _savedEvent;
+    if (aggregate == null) {
+      return null;
+    }
+
+    return DoublesScheduleRefreshSnapshot.fromCurrentState(
+      aggregate: aggregate,
+      scheduleResponse: _scheduleResponse,
+      progressSummary: _progressSummary,
+      matches: _matchProgresses,
+    );
+  }
+
   void _toggleSelectedPlayer(String playerId) {
     setState(() {
       _selectedPlayerId = _selectedPlayerId == playerId ? null : playerId;
@@ -135,8 +212,11 @@ class _SchedulePageState extends State<SchedulePage> {
     if (!mounted) return;
 
     if (latestEvent?.event.hasAdoptedSchedule == true) {
-      _showMessage(l10n.cannotRegenerateAdoptedScheduleMessage);
-      await _reloadSchedule();
+      _showMessage(
+        l10n.cannotRegenerateAdoptedScheduleMessage,
+        type: AppMessageType.warning,
+      );
+      await _reloadSchedule(showSuccess: false);
       return;
     }
 
@@ -171,8 +251,11 @@ class _SchedulePageState extends State<SchedulePage> {
     if (!mounted) return;
 
     if (latestBeforeGenerate?.event.hasAdoptedSchedule == true) {
-      _showMessage(l10n.cannotRegenerateAdoptedScheduleMessage);
-      await _reloadSchedule();
+      _showMessage(
+        l10n.cannotRegenerateAdoptedScheduleMessage,
+        type: AppMessageType.warning,
+      );
+      await _reloadSchedule(showSuccess: false);
       return;
     }
 
@@ -193,6 +276,8 @@ class _SchedulePageState extends State<SchedulePage> {
         _savedEvent = null;
         _scheduleResponse = null;
         _generatedScheduleId = null;
+        _progressSummary = null;
+        _matchProgresses = const [];
         _errorMessage = l10n.scheduleNotFoundMessage;
       });
       return null;
@@ -230,12 +315,18 @@ class _SchedulePageState extends State<SchedulePage> {
     final l10n = AppLocalizations.of(context);
     final shareUrl = _buildShareUrl();
     if (shareUrl == null) {
-      _showMessage(l10n.shareUrlCreateFailedMessage);
+      _showMessage(
+        l10n.shareUrlCreateFailedMessage,
+        type: AppMessageType.error,
+      );
       return;
     }
 
     await Clipboard.setData(ClipboardData(text: shareUrl));
-    _showMessage(l10n.shareUrlCopiedMessage);
+    _showMessage(
+      l10n.shareUrlCopiedMessage,
+      type: AppMessageType.success,
+    );
   }
 
   void _showShareDialog() {
@@ -243,7 +334,10 @@ class _SchedulePageState extends State<SchedulePage> {
     final shareUrl = _buildShareUrl();
 
     if (shareUrl == null) {
-      _showMessage(l10n.shareUrlCreateFailedMessage);
+      _showMessage(
+        l10n.shareUrlCreateFailedMessage,
+        type: AppMessageType.error,
+      );
       return;
     }
 
@@ -258,13 +352,23 @@ class _SchedulePageState extends State<SchedulePage> {
     );
   }
 
-  void _showMessage(String message) {
+  void _showMessage(
+    String message, {
+    AppMessageType type = AppMessageType.info,
+  }) {
+    var duration = const Duration(seconds: 2);
+    if (type == AppMessageType.warning) {
+      duration = const Duration(seconds: 3);
+    } else if (type == AppMessageType.error) {
+      duration = const Duration(seconds: 4);
+    }
+
     final messenger = ScaffoldMessenger.of(context);
     messenger.hideCurrentSnackBar();
     messenger.showSnackBar(
       SnackBar(
         content: Text(message),
-        duration: const Duration(seconds: 2),
+        duration: duration,
       ),
     );
   }
@@ -272,12 +376,17 @@ class _SchedulePageState extends State<SchedulePage> {
   Future<void> _generateSchedule() async {
     final l10n = AppLocalizations.of(context);
     if (_hasAdoptedSchedule) {
-      _showMessage(l10n.cannotRegenerateAdoptedScheduleMessage);
+      _showMessage(
+        l10n.cannotRegenerateAdoptedScheduleMessage,
+        type: AppMessageType.warning,
+      );
       return;
     }
 
+    _refreshRequestSequence += 1;
     setState(() {
       _isLoading = true;
+      _isRefreshing = false;
       _errorMessage = null;
     });
 
@@ -305,6 +414,8 @@ class _SchedulePageState extends State<SchedulePage> {
         _savedEvent = nextSavedEvent;
         _scheduleResponse = response;
         _generatedScheduleId = generatedScheduleId;
+        _progressSummary = null;
+        _matchProgresses = const [];
       });
 
       _replaceBrowserUrlWithPublicId(nextSavedEvent.event.publicId);
@@ -324,64 +435,123 @@ class _SchedulePageState extends State<SchedulePage> {
     }
   }
 
-  Future<void> _reloadSchedule() async {
+  Future<bool> _refreshLatestAll({
+    bool showSuccess = false,
+    bool initialLoad = false,
+  }) async {
+    final aggregate = _savedEvent;
+    if (aggregate == null) {
+      return false;
+    }
+
     final l10n = AppLocalizations.of(context);
+    final requestSequence = ++_refreshRequestSequence;
+    final previousGeneratedScheduleId = _generatedScheduleId;
+    final hadExistingDisplay = _scheduleResponse != null;
+
     setState(() {
-      _isLoading = true;
+      _isRefreshing = true;
+      if (initialLoad && !hadExistingDisplay) {
+        _isLoading = true;
+      }
       _errorMessage = null;
     });
 
     try {
-      var generatedScheduleId = _generatedScheduleId;
+      final snapshot = await _refreshService.loadLatestByPublicId(
+        publicId: aggregate.event.publicId,
+        current: _currentRefreshSnapshot,
+      );
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return false;
+      }
 
-      final savedEvent = _savedEvent;
-      if (savedEvent != null) {
-        final aggregate =
-            await appEventRepository.findByPublicId(savedEvent.event.publicId);
-        if (!mounted) return;
+      final latestPlayerIds =
+          snapshot.aggregate.players.map((player) => player.id).toSet();
+      final selectedPlayerId = _selectedPlayerId;
 
-        if (aggregate != null) {
-          generatedScheduleId = aggregate.event.displayGeneratedScheduleId;
-
-          setState(() {
-            _savedEvent = aggregate;
-            _generatedScheduleId = generatedScheduleId;
-          });
+      setState(() {
+        _savedEvent = snapshot.aggregate;
+        _scheduleResponse = snapshot.scheduleResponse;
+        _generatedScheduleId = snapshot.generatedScheduleId;
+        _progressSummary = snapshot.progressSummary;
+        _matchProgresses = snapshot.matches;
+        if (selectedPlayerId != null &&
+            !latestPlayerIds.contains(selectedPlayerId)) {
+          _selectedPlayerId = null;
         }
+        if (snapshot.aggregate.players.isEmpty) {
+          _errorMessage = l10n.noPlayersMessage;
+        } else if (snapshot.generatedScheduleId == null ||
+            snapshot.generatedScheduleId!.isEmpty) {
+          _errorMessage = l10n.scheduleNotLoadedMessage;
+        }
+        _isRefreshing = false;
+        _isLoading = false;
+      });
+
+      await _saveScheduleHistory(snapshot.aggregate);
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return true;
       }
 
-      if (generatedScheduleId == null || generatedScheduleId.isEmpty) {
-        if (!mounted) return;
+      final latestGeneratedScheduleId = snapshot.generatedScheduleId;
+      final scheduleWasReplaced = previousGeneratedScheduleId != null &&
+          previousGeneratedScheduleId.isNotEmpty &&
+          latestGeneratedScheduleId != previousGeneratedScheduleId;
 
-        setState(() {
-          _scheduleResponse = null;
-          _errorMessage = l10n.reloadScheduleMissingIdMessage;
-          _isLoading = false;
-        });
-        return;
+      if (scheduleWasReplaced) {
+        _showMessage(
+          l10n.scheduleUpdatedReloadMessage,
+          type: AppMessageType.info,
+        );
+      } else if (showSuccess) {
+        _showMessage(
+          l10n.eventInfoLoadedMessage,
+          type: AppMessageType.success,
+        );
       }
 
-      final response = await _service.getById(generatedScheduleId);
-      if (!mounted) return;
+      return true;
+    } on DoublesScheduleNotFoundException {
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return false;
+      }
 
       setState(() {
-        _scheduleResponse = response;
-        _generatedScheduleId = response['generated_schedule_id']?.toString() ??
-            generatedScheduleId;
+        _savedEvent = null;
+        _scheduleResponse = null;
+        _generatedScheduleId = null;
+        _selectedPlayerId = null;
+        _progressSummary = null;
+        _matchProgresses = const [];
+        _errorMessage = l10n.scheduleNotFoundMessage;
+        _isRefreshing = false;
+        _isLoading = false;
       });
+      _showMessage(
+        l10n.scheduleNotFoundMessage,
+        type: AppMessageType.error,
+      );
+      return false;
     } catch (e) {
-      if (!mounted) return;
-
-      setState(() {
-        _errorMessage = l10n.reloadScheduleFailedMessage(e.toString());
-      });
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isLoading = false;
-        });
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return false;
       }
+
+      final message = l10n.reloadScheduleFailedMessage(e.toString());
+      setState(() {
+        _errorMessage = message;
+        _isRefreshing = false;
+        _isLoading = false;
+      });
+      _showMessage(message, type: AppMessageType.error);
+      return false;
     }
+  }
+
+  Future<void> _reloadSchedule({bool showSuccess = true}) async {
+    await _refreshLatestAll(showSuccess: showSuccess);
   }
 
   Future<void> _adoptSchedule() async {
@@ -390,7 +560,10 @@ class _SchedulePageState extends State<SchedulePage> {
 
     if (displayedGeneratedScheduleId == null ||
         displayedGeneratedScheduleId.isEmpty) {
-      _showMessage(l10n.adoptScheduleMissingIdMessage);
+      _showMessage(
+        l10n.adoptScheduleMissingIdMessage,
+        type: AppMessageType.warning,
+      );
       return;
     }
 
@@ -406,13 +579,19 @@ class _SchedulePageState extends State<SchedulePage> {
       if (!mounted) return;
 
       if (latestEvent == null) {
-        _showMessage(l10n.adoptEventMissingMessage);
+        _showMessage(
+          l10n.adoptEventMissingMessage,
+          type: AppMessageType.error,
+        );
         return;
       }
 
       if (latestEvent.event.hasAdoptedSchedule) {
-        _showMessage(l10n.alreadyAdoptedScheduleMessage);
-        await _reloadSchedule();
+        _showMessage(
+          l10n.alreadyAdoptedScheduleMessage,
+          type: AppMessageType.info,
+        );
+        await _reloadSchedule(showSuccess: false);
         return;
       }
 
@@ -420,8 +599,11 @@ class _SchedulePageState extends State<SchedulePage> {
           latestEvent.event.currentGeneratedScheduleId;
 
       if (latestCurrentGeneratedScheduleId != displayedGeneratedScheduleId) {
-        _showMessage(l10n.scheduleUpdatedReloadMessage);
-        await _reloadSchedule();
+        _showMessage(
+          l10n.scheduleUpdatedReloadMessage,
+          type: AppMessageType.info,
+        );
+        await _reloadSchedule(showSuccess: false);
         return;
       }
 
@@ -444,8 +626,11 @@ class _SchedulePageState extends State<SchedulePage> {
       });
       await _saveScheduleHistory(nextSavedEvent);
 
-      _showMessage(l10n.adoptScheduleCompletedMessage);
-      await _reloadSchedule();
+      _showMessage(
+        l10n.adoptScheduleCompletedMessage,
+        type: AppMessageType.success,
+      );
+      await _reloadSchedule(showSuccess: false);
     } catch (e) {
       if (!mounted) return;
 
@@ -471,33 +656,70 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   Future<void> _changeCourtDisplay() async {
-    final savedEvent = _savedEvent;
-    if (savedEvent == null || _hasAdoptedSchedule) return;
+    if (_isOpeningSharedDataDialog || _isRefreshing) {
+      return;
+    }
 
-    final nextSettings = await showDialog<List<SavedEventCourtSetting>>(
-      context: context,
-      builder: (context) {
-        return CourtDisplaySettingsDialog(
-          courtCount: savedEvent.event.courtCount,
-          initialSettings: _courtSettings,
-        );
-      },
-    );
-
-    if (!mounted || nextSettings == null) return;
-
-    final updatedAggregate = await appEventRepository.updateCourtSettings(
-      eventId: savedEvent.event.id,
-      courtSettings: nextSettings,
-    );
-
-    if (!mounted) return;
-
+    var dialogOpened = false;
     setState(() {
-      _savedEvent = updatedAggregate;
+      _isOpeningSharedDataDialog = true;
     });
 
-    await _saveScheduleHistory(updatedAggregate);
+    try {
+      final refreshed = await _refreshLatestAll(showSuccess: false);
+      if (!mounted || !refreshed) {
+        return;
+      }
+
+      final savedEvent = _savedEvent;
+      if (savedEvent == null || _hasAdoptedSchedule) {
+        return;
+      }
+
+      dialogOpened = true;
+      final nextSettings = await showDialog<List<SavedEventCourtSetting>>(
+        context: context,
+        builder: (context) {
+          return CourtDisplaySettingsDialog(
+            courtCount: savedEvent.event.courtCount,
+            initialSettings: _courtSettings,
+          );
+        },
+      );
+
+      if (!mounted || nextSettings == null) return;
+
+      final updatedAggregate = await appEventRepository.updateCourtSettings(
+        eventId: savedEvent.event.id,
+        courtSettings: nextSettings,
+      );
+
+      if (!mounted) return;
+
+      setState(() {
+        _savedEvent = updatedAggregate;
+      });
+
+      await _saveScheduleHistory(updatedAggregate);
+    } catch (e) {
+      if (!mounted) return;
+
+      final message =
+          AppLocalizations.of(context).reloadScheduleFailedMessage(e.toString());
+      setState(() {
+        _errorMessage = message;
+      });
+      _showMessage(message, type: AppMessageType.error);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isOpeningSharedDataDialog = false;
+        });
+      }
+      if (mounted && dialogOpened) {
+        await _refreshLatestAll(showSuccess: false);
+      }
+    }
   }
 
   void _handleMenu(_ScheduleMenuAction action) {
@@ -555,14 +777,18 @@ class _SchedulePageState extends State<SchedulePage> {
       children: [
         ScheduleEventSummaryCard(
           onShareUrl: _savedEvent == null ? null : _showShareDialog,
-          onRefresh: _reloadSchedule,
-          canRefresh: _generatedScheduleId != null,
+          onRefresh: () => _reloadSchedule(),
+          canRefresh: _generatedScheduleId != null &&
+              !_isLoading &&
+              !_isOpeningSharedDataDialog,
+          isRefreshing: _isRefreshing,
+          progressText: _progressText,
         ),
         const SizedBox(height: 12),
         SchedulePlayersCard(
           title: l10n.schedulePlayersTitle(
-            widget.draft.courts,
-            widget.draft.playerCount,
+            _displayCourtCount,
+            _displayPlayerCount,
           ),
           players: _playerViewModels,
           selectedPlayerId: _selectedPlayerId,
@@ -572,10 +798,14 @@ class _SchedulePageState extends State<SchedulePage> {
         ScheduleSectionCard(
           child: ScheduleOperationPanel(
             courtDisplaySummary: _courtDisplaySummary,
-            canChangeCourtDisplay: !_hasAdoptedSchedule && _savedEvent != null,
+            canChangeCourtDisplay: !_hasAdoptedSchedule &&
+                _savedEvent != null &&
+                !_isRefreshing &&
+                !_isOpeningSharedDataDialog,
             onChangeCourtDisplay: _changeCourtDisplay,
             showActionButtons: !_hasAdoptedSchedule,
-            isLoading: _isLoading,
+            isLoading:
+                _isLoading || _isRefreshing || _isOpeningSharedDataDialog,
             isAdopting: _isAdopting,
             generateButtonLabel: _generateButtonLabel(l10n),
             canAdopt: _generatedScheduleId != null && _scheduleResponse != null,
@@ -596,7 +826,7 @@ class _SchedulePageState extends State<SchedulePage> {
               : ScheduleRoundsView(
                   scheduleResponse: _scheduleResponse,
                   playerNameById: _playerNameById,
-                  courtCount: widget.draft.courts,
+                  courtCount: _displayCourtCount,
                   selectedPlayerId: _selectedPlayerId,
                   onPlayerSelected: _toggleSelectedPlayer,
                   courtLabelByNumber: _courtLabelByNumber,
@@ -622,7 +852,7 @@ class _SchedulePageState extends State<SchedulePage> {
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false,
-        title: Text(widget.draft.eventName),
+        title: Text(_pageTitle),
         actions: [
           PopupMenuButton<_ScheduleMenuAction>(
             onSelected: _handleMenu,

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -208,16 +208,23 @@ class _SchedulePageState extends State<SchedulePage> {
 
   Future<void> _requestGenerateSchedule() async {
     final l10n = AppLocalizations.of(context);
-    final latestEvent = await _refreshSavedEventForAction();
-    if (!mounted) return;
+    final displayedGeneratedScheduleId = _generatedScheduleId;
 
-    if (latestEvent?.event.hasAdoptedSchedule == true) {
-      _showMessage(
-        l10n.cannotRegenerateAdoptedScheduleMessage,
-        type: AppMessageType.warning,
-      );
-      await _reloadSchedule(showSuccess: false);
-      return;
+    if (_savedEvent != null) {
+      final refreshed = await _refreshLatestAll(showSuccess: false);
+      if (!mounted || !refreshed) return;
+
+      if (_hasAdoptedSchedule) {
+        _showMessage(
+          l10n.cannotRegenerateAdoptedScheduleMessage,
+          type: AppMessageType.warning,
+        );
+        return;
+      }
+
+      if (_generatedScheduleId != displayedGeneratedScheduleId) {
+        return;
+      }
     }
 
     if (!_hasGeneratedSchedule) {
@@ -225,6 +232,7 @@ class _SchedulePageState extends State<SchedulePage> {
       return;
     }
 
+    final expectedGeneratedScheduleId = _generatedScheduleId;
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) {
@@ -247,15 +255,19 @@ class _SchedulePageState extends State<SchedulePage> {
 
     if (!mounted || confirmed != true) return;
 
-    final latestBeforeGenerate = await _refreshSavedEventForAction();
-    if (!mounted) return;
+    final refreshedBeforeGenerate =
+        await _refreshLatestAll(showSuccess: false);
+    if (!mounted || !refreshedBeforeGenerate) return;
 
-    if (latestBeforeGenerate?.event.hasAdoptedSchedule == true) {
+    if (_hasAdoptedSchedule) {
       _showMessage(
         l10n.cannotRegenerateAdoptedScheduleMessage,
         type: AppMessageType.warning,
       );
-      await _reloadSchedule(showSuccess: false);
+      return;
+    }
+
+    if (_generatedScheduleId != expectedGeneratedScheduleId) {
       return;
     }
 

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -47,6 +47,7 @@ class _SchedulePageState extends State<SchedulePage> {
   bool _isLoading = true;
   bool _isAdopting = false;
   bool _isRefreshing = false;
+  bool _isCheckingRegenerate = false;
   bool _isOpeningSharedDataDialog = false;
   int _refreshRequestSequence = 0;
   String? _errorMessage;
@@ -207,32 +208,21 @@ class _SchedulePageState extends State<SchedulePage> {
   }
 
   Future<void> _requestGenerateSchedule() async {
-    final l10n = AppLocalizations.of(context);
-    final displayedGeneratedScheduleId = _generatedScheduleId;
-
-    if (_savedEvent != null) {
-      final refreshed = await _refreshLatestAll(showSuccess: false);
-      if (!mounted || !refreshed) return;
-
-      if (_hasAdoptedSchedule) {
-        _showMessage(
-          l10n.cannotRegenerateAdoptedScheduleMessage,
-          type: AppMessageType.warning,
-        );
-        return;
-      }
-
-      if (_generatedScheduleId != displayedGeneratedScheduleId) {
-        return;
-      }
-    }
+    if (_isCheckingRegenerate || _isLoading || _isAdopting) return;
 
     if (!_hasGeneratedSchedule) {
       await _generateSchedule();
       return;
     }
 
+    final l10n = AppLocalizations.of(context);
     final expectedGeneratedScheduleId = _generatedScheduleId;
+    if (expectedGeneratedScheduleId == null ||
+        expectedGeneratedScheduleId.isEmpty) {
+      await _generateSchedule();
+      return;
+    }
+
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) {
@@ -255,23 +245,117 @@ class _SchedulePageState extends State<SchedulePage> {
 
     if (!mounted || confirmed != true) return;
 
-    final refreshedBeforeGenerate =
-        await _refreshLatestAll(showSuccess: false);
-    if (!mounted || !refreshedBeforeGenerate) return;
-
-    if (_hasAdoptedSchedule) {
-      _showMessage(
-        l10n.cannotRegenerateAdoptedScheduleMessage,
-        type: AppMessageType.warning,
-      );
-      return;
-    }
-
-    if (_generatedScheduleId != expectedGeneratedScheduleId) {
-      return;
-    }
+    final canGenerate = await _refreshBeforeRegenerate(
+      expectedGeneratedScheduleId: expectedGeneratedScheduleId,
+    );
+    if (!mounted || !canGenerate) return;
 
     await _generateSchedule();
+  }
+
+  Future<bool> _refreshBeforeRegenerate({
+    required String expectedGeneratedScheduleId,
+  }) async {
+    final aggregate = _savedEvent;
+    if (aggregate == null) return false;
+
+    final l10n = AppLocalizations.of(context);
+    final requestSequence = ++_refreshRequestSequence;
+    final currentSnapshot = _currentRefreshSnapshot;
+
+    setState(() {
+      _isCheckingRegenerate = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final snapshot = await _refreshService.loadLatestByPublicId(
+        publicId: aggregate.event.publicId,
+        current: currentSnapshot,
+      );
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return false;
+      }
+
+      final shouldApplySnapshot =
+          currentSnapshot == null || snapshot.hasChanges;
+      final latestPlayerIds =
+          snapshot.aggregate.players.map((player) => player.id).toSet();
+      final selectedPlayerId = _selectedPlayerId;
+
+      setState(() {
+        if (shouldApplySnapshot) {
+          _savedEvent = snapshot.aggregate;
+          _scheduleResponse = snapshot.scheduleResponse;
+          _generatedScheduleId = snapshot.generatedScheduleId;
+          _progressSummary = snapshot.progressSummary;
+          _matchProgresses = snapshot.matches;
+          if (selectedPlayerId != null &&
+              !latestPlayerIds.contains(selectedPlayerId)) {
+            _selectedPlayerId = null;
+          }
+        }
+      });
+
+      await _saveScheduleHistory(snapshot.aggregate);
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return false;
+      }
+
+      if (snapshot.aggregate.event.hasAdoptedSchedule) {
+        _showMessage(
+          l10n.cannotRegenerateAdoptedScheduleMessage,
+          type: AppMessageType.warning,
+        );
+        return false;
+      }
+
+      if (snapshot.generatedScheduleId != expectedGeneratedScheduleId) {
+        _showMessage(
+          l10n.scheduleUpdatedReloadMessage,
+          type: AppMessageType.info,
+        );
+        return false;
+      }
+
+      return true;
+    } on DoublesScheduleNotFoundException {
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return false;
+      }
+
+      setState(() {
+        _savedEvent = null;
+        _scheduleResponse = null;
+        _generatedScheduleId = null;
+        _selectedPlayerId = null;
+        _progressSummary = null;
+        _matchProgresses = const [];
+        _errorMessage = l10n.scheduleNotFoundMessage;
+      });
+      _showMessage(
+        l10n.scheduleNotFoundMessage,
+        type: AppMessageType.error,
+      );
+      return false;
+    } catch (e) {
+      if (!mounted || requestSequence != _refreshRequestSequence) {
+        return false;
+      }
+
+      final message = l10n.reloadScheduleFailedMessage(e.toString());
+      setState(() {
+        _errorMessage = message;
+      });
+      _showMessage(message, type: AppMessageType.error);
+      return false;
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isCheckingRegenerate = false;
+        });
+      }
+    }
   }
 
   Future<SavedEventAggregate?> _refreshSavedEventForAction() async {
@@ -818,11 +902,14 @@ class _SchedulePageState extends State<SchedulePage> {
             canChangeCourtDisplay: !_hasAdoptedSchedule &&
                 _savedEvent != null &&
                 !_isRefreshing &&
+                !_isCheckingRegenerate &&
                 !_isOpeningSharedDataDialog,
             onChangeCourtDisplay: _changeCourtDisplay,
             showActionButtons: !_hasAdoptedSchedule,
-            isLoading:
-                _isLoading || _isRefreshing || _isOpeningSharedDataDialog,
+            isLoading: _isLoading ||
+                _isRefreshing ||
+                _isCheckingRegenerate ||
+                _isOpeningSharedDataDialog,
             isAdopting: _isAdopting,
             generateButtonLabel: _generateButtonLabel(l10n),
             canAdopt: _generatedScheduleId != null && _scheduleResponse != null,

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -156,7 +156,9 @@ class _SchedulePageState extends State<SchedulePage> {
 
   int get _displayPlayerCount {
     final savedPlayers = _orderedSavedPlayers;
-    return savedPlayers.isEmpty ? widget.draft.playerCount : savedPlayers.length;
+    return savedPlayers.isEmpty
+        ? widget.draft.playerCount
+        : savedPlayers.length;
   }
 
   List<SavedEventCourtSetting> get _courtSettings {
@@ -805,8 +807,8 @@ class _SchedulePageState extends State<SchedulePage> {
     } catch (e) {
       if (!mounted) return;
 
-      final message =
-          AppLocalizations.of(context).reloadScheduleFailedMessage(e.toString());
+      final message = AppLocalizations.of(context)
+          .reloadScheduleFailedMessage(e.toString());
       setState(() {
         _errorMessage = message;
       });

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -446,6 +446,7 @@ class _SchedulePageState extends State<SchedulePage> {
 
     final l10n = AppLocalizations.of(context);
     final requestSequence = ++_refreshRequestSequence;
+    final currentSnapshot = _currentRefreshSnapshot;
     final previousGeneratedScheduleId = _generatedScheduleId;
     final hadExistingDisplay = _scheduleResponse != null;
 
@@ -460,25 +461,29 @@ class _SchedulePageState extends State<SchedulePage> {
     try {
       final snapshot = await _refreshService.loadLatestByPublicId(
         publicId: aggregate.event.publicId,
-        current: _currentRefreshSnapshot,
+        current: currentSnapshot,
       );
       if (!mounted || requestSequence != _refreshRequestSequence) {
         return false;
       }
 
+      final shouldApplySnapshot =
+          currentSnapshot == null || snapshot.hasChanges;
       final latestPlayerIds =
           snapshot.aggregate.players.map((player) => player.id).toSet();
       final selectedPlayerId = _selectedPlayerId;
 
       setState(() {
-        _savedEvent = snapshot.aggregate;
-        _scheduleResponse = snapshot.scheduleResponse;
-        _generatedScheduleId = snapshot.generatedScheduleId;
-        _progressSummary = snapshot.progressSummary;
-        _matchProgresses = snapshot.matches;
-        if (selectedPlayerId != null &&
-            !latestPlayerIds.contains(selectedPlayerId)) {
-          _selectedPlayerId = null;
+        if (shouldApplySnapshot) {
+          _savedEvent = snapshot.aggregate;
+          _scheduleResponse = snapshot.scheduleResponse;
+          _generatedScheduleId = snapshot.generatedScheduleId;
+          _progressSummary = snapshot.progressSummary;
+          _matchProgresses = snapshot.matches;
+          if (selectedPlayerId != null &&
+              !latestPlayerIds.contains(selectedPlayerId)) {
+            _selectedPlayerId = null;
+          }
         }
         if (snapshot.aggregate.players.isEmpty) {
           _errorMessage = l10n.noPlayersMessage;
@@ -507,7 +512,7 @@ class _SchedulePageState extends State<SchedulePage> {
         );
       } else if (showSuccess) {
         _showMessage(
-          l10n.eventInfoLoadedMessage,
+          l10n.bocciaScoreRefreshedMessage,
           type: AppMessageType.success,
         );
       }

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -7,11 +7,15 @@ class ScheduleEventSummaryCard extends StatelessWidget {
     this.onShareUrl,
     this.onRefresh,
     this.canRefresh = true,
+    this.isRefreshing = false,
+    this.progressText,
   });
 
   final VoidCallback? onShareUrl;
   final VoidCallback? onRefresh;
   final bool canRefresh;
+  final bool isRefreshing;
+  final String? progressText;
 
   @override
   Widget build(BuildContext context) {
@@ -36,9 +40,20 @@ class ScheduleEventSummaryCard extends StatelessWidget {
                   ),
                 if (onRefresh != null)
                   FilledButton.tonalIcon(
-                    onPressed: canRefresh ? onRefresh : null,
-                    icon: const Icon(Icons.sync),
+                    onPressed: canRefresh && !isRefreshing ? onRefresh : null,
+                    icon: isRefreshing
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.sync),
                     label: Text(l10n.refreshLatestButton),
+                  ),
+                if (progressText != null)
+                  Chip(
+                    avatar: const Icon(Icons.sports_score, size: 18),
+                    label: Text(progressText!),
                   ),
               ],
             ),

--- a/lib/shared/presentation/app_message_type.dart
+++ b/lib/shared/presentation/app_message_type.dart
@@ -1,0 +1,6 @@
+enum AppMessageType {
+  success,
+  info,
+  warning,
+  error,
+}

--- a/test/features/doubles_scheduler/application/doubles_schedule_refresh_service_test.dart
+++ b/test/features/doubles_scheduler/application/doubles_schedule_refresh_service_test.dart
@@ -9,13 +9,12 @@ import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_m
 void main() {
   group('DoublesScheduleRefreshService', () {
     test('loads schedule without creating progress summary', () async {
-      final eventRepository = _FakeEventRepository(
-        aggregate: _buildAggregate(generatedScheduleId: 'generated-1'),
-      );
       final progressRepository = _FakeProgressRepository();
       var scheduleLoadCount = 0;
       final service = DoublesScheduleRefreshService(
-        eventRepository: eventRepository,
+        eventRepository: _FakeEventRepository(
+          aggregate: _buildAggregate(generatedScheduleId: 'generated-1'),
+        ),
         progressRepository: progressRepository,
         loadGeneratedSchedule: (generatedScheduleId) async {
           scheduleLoadCount += 1;
@@ -36,19 +35,17 @@ void main() {
       expect(snapshot.progressText, '- / -');
     });
 
-    test('reuses schedule and matches when revisions are unchanged', () async {
+    test('reuses unchanged schedule and progress matches', () async {
       final aggregate = _buildAggregate(generatedScheduleId: 'generated-1');
-      final scope = _scope('generated-1');
       final summary = _summary(revision: 2);
-      final match = _match(revision: 3);
       final current = DoublesScheduleRefreshSnapshot(
         aggregate: aggregate,
         scheduleResponse: const <String, dynamic>{
           'generated_schedule_id': 'generated-1',
         },
-        progressScope: scope,
+        progressScope: _scope('generated-1'),
         progressSummary: summary,
-        matches: <ScheduleMatchProgress>[match],
+        matches: <ScheduleMatchProgress>[_match(revision: 3)],
         eventChanged: false,
         scheduleChanged: false,
         progressChanged: false,
@@ -58,11 +55,9 @@ void main() {
       final service = DoublesScheduleRefreshService(
         eventRepository: _FakeEventRepository(aggregate: aggregate),
         progressRepository: progressRepository,
-        loadGeneratedSchedule: (generatedScheduleId) async {
+        loadGeneratedSchedule: (_) async {
           scheduleLoadCount += 1;
-          return <String, dynamic>{
-            'generated_schedule_id': generatedScheduleId,
-          };
+          return const <String, dynamic>{};
         },
       );
 
@@ -79,10 +74,9 @@ void main() {
       expect(snapshot.matches.single.revision, 3);
     });
 
-    test('reloads matches when progress summary revision changes', () async {
-      final aggregate = _buildAggregate(generatedScheduleId: 'generated-1');
+    test('reloads schedule and matches when versions change', () async {
       final current = DoublesScheduleRefreshSnapshot(
-        aggregate: aggregate,
+        aggregate: _buildAggregate(generatedScheduleId: 'generated-1'),
         scheduleResponse: const <String, dynamic>{
           'generated_schedule_id': 'generated-1',
         },
@@ -93,41 +87,16 @@ void main() {
         scheduleChanged: false,
         progressChanged: false,
       );
-      final latestMatch = _match(revision: 2);
+      final latestMatch = _match(
+        generatedScheduleId: 'generated-2',
+        revision: 2,
+      );
       final progressRepository = _FakeProgressRepository(
-        summary: _summary(revision: 2),
+        summary: _summary(
+          generatedScheduleId: 'generated-2',
+          revision: 2,
+        ),
         matches: <ScheduleMatchProgress>[latestMatch],
-      );
-      final service = DoublesScheduleRefreshService(
-        eventRepository: _FakeEventRepository(aggregate: aggregate),
-        progressRepository: progressRepository,
-        loadGeneratedSchedule: (_) async =>
-            throw StateError('schedule must be reused'),
-      );
-
-      final snapshot = await service.loadLatestByPublicId(
-        publicId: 'ABC123',
-        current: current,
-      );
-
-      expect(progressRepository.listMatchesCallCount, 1);
-      expect(snapshot.progressChanged, isTrue);
-      expect(snapshot.matches.single.revision, 2);
-      expect(snapshot.progressText, '0 / 15');
-    });
-
-    test('reloads generated schedule when display id changes', () async {
-      final current = DoublesScheduleRefreshSnapshot(
-        aggregate: _buildAggregate(generatedScheduleId: 'generated-1'),
-        scheduleResponse: const <String, dynamic>{
-          'generated_schedule_id': 'generated-1',
-        },
-        progressScope: _scope('generated-1'),
-        progressSummary: null,
-        matches: const <ScheduleMatchProgress>[],
-        eventChanged: false,
-        scheduleChanged: false,
-        progressChanged: false,
       );
       var loadedId = '';
       final service = DoublesScheduleRefreshService(
@@ -137,7 +106,7 @@ void main() {
             revision: 2,
           ),
         ),
-        progressRepository: _FakeProgressRepository(),
+        progressRepository: progressRepository,
         loadGeneratedSchedule: (generatedScheduleId) async {
           loadedId = generatedScheduleId;
           return <String, dynamic>{
@@ -152,9 +121,12 @@ void main() {
       );
 
       expect(loadedId, 'generated-2');
+      expect(progressRepository.listMatchesCallCount, 1);
       expect(snapshot.eventChanged, isTrue);
       expect(snapshot.scheduleChanged, isTrue);
-      expect(snapshot.generatedScheduleId, 'generated-2');
+      expect(snapshot.progressChanged, isTrue);
+      expect(snapshot.matches.single.generatedScheduleId, 'generated-2');
+      expect(snapshot.progressText, '0 / 15');
     });
 
     test('throws not found when event does not exist', () async {
@@ -164,8 +136,8 @@ void main() {
         loadGeneratedSchedule: (_) async => const <String, dynamic>{},
       );
 
-      expect(
-        () => service.loadLatestByPublicId(publicId: 'ABC123'),
+      await expectLater(
+        service.loadLatestByPublicId(publicId: 'ABC123'),
         throwsA(isA<DoublesScheduleNotFoundException>()),
       );
     });
@@ -221,12 +193,15 @@ ScheduleProgressScope _scope(String generatedScheduleId) {
   );
 }
 
-ScheduleProgressSummary _summary({required int revision}) {
+ScheduleProgressSummary _summary({
+  String generatedScheduleId = 'generated-1',
+  required int revision,
+}) {
   final now = DateTime.utc(2026, 7, 31, 1);
   return ScheduleProgressSummary(
     schemaVersion: ScheduleProgressSummary.currentSchemaVersion,
     scheduleType: ScheduleProgressScheduleType.doubles,
-    generatedScheduleId: 'generated-1',
+    generatedScheduleId: generatedScheduleId,
     totalMatchCount: 15,
     completedMatchCount: 0,
     inProgressMatchCount: 0,
@@ -236,12 +211,15 @@ ScheduleProgressSummary _summary({required int revision}) {
   );
 }
 
-ScheduleMatchProgress _match({required int revision}) {
+ScheduleMatchProgress _match({
+  String generatedScheduleId = 'generated-1',
+  required int revision,
+}) {
   final now = DateTime.utc(2026, 7, 31, 1);
   return ScheduleMatchProgress(
     schemaVersion: ScheduleMatchProgress.currentSchemaVersion,
     scheduleType: ScheduleProgressScheduleType.doubles,
-    generatedScheduleId: 'generated-1',
+    generatedScheduleId: generatedScheduleId,
     roundNo: 1,
     courtNo: 1,
     matchNo: 1,

--- a/test/features/doubles_scheduler/application/doubles_schedule_refresh_service_test.dart
+++ b/test/features/doubles_scheduler/application/doubles_schedule_refresh_service_test.dart
@@ -1,0 +1,360 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:srp_lanske/features/doubles_scheduler/application/doubles_schedule_refresh_service.dart';
+import 'package:srp_lanske/features/doubles_scheduler/application/event_repository.dart';
+import 'package:srp_lanske/features/doubles_scheduler/domain/saved_event_models.dart';
+import 'package:srp_lanske/features/doubles_scheduler/presentation/models/event_draft.dart';
+import 'package:srp_lanske/features/schedule_progress/application/schedule_progress_repository.dart';
+import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_models.dart';
+
+void main() {
+  group('DoublesScheduleRefreshService', () {
+    test('loads schedule without creating progress summary', () async {
+      final eventRepository = _FakeEventRepository(
+        aggregate: _buildAggregate(generatedScheduleId: 'generated-1'),
+      );
+      final progressRepository = _FakeProgressRepository();
+      var scheduleLoadCount = 0;
+      final service = DoublesScheduleRefreshService(
+        eventRepository: eventRepository,
+        progressRepository: progressRepository,
+        loadGeneratedSchedule: (generatedScheduleId) async {
+          scheduleLoadCount += 1;
+          return <String, dynamic>{
+            'generated_schedule_id': generatedScheduleId,
+          };
+        },
+      );
+
+      final snapshot = await service.loadLatestByPublicId(publicId: 'ABC123');
+
+      expect(scheduleLoadCount, 1);
+      expect(progressRepository.ensureSummaryCallCount, 0);
+      expect(progressRepository.findSummaryCallCount, 1);
+      expect(progressRepository.listMatchesCallCount, 0);
+      expect(snapshot.progressSummary, isNull);
+      expect(snapshot.matches, isEmpty);
+      expect(snapshot.progressText, '- / -');
+    });
+
+    test('reuses schedule and matches when revisions are unchanged', () async {
+      final aggregate = _buildAggregate(generatedScheduleId: 'generated-1');
+      final scope = _scope('generated-1');
+      final summary = _summary(revision: 2);
+      final match = _match(revision: 3);
+      final current = DoublesScheduleRefreshSnapshot(
+        aggregate: aggregate,
+        scheduleResponse: const <String, dynamic>{
+          'generated_schedule_id': 'generated-1',
+        },
+        progressScope: scope,
+        progressSummary: summary,
+        matches: <ScheduleMatchProgress>[match],
+        eventChanged: false,
+        scheduleChanged: false,
+        progressChanged: false,
+      );
+      final progressRepository = _FakeProgressRepository(summary: summary);
+      var scheduleLoadCount = 0;
+      final service = DoublesScheduleRefreshService(
+        eventRepository: _FakeEventRepository(aggregate: aggregate),
+        progressRepository: progressRepository,
+        loadGeneratedSchedule: (generatedScheduleId) async {
+          scheduleLoadCount += 1;
+          return <String, dynamic>{
+            'generated_schedule_id': generatedScheduleId,
+          };
+        },
+      );
+
+      final snapshot = await service.loadLatestByPublicId(
+        publicId: 'ABC123',
+        current: current,
+      );
+
+      expect(scheduleLoadCount, 0);
+      expect(progressRepository.listMatchesCallCount, 0);
+      expect(snapshot.eventChanged, isFalse);
+      expect(snapshot.scheduleChanged, isFalse);
+      expect(snapshot.progressChanged, isFalse);
+      expect(snapshot.matches.single.revision, 3);
+    });
+
+    test('reloads matches when progress summary revision changes', () async {
+      final aggregate = _buildAggregate(generatedScheduleId: 'generated-1');
+      final current = DoublesScheduleRefreshSnapshot(
+        aggregate: aggregate,
+        scheduleResponse: const <String, dynamic>{
+          'generated_schedule_id': 'generated-1',
+        },
+        progressScope: _scope('generated-1'),
+        progressSummary: _summary(revision: 1),
+        matches: <ScheduleMatchProgress>[_match(revision: 1)],
+        eventChanged: false,
+        scheduleChanged: false,
+        progressChanged: false,
+      );
+      final latestMatch = _match(revision: 2);
+      final progressRepository = _FakeProgressRepository(
+        summary: _summary(revision: 2),
+        matches: <ScheduleMatchProgress>[latestMatch],
+      );
+      final service = DoublesScheduleRefreshService(
+        eventRepository: _FakeEventRepository(aggregate: aggregate),
+        progressRepository: progressRepository,
+        loadGeneratedSchedule: (_) async =>
+            throw StateError('schedule must be reused'),
+      );
+
+      final snapshot = await service.loadLatestByPublicId(
+        publicId: 'ABC123',
+        current: current,
+      );
+
+      expect(progressRepository.listMatchesCallCount, 1);
+      expect(snapshot.progressChanged, isTrue);
+      expect(snapshot.matches.single.revision, 2);
+      expect(snapshot.progressText, '0 / 15');
+    });
+
+    test('reloads generated schedule when display id changes', () async {
+      final current = DoublesScheduleRefreshSnapshot(
+        aggregate: _buildAggregate(generatedScheduleId: 'generated-1'),
+        scheduleResponse: const <String, dynamic>{
+          'generated_schedule_id': 'generated-1',
+        },
+        progressScope: _scope('generated-1'),
+        progressSummary: null,
+        matches: const <ScheduleMatchProgress>[],
+        eventChanged: false,
+        scheduleChanged: false,
+        progressChanged: false,
+      );
+      var loadedId = '';
+      final service = DoublesScheduleRefreshService(
+        eventRepository: _FakeEventRepository(
+          aggregate: _buildAggregate(
+            generatedScheduleId: 'generated-2',
+            revision: 2,
+          ),
+        ),
+        progressRepository: _FakeProgressRepository(),
+        loadGeneratedSchedule: (generatedScheduleId) async {
+          loadedId = generatedScheduleId;
+          return <String, dynamic>{
+            'generated_schedule_id': generatedScheduleId,
+          };
+        },
+      );
+
+      final snapshot = await service.loadLatestByPublicId(
+        publicId: 'ABC123',
+        current: current,
+      );
+
+      expect(loadedId, 'generated-2');
+      expect(snapshot.eventChanged, isTrue);
+      expect(snapshot.scheduleChanged, isTrue);
+      expect(snapshot.generatedScheduleId, 'generated-2');
+    });
+
+    test('throws not found when event does not exist', () async {
+      final service = DoublesScheduleRefreshService(
+        eventRepository: _FakeEventRepository(aggregate: null),
+        progressRepository: _FakeProgressRepository(),
+        loadGeneratedSchedule: (_) async => const <String, dynamic>{},
+      );
+
+      expect(
+        () => service.loadLatestByPublicId(publicId: 'ABC123'),
+        throwsA(isA<DoublesScheduleNotFoundException>()),
+      );
+    });
+  });
+}
+
+SavedEventAggregate _buildAggregate({
+  required String generatedScheduleId,
+  int revision = 1,
+}) {
+  final now = DateTime.utc(2026, 7, 31, 1);
+  final event = SavedEvent(
+    id: 'event-1',
+    publicId: 'ABC123',
+    title: 'Event',
+    courtCount: 1,
+    sourceType: EventSourceType.manual,
+    sourceUrl: null,
+    status: SavedEventStatus.generated,
+    currentGeneratedScheduleId: generatedScheduleId,
+    createdAt: now,
+    updatedAt: now,
+    revision: revision,
+  );
+
+  return SavedEventAggregate(
+    event: event,
+    players: <SavedEventPlayer>[
+      SavedEventPlayer(
+        id: 'player-1',
+        eventId: event.id,
+        displayName: 'Player 1',
+        orderNo: 1,
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      ),
+    ],
+    share: SavedEventShare(
+      publicId: event.publicId,
+      eventId: event.id,
+      createdAt: now,
+      updatedAt: now,
+    ),
+  );
+}
+
+ScheduleProgressScope _scope(String generatedScheduleId) {
+  return ScheduleProgressScope(
+    scheduleType: ScheduleProgressScheduleType.doubles,
+    shareId: 'ABC123',
+    generatedScheduleId: generatedScheduleId,
+  );
+}
+
+ScheduleProgressSummary _summary({required int revision}) {
+  final now = DateTime.utc(2026, 7, 31, 1);
+  return ScheduleProgressSummary(
+    schemaVersion: ScheduleProgressSummary.currentSchemaVersion,
+    scheduleType: ScheduleProgressScheduleType.doubles,
+    generatedScheduleId: 'generated-1',
+    totalMatchCount: 15,
+    completedMatchCount: 0,
+    inProgressMatchCount: 0,
+    createdAt: now,
+    updatedAt: now,
+    revision: revision,
+  );
+}
+
+ScheduleMatchProgress _match({required int revision}) {
+  final now = DateTime.utc(2026, 7, 31, 1);
+  return ScheduleMatchProgress(
+    schemaVersion: ScheduleMatchProgress.currentSchemaVersion,
+    scheduleType: ScheduleProgressScheduleType.doubles,
+    generatedScheduleId: 'generated-1',
+    roundNo: 1,
+    courtNo: 1,
+    matchNo: 1,
+    status: ScheduleMatchStatus.scheduled,
+    result: null,
+    note: '',
+    startedAt: null,
+    finishedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    revision: revision,
+  );
+}
+
+class _FakeEventRepository implements EventRepository {
+  _FakeEventRepository({required this.aggregate});
+
+  final SavedEventAggregate? aggregate;
+
+  @override
+  Future<SavedEventAggregate?> findByPublicId(String publicId) async {
+    return aggregate;
+  }
+
+  @override
+  Future<SavedEventAggregate> createFromDraft(EventDraft draft) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<SavedEventPlayer>> listPlayers(String eventId) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SavedEvent> updateAdoptedGeneratedScheduleId({
+    required String eventId,
+    required String generatedScheduleId,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SavedEventAggregate> updateCourtSettings({
+    required String eventId,
+    required List<SavedEventCourtSetting> courtSettings,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SavedEvent> updateCurrentGeneratedScheduleId({
+    required String eventId,
+    required String generatedScheduleId,
+  }) {
+    throw UnimplementedError();
+  }
+}
+
+class _FakeProgressRepository implements ScheduleProgressRepository {
+  _FakeProgressRepository({
+    this.summary,
+    this.matches = const <ScheduleMatchProgress>[],
+  });
+
+  final ScheduleProgressSummary? summary;
+  final List<ScheduleMatchProgress> matches;
+  int ensureSummaryCallCount = 0;
+  int findSummaryCallCount = 0;
+  int listMatchesCallCount = 0;
+
+  @override
+  Future<ScheduleProgressSummary> ensureSummary({
+    required ScheduleProgressScope scope,
+    required int totalMatchCount,
+  }) {
+    ensureSummaryCallCount += 1;
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<ScheduleProgressSummary?> findSummary(
+    ScheduleProgressScope scope,
+  ) async {
+    findSummaryCallCount += 1;
+    return summary;
+  }
+
+  @override
+  Future<List<ScheduleMatchProgress>> listMatches(
+    ScheduleProgressScope scope,
+  ) async {
+    listMatchesCallCount += 1;
+    return matches;
+  }
+
+  @override
+  Future<ScheduleMatchProgress> findMatch({
+    required ScheduleProgressScope scope,
+    required int roundNo,
+    required int courtNo,
+    int? matchNo,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<ScheduleMatchProgress> saveMatch({
+    required ScheduleProgressScope scope,
+    required ScheduleMatchProgressUpdate update,
+    required int totalMatchCount,
+    required int expectedRevision,
+  }) {
+    throw UnimplementedError();
+  }
+}

--- a/test/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card_test.dart
+++ b/test/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:srp_lanske/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
+
+void main() {
+  testWidgets('disables refresh while loading and shows progress text',
+      (tester) async {
+    var refreshCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('ja'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ScheduleEventSummaryCard(
+            onRefresh: () {
+              refreshCount += 1;
+            },
+            isRefreshing: true,
+            progressText: '- / -',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('- / -'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await tester.tap(find.byType(FilledButton));
+    expect(refreshCount, 0);
+  });
+
+  testWidgets('runs refresh action when enabled', (tester) async {
+    var refreshCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('ja'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ScheduleEventSummaryCard(
+            onRefresh: () {
+              refreshCount += 1;
+            },
+            progressText: '3 / 15',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('3 / 15'), findsOneWidget);
+    expect(find.byIcon(Icons.sync), findsOneWidget);
+
+    await tester.tap(find.byType(FilledButton));
+    expect(refreshCount, 1);
+  });
+}


### PR DESCRIPTION
## 概要

ダブルス対戦表で、手動更新や共有データの操作、再生成・採用の前後に最新情報を確認できるようにします。

複数端末で同じ共有URLを開いている場合も、古い表示状態のまま操作を続行せず、イベント・表示対象の対戦表・試合進行の変更へ追従します。

## 内容

- ダブルス対戦表用の共通更新サービスを追加
  - event revision
  - display generated schedule ID
  - progress summary revision
  を比較し、変更された範囲だけ再取得
- 生成直後画面と共有URLからの復元画面で更新処理を共通化
- 「最新の情報に更新」ボタンを追加
- 更新中は現在の対戦表を残し、対象操作の重複実行を抑止
- 最新リクエストの結果だけを画面へ反映する request sequence を追加
- 一時的な取得失敗では既存表示を維持
- 対戦表が削除・不存在の場合はエラー状態へ移行
- 共有データを扱うダイアログの表示前後に最新情報を取得
  - 現時点ではコート表示設定ダイアログへ適用
- 再生成確定後に保存済み状態を確認
  - 表示中の対戦表と同じ場合のみ再生成
  - 別端末ですでに再生成されている場合は、追加生成せず最新の対戦表を表示
  - 採用済みになっている場合は再生成を中止
- 採用前に表示中の対戦表と保存済みの対戦表を照合
- progress summary が存在しない場合は進捗を `- / -` と表示
- 後続の試合編集から利用する、対象試合の最新情報取得口を用意
- 通知を `success / info / warning / error` の種別で扱えるように整理
- 更新サービスと更新ボタンのテストを追加

## 動作確認

- [x] local で確認
- [x] ~Codespaces で確認~

確認内容:

- `dart format lib/ test/`
- `flutter analyze`
- `flutter test`
- Firestoreへのイベント保存
- ページ更新からの対戦表復元
- 共有URLからの対戦表表示
- 手動更新
- 複数端末での再生成・採用・最新状態への追従
- progress summary 未作成時の `- / -` 表示

## Issue

closes #144