### PR TITLE
🎨 Unify SnackBar notifications and display rules refs #150

### DIFF
--- a/lib/app/theme/app_theme.dart
+++ b/lib/app/theme/app_theme.dart
@@ -32,4 +32,11 @@ final ThemeData appTheme = _baseTheme.copyWith(
       ),
     ),
   ),
+  snackBarTheme: SnackBarThemeData(
+    behavior: SnackBarBehavior.floating,
+    elevation: 6,
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(20),
+    ),
+  ),
 );

--- a/lib/features/doubles_scheduler/presentation/event_list_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_list_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
+import 'package:srp_lanske/shared/presentation/app_message_type.dart';
+import 'package:srp_lanske/shared/presentation/app_snack_bar.dart';
 import 'package:srp_lanske/shared/utils/browser_url.dart';
 
 import '../data/local_schedule_history_item.dart';
@@ -133,13 +135,10 @@ class _EventListPageState extends State<EventListPage> {
   }
 
   void _showMessage(String message) {
-    final messenger = ScaffoldMessenger.of(context);
-    messenger.hideCurrentSnackBar();
-    messenger.showSnackBar(
-      SnackBar(
-        content: Text(message),
-        duration: const Duration(seconds: 2),
-      ),
+    AppSnackBar.show(
+      context,
+      message: message,
+      type: AppMessageType.success,
     );
   }
 

--- a/lib/features/doubles_scheduler/presentation/event_setup_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_setup_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:srp_lanske/app/config/app_config.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
+import 'package:srp_lanske/shared/presentation/app_message_type.dart';
+import 'package:srp_lanske/shared/presentation/app_snack_bar.dart';
 import 'package:srp_lanske/shared/utils/external_link.dart';
 import 'package:srp_lanske/shared/utils/number_label_mapper.dart';
 
@@ -130,14 +132,14 @@ class _EventSetupPageState extends State<EventSetupPage> {
     }
   }
 
-  void _showMessage(String message) {
-    final messenger = ScaffoldMessenger.of(context);
-    messenger.hideCurrentSnackBar();
-    messenger.showSnackBar(
-      SnackBar(
-        content: Text(message),
-        duration: const Duration(seconds: 2),
-      ),
+  void _showMessage(
+    String message, {
+    AppMessageType type = AppMessageType.info,
+  }) {
+    AppSnackBar.show(
+      context,
+      message: message,
+      type: type,
     );
   }
 
@@ -388,12 +390,18 @@ class _EventSetupPageState extends State<EventSetupPage> {
     final originalUrl = _urlController.text.trim();
     final parsedUrl = parseTennisbearEventUrl(originalUrl);
     if (originalUrl.isEmpty) {
-      _showMessage(l10n.enterUrlMessage);
+      _showMessage(
+        l10n.enterUrlMessage,
+        type: AppMessageType.warning,
+      );
       return;
     }
 
     if (parsedUrl == null) {
-      _showMessage(l10n.enterTennisbearEventUrlMessage);
+      _showMessage(
+        l10n.enterTennisbearEventUrlMessage,
+        type: AppMessageType.warning,
+      );
       return;
     }
 
@@ -459,9 +467,15 @@ class _EventSetupPageState extends State<EventSetupPage> {
 
       final warnings = preview.warnings;
       if (warnings.isEmpty) {
-        _showMessage(l10n.eventInfoLoadedMessage);
+        _showMessage(
+          l10n.eventInfoLoadedMessage,
+          type: AppMessageType.success,
+        );
       } else {
-        _showMessage(l10n.eventInfoPartiallyLoadedMessage);
+        _showMessage(
+          l10n.eventInfoPartiallyLoadedMessage,
+          type: AppMessageType.warning,
+        );
       }
     } on TennisbearImportPreviewApiException catch (e) {
       final elapsed = DateTime.now().difference(startedAt);
@@ -471,7 +485,10 @@ class _EventSetupPageState extends State<EventSetupPage> {
       }
 
       if (!mounted) return;
-      _showMessage(e.message);
+      _showMessage(
+        e.message,
+        type: AppMessageType.error,
+      );
     } catch (_) {
       final elapsed = DateTime.now().difference(startedAt);
       const minLoading = Duration(milliseconds: 500);
@@ -481,7 +498,10 @@ class _EventSetupPageState extends State<EventSetupPage> {
 
       if (!mounted) return;
       // TODO: イベント情報取得失敗時のエラーログを送る仕組みができたら、ここで例外内容も送る。adminにメール送信するのもあり。
-      _showMessage(l10n.eventInfoLoadFailedMessage);
+      _showMessage(
+        l10n.eventInfoLoadFailedMessage,
+        type: AppMessageType.error,
+      );
     } finally {
       if (mounted) {
         setState(() {
@@ -547,7 +567,10 @@ class _EventSetupPageState extends State<EventSetupPage> {
     final text = data?.text?.trim() ?? '';
 
     if (text.isEmpty) {
-      _showMessage(l10n.clipboardUrlNotFoundMessage);
+      _showMessage(
+        l10n.clipboardUrlNotFoundMessage,
+        type: AppMessageType.warning,
+      );
       return;
     }
 
@@ -561,7 +584,10 @@ class _EventSetupPageState extends State<EventSetupPage> {
     });
 
     if (parseTennisbearEventUrl(text) == null) {
-      _showMessage(l10n.pasteTennisbearEventUrlMessage);
+      _showMessage(
+        l10n.pasteTennisbearEventUrlMessage,
+        type: AppMessageType.warning,
+      );
     }
   }
 

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -6,6 +6,7 @@ import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_m
 import 'package:srp_lanske/l10n/l10n.dart';
 import 'package:srp_lanske/shared/infrastructure/generated_schedule_api_client.dart';
 import 'package:srp_lanske/shared/presentation/app_message_type.dart';
+import 'package:srp_lanske/shared/presentation/app_snack_bar.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 import 'package:srp_lanske/shared/utils/browser_url.dart';
 import 'package:srp_lanske/shared/utils/external_link.dart';
@@ -844,20 +845,10 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     String message, {
     AppMessageType type = AppMessageType.info,
   }) {
-    var duration = const Duration(seconds: 2);
-    if (type == AppMessageType.warning) {
-      duration = const Duration(seconds: 3);
-    } else if (type == AppMessageType.error) {
-      duration = const Duration(seconds: 4);
-    }
-
-    final messenger = ScaffoldMessenger.of(context);
-    messenger.hideCurrentSnackBar();
-    messenger.showSnackBar(
-      SnackBar(
-        content: Text(message),
-        duration: duration,
-      ),
+    AppSnackBar.show(
+      context,
+      message: message,
+      type: type,
     );
   }
 

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -5,6 +5,7 @@ import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_m
 import 'package:srp_lanske/l10n/l10n.dart';
 import 'package:srp_lanske/shared/infrastructure/generated_schedule_api_client.dart';
 import 'package:srp_lanske/shared/presentation/app_message_type.dart';
+import 'package:srp_lanske/shared/presentation/app_snack_bar.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 import 'package:srp_lanske/shared/utils/browser_url.dart';
 import 'package:srp_lanske/shared/utils/external_link.dart';
@@ -454,20 +455,10 @@ class _SchedulePageState extends State<SchedulePage> {
     String message, {
     AppMessageType type = AppMessageType.info,
   }) {
-    var duration = const Duration(seconds: 2);
-    if (type == AppMessageType.warning) {
-      duration = const Duration(seconds: 3);
-    } else if (type == AppMessageType.error) {
-      duration = const Duration(seconds: 4);
-    }
-
-    final messenger = ScaffoldMessenger.of(context);
-    messenger.hideCurrentSnackBar();
-    messenger.showSnackBar(
-      SnackBar(
-        content: Text(message),
-        duration: duration,
-      ),
+    AppSnackBar.show(
+      context,
+      message: message,
+      type: type,
     );
   }
 

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -4,6 +4,8 @@ import 'package:srp_lanske/app/config/app_config.dart';
 import 'package:srp_lanske/features/doubles_scheduler/domain/public_id.dart';
 import 'package:srp_lanske/shared/infrastructure/generated_schedule_api_client.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
+import 'package:srp_lanske/shared/presentation/app_message_type.dart';
+import 'package:srp_lanske/shared/presentation/app_snack_bar.dart';
 import 'package:srp_lanske/shared/repositories/app_repositories.dart';
 
 import '../application/team_generated_schedule_service.dart';
@@ -662,22 +664,28 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     final l10n = AppLocalizations.of(context);
 
     if (_scores.selectedSport == TeamScheduleSport.none) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.selectSportBeforeScoreInputMessage)),
+      AppSnackBar.show(
+        context,
+        message: l10n.selectSportBeforeScoreInputMessage,
+        type: AppMessageType.warning,
       );
       return;
     }
 
     if (_scores.selectedSport != TeamScheduleSport.boccia) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.selectSportBeforeScoreInputMessage)),
+      AppSnackBar.show(
+        context,
+        message: l10n.selectSportBeforeScoreInputMessage,
+        type: AppMessageType.warning,
       );
       return;
     }
 
     if (match.teamSlots.length != 2) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.unsupportedBocciaMatchMessage)),
+      AppSnackBar.show(
+        context,
+        message: l10n.unsupportedBocciaMatchMessage,
+        type: AppMessageType.warning,
       );
       return;
     }
@@ -752,8 +760,10 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       return;
     }
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(l10n.teamScheduleShareUrlCopiedMessage)),
+    AppSnackBar.show(
+      context,
+      message: l10n.teamScheduleShareUrlCopiedMessage,
+      type: AppMessageType.success,
     );
   }
 
@@ -1042,8 +1052,11 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
             ),
             const SizedBox(height: 8),
             Text(
-              l10n.teamScheduleSummary(schedule.teams.length,
-                  schedule.members.length, schedule.concurrentMatchCount),
+              l10n.teamScheduleSummary(
+                schedule.teams.length,
+                schedule.members.length,
+                schedule.concurrentMatchCount,
+              ),
               style: theme.textTheme.bodyMedium,
             ),
             const SizedBox(height: 16),
@@ -1292,7 +1305,9 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
               ],
               Text(
                 l10n.teamChoiceLabel(
-                    _teamName(team.teamSlot), team.memberPlayerSlots.length),
+                  _teamName(team.teamSlot),
+                  team.memberPlayerSlots.length,
+                ),
                 style: theme.textTheme.bodyMedium,
               ),
               IconButton(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -240,7 +240,7 @@
   "@alreadyAdoptedScheduleMessage": {
     "description": "Message shown when the schedule has already been adopted."
   },
-  "scheduleUpdatedReloadMessage": "The match table has been updated. Loading the latest information.",
+  "scheduleUpdatedReloadMessage": "The match table had been updated, so the latest version is now displayed.",
   "@scheduleUpdatedReloadMessage": {
     "description": "Message shown when the displayed schedule is outdated."
   },

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -240,7 +240,7 @@
   "@alreadyAdoptedScheduleMessage": {
     "description": "Message shown when the schedule has already been adopted."
   },
-  "scheduleUpdatedReloadMessage": "対戦表が更新されています。最新の情報に更新します",
+  "scheduleUpdatedReloadMessage": "対戦表が更新されていたため、最新の対戦表を表示しました。",
   "@scheduleUpdatedReloadMessage": {
     "description": "Message shown when the displayed schedule is outdated."
   },

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -413,7 +413,7 @@ abstract class AppLocalizations {
   /// Message shown when the displayed schedule is outdated.
   ///
   /// In ja, this message translates to:
-  /// **'対戦表が更新されています。最新の情報に更新します'**
+  /// **'対戦表が更新されていたため、最新の対戦表を表示しました。'**
   String get scheduleUpdatedReloadMessage;
 
   /// Message shown when schedule adoption completed.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -184,7 +184,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get scheduleUpdatedReloadMessage =>
-      'The match table has been updated. Loading the latest information.';
+      'The match table had been updated, so the latest version is now displayed.';
 
   @override
   String get adoptScheduleCompletedMessage => 'This match table was adopted.';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -178,7 +178,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get alreadyAdoptedScheduleMessage => 'すでに採用済みです';
 
   @override
-  String get scheduleUpdatedReloadMessage => '対戦表が更新されています。最新の情報に更新します';
+  String get scheduleUpdatedReloadMessage => '対戦表が更新されていたため、最新の対戦表を表示しました。';
 
   @override
   String get adoptScheduleCompletedMessage => 'この対戦表を採用しました';

--- a/lib/shared/presentation/app_snack_bar.dart
+++ b/lib/shared/presentation/app_snack_bar.dart
@@ -78,9 +78,7 @@ abstract final class AppSnackBar {
         key: const ValueKey<String>('app-snack-bar'),
         behavior: SnackBarBehavior.floating,
         width: useFixedWidth ? 560 : null,
-        margin: useFixedWidth
-            ? null
-            : const EdgeInsets.fromLTRB(12, 0, 12, 12),
+        margin: useFixedWidth ? null : const EdgeInsets.fromLTRB(12, 0, 12, 12),
         elevation: 6,
         backgroundColor: style.backgroundColor,
         shape: RoundedRectangleBorder(

--- a/lib/shared/presentation/app_snack_bar.dart
+++ b/lib/shared/presentation/app_snack_bar.dart
@@ -219,43 +219,59 @@ class _AppMessageStyle {
   });
 
   factory _AppMessageStyle.resolve(
-    ColorScheme colors,
+    ColorScheme appColors,
     AppMessageType type,
   ) {
+    final semanticColors = switch (type) {
+      AppMessageType.success => ColorScheme.fromSeed(
+          seedColor: Colors.green,
+          brightness: appColors.brightness,
+        ),
+      AppMessageType.info => ColorScheme.fromSeed(
+          seedColor: Colors.blue,
+          brightness: appColors.brightness,
+        ),
+      AppMessageType.warning => ColorScheme.fromSeed(
+          seedColor: Colors.orange,
+          brightness: appColors.brightness,
+        ),
+      AppMessageType.error => appColors,
+    };
+
     return switch (type) {
       AppMessageType.success => _AppMessageStyle(
-          backgroundColor: colors.primaryContainer,
-          foregroundColor: colors.onPrimaryContainer,
-          iconColor: colors.primary,
-          actionColor: colors.primary,
-          borderColor: colors.primary.withAlpha(115),
+          backgroundColor: semanticColors.primaryContainer,
+          foregroundColor: semanticColors.onPrimaryContainer,
+          iconColor: semanticColors.primary,
+          actionColor: semanticColors.primary,
+          borderColor: semanticColors.primary.withAlpha(115),
           icon: Icons.check_circle_outline,
           borderRadius: 28,
         ),
       AppMessageType.info => _AppMessageStyle(
-          backgroundColor: colors.secondaryContainer,
-          foregroundColor: colors.onSecondaryContainer,
-          iconColor: colors.secondary,
-          actionColor: colors.secondary,
-          borderColor: colors.secondary.withAlpha(115),
+          backgroundColor: semanticColors.primaryContainer,
+          foregroundColor: semanticColors.onPrimaryContainer,
+          iconColor: semanticColors.primary,
+          actionColor: semanticColors.primary,
+          borderColor: semanticColors.primary.withAlpha(115),
           icon: Icons.info_outline,
           borderRadius: 20,
         ),
       AppMessageType.warning => _AppMessageStyle(
-          backgroundColor: colors.tertiaryContainer,
-          foregroundColor: colors.onTertiaryContainer,
-          iconColor: colors.tertiary,
-          actionColor: colors.tertiary,
-          borderColor: colors.tertiary.withAlpha(140),
+          backgroundColor: semanticColors.primaryContainer,
+          foregroundColor: semanticColors.onPrimaryContainer,
+          iconColor: semanticColors.primary,
+          actionColor: semanticColors.primary,
+          borderColor: semanticColors.primary.withAlpha(140),
           icon: Icons.warning_amber_rounded,
           borderRadius: 16,
         ),
       AppMessageType.error => _AppMessageStyle(
-          backgroundColor: colors.errorContainer,
-          foregroundColor: colors.onErrorContainer,
-          iconColor: colors.error,
-          actionColor: colors.error,
-          borderColor: colors.error.withAlpha(166),
+          backgroundColor: appColors.errorContainer,
+          foregroundColor: appColors.onErrorContainer,
+          iconColor: appColors.error,
+          actionColor: appColors.error,
+          borderColor: appColors.error.withAlpha(166),
           icon: Icons.error_outline,
           borderRadius: 12,
         ),

--- a/lib/shared/presentation/app_snack_bar.dart
+++ b/lib/shared/presentation/app_snack_bar.dart
@@ -2,9 +2,14 @@ import 'package:flutter/material.dart';
 
 import 'app_message_type.dart';
 
+/// Displays application messages with shared styling and queue rules.
+///
+/// The newest message replaces the current message. Identical messages shown
+/// within two seconds are suppressed. While a persistent message is visible,
+/// lightweight success and info messages are discarded instead of queued.
 abstract final class AppSnackBar {
   static const Duration _duplicateWindow = Duration(seconds: 2);
-  static const Duration _persistentDuration = Duration(days: 1);
+  static const Duration _persistentDuration = Duration(days: 365);
   static final Expando<_AppSnackBarState> _states =
       Expando<_AppSnackBarState>('appSnackBarState');
 
@@ -58,11 +63,10 @@ abstract final class AppSnackBar {
     final style = _AppMessageStyle.resolve(theme.colorScheme, type);
     final mediaWidth = MediaQuery.sizeOf(context).width;
     final useFixedWidth = mediaWidth >= 640;
+    final defaultShowCloseIcon =
+        type == AppMessageType.warning || type == AppMessageType.error;
     final shouldShowCloseIcon =
-        showCloseIcon ??
-        persistent ||
-        type == AppMessageType.warning ||
-        type == AppMessageType.error;
+        persistent || (showCloseIcon ?? defaultShowCloseIcon);
 
     state
       ..lastSignature = signature

--- a/lib/shared/presentation/app_snack_bar.dart
+++ b/lib/shared/presentation/app_snack_bar.dart
@@ -1,0 +1,268 @@
+import 'package:flutter/material.dart';
+
+import 'app_message_type.dart';
+
+abstract final class AppSnackBar {
+  static const Duration _duplicateWindow = Duration(seconds: 2);
+  static const Duration _persistentDuration = Duration(days: 1);
+  static final Expando<_AppSnackBarState> _states =
+      Expando<_AppSnackBarState>('appSnackBarState');
+
+  static void show(
+    BuildContext context, {
+    required String message,
+    AppMessageType type = AppMessageType.info,
+    String? title,
+    Duration? duration,
+    bool persistent = false,
+    bool? showCloseIcon,
+    String? actionLabel,
+    VoidCallback? onAction,
+  }) {
+    if ((actionLabel == null) != (onAction == null)) {
+      throw ArgumentError(
+        'actionLabel and onAction must either both be set or both be null.',
+      );
+    }
+
+    final messenger = ScaffoldMessenger.of(context);
+    final state = _states[messenger] ?? _AppSnackBarState();
+    _states[messenger] = state;
+
+    final now = DateTime.now();
+    final signature = _AppMessageSignature(
+      type: type,
+      title: title,
+      message: message,
+      actionLabel: actionLabel,
+      persistent: persistent,
+    );
+    final lastShownAt = state.lastShownAt;
+
+    if (state.lastSignature == signature &&
+        lastShownAt != null &&
+        now.difference(lastShownAt) < _duplicateWindow) {
+      return;
+    }
+
+    final isLightweight =
+        type == AppMessageType.success || type == AppMessageType.info;
+    if (state.isPersistent && isLightweight) {
+      return;
+    }
+
+    messenger.removeCurrentSnackBar(reason: SnackBarClosedReason.remove);
+    messenger.clearSnackBars();
+
+    final theme = Theme.of(context);
+    final style = _AppMessageStyle.resolve(theme.colorScheme, type);
+    final mediaWidth = MediaQuery.sizeOf(context).width;
+    final useFixedWidth = mediaWidth >= 640;
+    final shouldShowCloseIcon =
+        showCloseIcon ??
+        persistent ||
+        type == AppMessageType.warning ||
+        type == AppMessageType.error;
+
+    state
+      ..lastSignature = signature
+      ..lastShownAt = now
+      ..isPersistent = persistent;
+
+    final controller = messenger.showSnackBar(
+      SnackBar(
+        key: const ValueKey<String>('app-snack-bar'),
+        behavior: SnackBarBehavior.floating,
+        width: useFixedWidth ? 560 : null,
+        margin: useFixedWidth
+            ? null
+            : const EdgeInsets.fromLTRB(12, 0, 12, 12),
+        elevation: 6,
+        backgroundColor: style.backgroundColor,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(style.borderRadius),
+          side: BorderSide(color: style.borderColor),
+        ),
+        clipBehavior: Clip.antiAlias,
+        duration: persistent
+            ? _persistentDuration
+            : duration ?? _defaultDuration(type),
+        showCloseIcon: shouldShowCloseIcon,
+        closeIconColor: style.foregroundColor,
+        action: actionLabel == null
+            ? null
+            : SnackBarAction(
+                label: actionLabel,
+                textColor: style.actionColor,
+                onPressed: onAction!,
+              ),
+        content: Semantics(
+          liveRegion: true,
+          child: Row(
+            crossAxisAlignment: title == null
+                ? CrossAxisAlignment.center
+                : CrossAxisAlignment.start,
+            children: [
+              Icon(
+                style.icon,
+                key: ValueKey<String>('app-snack-bar-${type.name}-icon'),
+                color: style.iconColor,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: title == null
+                    ? Text(
+                        message,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: style.foregroundColor,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      )
+                    : Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            title,
+                            style: theme.textTheme.titleSmall?.copyWith(
+                              color: style.foregroundColor,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            message,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: style.foregroundColor,
+                            ),
+                          ),
+                        ],
+                      ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    controller.closed.then<void>((_) {
+      if (state.lastSignature == signature) {
+        state.isPersistent = false;
+      }
+    });
+  }
+
+  static Duration _defaultDuration(AppMessageType type) {
+    return switch (type) {
+      AppMessageType.success => const Duration(seconds: 3),
+      AppMessageType.info => const Duration(seconds: 4),
+      AppMessageType.warning => const Duration(seconds: 6),
+      AppMessageType.error => const Duration(seconds: 8),
+    };
+  }
+}
+
+class _AppSnackBarState {
+  _AppMessageSignature? lastSignature;
+  DateTime? lastShownAt;
+  bool isPersistent = false;
+}
+
+class _AppMessageSignature {
+  const _AppMessageSignature({
+    required this.type,
+    required this.title,
+    required this.message,
+    required this.actionLabel,
+    required this.persistent,
+  });
+
+  final AppMessageType type;
+  final String? title;
+  final String message;
+  final String? actionLabel;
+  final bool persistent;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _AppMessageSignature &&
+        other.type == type &&
+        other.title == title &&
+        other.message == message &&
+        other.actionLabel == actionLabel &&
+        other.persistent == persistent;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        type,
+        title,
+        message,
+        actionLabel,
+        persistent,
+      );
+}
+
+class _AppMessageStyle {
+  const _AppMessageStyle({
+    required this.backgroundColor,
+    required this.foregroundColor,
+    required this.iconColor,
+    required this.actionColor,
+    required this.borderColor,
+    required this.icon,
+    required this.borderRadius,
+  });
+
+  factory _AppMessageStyle.resolve(
+    ColorScheme colors,
+    AppMessageType type,
+  ) {
+    return switch (type) {
+      AppMessageType.success => _AppMessageStyle(
+          backgroundColor: colors.primaryContainer,
+          foregroundColor: colors.onPrimaryContainer,
+          iconColor: colors.primary,
+          actionColor: colors.primary,
+          borderColor: colors.primary.withAlpha(115),
+          icon: Icons.check_circle_outline,
+          borderRadius: 28,
+        ),
+      AppMessageType.info => _AppMessageStyle(
+          backgroundColor: colors.secondaryContainer,
+          foregroundColor: colors.onSecondaryContainer,
+          iconColor: colors.secondary,
+          actionColor: colors.secondary,
+          borderColor: colors.secondary.withAlpha(115),
+          icon: Icons.info_outline,
+          borderRadius: 20,
+        ),
+      AppMessageType.warning => _AppMessageStyle(
+          backgroundColor: colors.tertiaryContainer,
+          foregroundColor: colors.onTertiaryContainer,
+          iconColor: colors.tertiary,
+          actionColor: colors.tertiary,
+          borderColor: colors.tertiary.withAlpha(140),
+          icon: Icons.warning_amber_rounded,
+          borderRadius: 16,
+        ),
+      AppMessageType.error => _AppMessageStyle(
+          backgroundColor: colors.errorContainer,
+          foregroundColor: colors.onErrorContainer,
+          iconColor: colors.error,
+          actionColor: colors.error,
+          borderColor: colors.error.withAlpha(166),
+          icon: Icons.error_outline,
+          borderRadius: 12,
+        ),
+    };
+  }
+
+  final Color backgroundColor;
+  final Color foregroundColor;
+  final Color iconColor;
+  final Color actionColor;
+  final Color borderColor;
+  final IconData icon;
+  final double borderRadius;
+}

--- a/test/shared/presentation/app_snack_bar_test.dart
+++ b/test/shared/presentation/app_snack_bar_test.dart
@@ -149,8 +149,7 @@ void main() {
     expect(snackBar.showCloseIcon, isTrue);
   });
 
-  testWidgets('replaces a persistent warning with a new error',
-      (tester) async {
+  testWidgets('replaces a persistent warning with a new error', (tester) async {
     final context = await pumpHost(tester);
 
     AppSnackBar.show(

--- a/test/shared/presentation/app_snack_bar_test.dart
+++ b/test/shared/presentation/app_snack_bar_test.dart
@@ -95,8 +95,9 @@ void main() {
       find.byKey(const ValueKey<String>('app-snack-bar')),
     );
     expect(snackBar.duration, const Duration(seconds: 12));
+    expect(snackBar.action?.label, 'Retry');
 
-    await tester.tap(find.text('Retry'));
+    snackBar.action!.onPressed();
     expect(actionCount, 1);
   });
 

--- a/test/shared/presentation/app_snack_bar_test.dart
+++ b/test/shared/presentation/app_snack_bar_test.dart
@@ -10,7 +10,8 @@ void main() {
   }) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = size;
-    addTearDown(() {
+    addTearDown(() async {
+      await tester.pumpWidget(const SizedBox.shrink());
       tester.view.resetDevicePixelRatio();
       tester.view.resetPhysicalSize();
     });

--- a/test/shared/presentation/app_snack_bar_test.dart
+++ b/test/shared/presentation/app_snack_bar_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:srp_lanske/shared/presentation/app_message_type.dart';
+import 'package:srp_lanske/shared/presentation/app_snack_bar.dart';
+
+void main() {
+  Future<BuildContext> pumpHost(
+    WidgetTester tester, {
+    Size size = const Size(390, 844),
+  }) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = size;
+    addTearDown(() {
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetPhysicalSize();
+    });
+
+    late BuildContext messageContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
+          useMaterial3: true,
+        ),
+        home: Builder(
+          builder: (context) {
+            messageContext = context;
+            return const Scaffold(body: SizedBox.expand());
+          },
+        ),
+      ),
+    );
+
+    return messageContext;
+  }
+
+  testWidgets('shows type-specific icon, duration, and close rule',
+      (tester) async {
+    final context = await pumpHost(tester);
+    final expectedDurations = <AppMessageType, Duration>{
+      AppMessageType.success: const Duration(seconds: 3),
+      AppMessageType.info: const Duration(seconds: 4),
+      AppMessageType.warning: const Duration(seconds: 6),
+      AppMessageType.error: const Duration(seconds: 8),
+    };
+
+    for (final type in AppMessageType.values) {
+      AppSnackBar.show(
+        context,
+        message: type.name,
+        type: type,
+      );
+      await tester.pump();
+
+      expect(
+        find.byKey(ValueKey<String>('app-snack-bar-${type.name}-icon')),
+        findsOneWidget,
+      );
+
+      final snackBar = tester.widget<SnackBar>(
+        find.byKey(const ValueKey<String>('app-snack-bar')),
+      );
+      expect(snackBar.duration, expectedDurations[type]);
+      expect(
+        snackBar.showCloseIcon,
+        type == AppMessageType.warning || type == AppMessageType.error,
+      );
+
+      ScaffoldMessenger.of(context).removeCurrentSnackBar();
+      await tester.pump();
+    }
+  });
+
+  testWidgets('supports title, custom duration, and action', (tester) async {
+    final context = await pumpHost(tester);
+    var actionCount = 0;
+
+    AppSnackBar.show(
+      context,
+      title: 'Network error',
+      message: 'Try again.',
+      duration: const Duration(seconds: 12),
+      actionLabel: 'Retry',
+      onAction: () {
+        actionCount += 1;
+      },
+    );
+    await tester.pump();
+
+    expect(find.text('Network error'), findsOneWidget);
+    expect(find.text('Try again.'), findsOneWidget);
+
+    final snackBar = tester.widget<SnackBar>(
+      find.byKey(const ValueKey<String>('app-snack-bar')),
+    );
+    expect(snackBar.duration, const Duration(seconds: 12));
+
+    await tester.tap(find.text('Retry'));
+    expect(actionCount, 1);
+  });
+
+  testWidgets('suppresses the same notification shown consecutively',
+      (tester) async {
+    final context = await pumpHost(tester);
+
+    AppSnackBar.show(context, message: 'same message');
+    await tester.pump();
+    final firstSnackBar = tester.widget<SnackBar>(
+      find.byKey(const ValueKey<String>('app-snack-bar')),
+    );
+
+    AppSnackBar.show(context, message: 'same message');
+    await tester.pump();
+    final secondSnackBar = tester.widget<SnackBar>(
+      find.byKey(const ValueKey<String>('app-snack-bar')),
+    );
+
+    expect(identical(firstSnackBar, secondSnackBar), isTrue);
+    expect(find.text('same message'), findsOneWidget);
+  });
+
+  testWidgets('keeps a persistent warning instead of lightweight messages',
+      (tester) async {
+    final context = await pumpHost(tester);
+
+    AppSnackBar.show(
+      context,
+      message: 'persistent warning',
+      type: AppMessageType.warning,
+      persistent: true,
+    );
+    await tester.pump();
+
+    AppSnackBar.show(
+      context,
+      message: 'lightweight info',
+      type: AppMessageType.info,
+    );
+    await tester.pump();
+
+    expect(find.text('persistent warning'), findsOneWidget);
+    expect(find.text('lightweight info'), findsNothing);
+
+    final snackBar = tester.widget<SnackBar>(
+      find.byKey(const ValueKey<String>('app-snack-bar')),
+    );
+    expect(snackBar.showCloseIcon, isTrue);
+  });
+
+  testWidgets('replaces a persistent warning with a new error',
+      (tester) async {
+    final context = await pumpHost(tester);
+
+    AppSnackBar.show(
+      context,
+      message: 'persistent warning',
+      type: AppMessageType.warning,
+      persistent: true,
+    );
+    await tester.pump();
+
+    AppSnackBar.show(
+      context,
+      message: 'new error',
+      type: AppMessageType.error,
+      persistent: true,
+    );
+    await tester.pump();
+
+    expect(find.text('persistent warning'), findsNothing);
+    expect(find.text('new error'), findsOneWidget);
+  });
+
+  testWidgets('uses margins on mobile and fixed width on desktop',
+      (tester) async {
+    var context = await pumpHost(tester);
+
+    AppSnackBar.show(context, message: 'mobile message');
+    await tester.pump();
+    var snackBar = tester.widget<SnackBar>(
+      find.byKey(const ValueKey<String>('app-snack-bar')),
+    );
+    expect(snackBar.margin, isNotNull);
+    expect(snackBar.width, isNull);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    context = await pumpHost(tester, size: const Size(1200, 900));
+
+    AppSnackBar.show(context, message: 'desktop message');
+    await tester.pump();
+    snackBar = tester.widget<SnackBar>(
+      find.byKey(const ValueKey<String>('app-snack-bar')),
+    );
+    expect(snackBar.margin, isNull);
+    expect(snackBar.width, 560);
+  });
+
+  testWidgets('requires action label and callback together', (tester) async {
+    final context = await pumpHost(tester);
+
+    expect(
+      () => AppSnackBar.show(
+        context,
+        message: 'invalid action',
+        actionLabel: 'Retry',
+      ),
+      throwsArgumentError,
+    );
+  });
+}


### PR DESCRIPTION
## 概要

アプリ内のSnackBar通知について、見た目と表示ルールを共通化しました。

通知種別ごとの視覚表現、表示時間、閉じるボタン、アクション、重複表示および永続通知中の扱いを共通処理へ集約しています。

Closes #150

## 変更内容

- 共通の `AppSnackBar` helperを追加
- 以下の通知種別に対応
  - success
  - info
  - warning
  - error
- 通知種別ごとに以下を設定
  - アイコン
  - 配色
  - 表示時間
  - 角丸
  - 閉じるボタンの既定値
- タイトル、補足文、任意のアクションに対応
- 同一通知の短時間での連続表示を抑制
- 永続的な警告・エラー表示中は、success／info通知を破棄
- 新しい警告・エラーは表示中の永続通知を置き換える
- 通知キューを溜めず、原則として最新通知を優先
- モバイルでは左右余白、デスクトップでは固定幅で表示
- `SnackBarThemeData` に共通設定を追加

## 既存画面の移行

以下の主要なSnackBar表示を共通処理へ移行しました。

- ダブルス用イベント一覧
- ダブルス用セットアップ画面
- ダブルス用対戦表画面
- 復元したダブルス用対戦表画面
- チーム用対戦表画面

通知内容に応じて、success／info／warning／errorを割り当てています。

## l10n

最新情報へ更新済みであることが分かるよう、対戦表更新時の通知文言を日本語・英語ともに調整しました。

生成されたlocalizationファイルも更新しています。

## テスト

共通SnackBarについてwidgetテストを追加しました。

確認内容:

- 通知種別ごとのアイコン・表示時間・閉じるボタン
- タイトルと任意の表示時間
- アクション設定とcallback
- 同一通知の連続表示抑制
- 永続通知中の軽量通知抑制
- 永続通知の警告／エラーによる置き換え
- モバイル／デスクトップの表示幅
- action引数の組み合わせ検証

## 確認

- `dart format lib/ test/`
- `flutter analyze`
- `flutter test`

すべて成功しています。

## Docs

通知共通処理にはdoc commentを追加しています。

外部仕様や運用手順の変更はないため、独立したdocs更新は不要と判断しました。