### PR TITLE
🧱 feat: add safe partial updates and optimistic locking for doubles event display data refs #153

### DIFF
--- a/docs/doubles-event-display-persistence.md
+++ b/docs/doubles-event-display-persistence.md
@@ -1,0 +1,64 @@
+# ダブルスイベント表示情報の保存と競合制御
+
+## 目的
+
+ダブルス対戦表のイベントタイトル、イベントメモ、プレイヤー表示名、コート表示設定を更新する際に、古いイベントaggregateで他端末の変更を巻き戻さないための保存方針を整理する。
+
+## 保存schema
+
+`events/{publicId}` は、現行のaggregate形式を `schemaVersion: 1` として扱う。
+
+イベント表示情報として以下を保存する。
+
+- `event.title`: 現在のイベントタイトル
+- `event.memo`: イベント単位のメモ
+- `event.revision`: イベントaggregate上の共有表示情報を更新するためのrevision
+- `players[].initialDisplayName`: 対戦表生成時の表示名
+- `players[].displayName`: 現在の表示名
+- `courtSettings[]`: コート表示設定
+
+既存Documentとの互換性のため、フィールドがない場合は以下として読み込む。
+
+- `event.memo`: 空文字
+- `players[].initialDisplayName`: 同じplayerの `displayName`
+
+今回の追加は既存形式へ省略可能なフィールドを追加するため、schema versionは1のままとする。
+
+## 更新単位
+
+### イベント情報と全プレイヤー表示名
+
+イベントタイトル、メモ、全プレイヤー表示名は、まとめて編集・保存する単位として扱う。
+
+保存時には、画面で最新情報を取得した際の `event.revision` を `expectedRevision` として渡す。
+
+Firestoreではtransaction内で最新Documentを取得し、次を行う。
+
+1. 入力されたplayer IDが現在のplayer IDと一致することを確認する
+2. 保存済みの値と入力値がすべて同じ場合はno-op成功とする
+3. 値が異なり、revisionが一致しない場合は保存しない
+4. revisionが一致した場合だけ、タイトル、メモ、players配列、revision、更新日時を更新する
+
+生成済み対戦表ID、採用状態、共有情報、取り込み情報、コート表示設定など、変更対象外の情報は更新しない。
+
+### コート表示設定
+
+revisionを指定する更新APIでは、同じくno-op判定後にrevisionを確認し、コート表示設定、revision、更新日時だけを更新する。
+
+既存UIとの互換用APIもFirestore transactionによる部分更新を利用し、古いaggregate全体の保存は行わない。
+
+## 競合時の扱い
+
+異なる値を保存しようとしてrevisionが一致しない場合は、`EventRevisionConflictException` を返す。
+
+UIでは競合した入力を自動マージせず、ダイアログを閉じないまま最新情報を取得し、ユーザーが内容を確認して再編集できる状態にする。
+
+base、最新値、入力値を比較する高度な競合解消は別Issueで扱う。
+
+## 将来拡張
+
+外部サービス上のplayer ID、レベル、年代、性別などは、取得形式と正規化方法が確定してからイベント時点のsource snapshotとして追加する。
+
+ポット分けはplayer属性ではなく、対戦表生成条件側のポット情報として扱う。
+
+将来、プレイヤー詳細の個別編集を追加する場合は、プレイヤー単位revisionまたはDocument分割を検討する。

--- a/lib/features/doubles_scheduler/application/event_repository.dart
+++ b/lib/features/doubles_scheduler/application/event_repository.dart
@@ -18,8 +18,39 @@ abstract class EventRepository {
     required String generatedScheduleId,
   });
 
+  Future<SavedEventAggregate> updateDisplayInfo({
+    required String publicId,
+    required int expectedRevision,
+    required String title,
+    required String memo,
+    required Map<String, String> playerDisplayNamesById,
+  }) {
+    throw UnimplementedError('updateDisplayInfo is not implemented');
+  }
+
   Future<SavedEventAggregate> updateCourtSettings({
     required String eventId,
     required List<SavedEventCourtSetting> courtSettings,
   });
+}
+
+class EventRevisionConflictException implements Exception {
+  const EventRevisionConflictException({
+    required this.eventId,
+    required this.expectedRevision,
+    required this.actualRevision,
+  });
+
+  final String eventId;
+  final int expectedRevision;
+  final int actualRevision;
+
+  @override
+  String toString() {
+    return 'EventRevisionConflictException('
+        'eventId: $eventId, '
+        'expectedRevision: $expectedRevision, '
+        'actualRevision: $actualRevision'
+        ')';
+  }
 }

--- a/lib/features/doubles_scheduler/application/event_repository.dart
+++ b/lib/features/doubles_scheduler/application/event_repository.dart
@@ -32,6 +32,16 @@ abstract class EventRepository {
     required String eventId,
     required List<SavedEventCourtSetting> courtSettings,
   });
+
+  Future<SavedEventAggregate> updateCourtSettingsWithRevision({
+    required String eventId,
+    required int expectedRevision,
+    required List<SavedEventCourtSetting> courtSettings,
+  }) {
+    throw UnimplementedError(
+      'updateCourtSettingsWithRevision is not implemented',
+    );
+  }
 }
 
 class EventRevisionConflictException implements Exception {

--- a/lib/features/doubles_scheduler/data/firestore_saved_event_json_store.dart
+++ b/lib/features/doubles_scheduler/data/firestore_saved_event_json_store.dart
@@ -50,6 +50,31 @@ class FirestoreSavedEventJsonStore implements SavedEventJsonStore {
     return _copy(snapshot.docs.first.data());
   }
 
+  @override
+  Future<Map<String, dynamic>?> updateByPublicId({
+    required String publicId,
+    required SavedEventJsonUpdater update,
+  }) {
+    final reference = _collection.doc(publicId);
+
+    return _firestore.runTransaction<Map<String, dynamic>?>(
+      (transaction) async {
+        final snapshot = await transaction.get(reference);
+        final data = snapshot.data();
+        if (!snapshot.exists || data == null) {
+          return null;
+        }
+
+        final result = update(_copy(data));
+        if (!result.isNoOp) {
+          transaction.update(reference, _copy(result.fields));
+        }
+
+        return _copy(result.data);
+      },
+    );
+  }
+
   Map<String, dynamic> _copy(Map<String, dynamic> data) {
     return jsonDecode(jsonEncode(data)) as Map<String, dynamic>;
   }

--- a/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
+++ b/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
@@ -8,10 +8,13 @@ import '../presentation/models/event_draft.dart';
 class InMemoryEventRepository implements EventRepository {
   InMemoryEventRepository({
     String Function()? publicIdGenerator,
-  }) : _publicIdGenerator = publicIdGenerator ?? generatePublicId;
+    DateTime Function()? clock,
+  })  : _publicIdGenerator = publicIdGenerator ?? generatePublicId,
+        _clock = clock ?? DateTime.now;
 
   final _uuid = const Uuid();
   final String Function() _publicIdGenerator;
+  final DateTime Function() _clock;
 
   final Map<String, SavedEvent> _eventsById = {};
   final Map<String, String> _eventIdByPublicId = {};
@@ -22,7 +25,7 @@ class InMemoryEventRepository implements EventRepository {
 
   @override
   Future<SavedEventAggregate> createFromDraft(EventDraft draft) async {
-    final now = DateTime.now();
+    final now = _clock();
     final eventId = _uuid.v4();
     final publicId = _generateUniquePublicId();
     final courtSettings = buildDefaultCourtSettings(draft.courts);
@@ -47,6 +50,7 @@ class InMemoryEventRepository implements EventRepository {
       return SavedEventPlayer(
         id: player.id,
         eventId: eventId,
+        initialDisplayName: player.displayName,
         displayName: player.displayName,
         orderNo: index + 1,
         status: 'active',
@@ -81,13 +85,7 @@ class InMemoryEventRepository implements EventRepository {
     }
     _courtSettingsByEventId[eventId] = courtSettings;
 
-    return SavedEventAggregate(
-      event: event,
-      players: players,
-      share: share,
-      importRecord: importRecord,
-      courtSettings: courtSettings,
-    );
+    return _buildAggregate(event);
   }
 
   @override
@@ -99,14 +97,7 @@ class InMemoryEventRepository implements EventRepository {
     final share = _sharesByPublicId[publicId];
     if (event == null || share == null) return null;
 
-    return SavedEventAggregate(
-      event: event,
-      players: _playersByEventId[eventId] ?? const [],
-      share: share,
-      importRecord: _importsByEventId[eventId],
-      courtSettings: _courtSettingsByEventId[eventId] ??
-          buildDefaultCourtSettings(event.courtCount),
-    );
+    return _buildAggregate(event);
   }
 
   @override
@@ -132,7 +123,7 @@ class InMemoryEventRepository implements EventRepository {
       status: SavedEventStatus.generated,
       currentGeneratedScheduleId: generatedScheduleId,
       revision: event.revision + 1,
-      updatedAt: DateTime.now(),
+      updatedAt: _clock(),
     );
 
     _eventsById[eventId] = updated;
@@ -149,7 +140,7 @@ class InMemoryEventRepository implements EventRepository {
       throw StateError('event not found: $eventId');
     }
 
-    final now = DateTime.now();
+    final now = _clock();
     final updated = event.copyWith(
       status: SavedEventStatus.adopted,
       currentGeneratedScheduleId: generatedScheduleId,
@@ -161,6 +152,96 @@ class InMemoryEventRepository implements EventRepository {
 
     _eventsById[eventId] = updated;
     return updated;
+  }
+
+  @override
+  Future<SavedEventAggregate> updateDisplayInfo({
+    required String publicId,
+    required int expectedRevision,
+    required String title,
+    required String memo,
+    required Map<String, String> playerDisplayNamesById,
+  }) async {
+    if (expectedRevision < 1) {
+      throw ArgumentError.value(
+        expectedRevision,
+        'expectedRevision',
+        'must be greater than or equal to 1',
+      );
+    }
+
+    final eventId = _eventIdByPublicId[publicId];
+    final event = eventId == null ? null : _eventsById[eventId];
+    if (eventId == null || event == null) {
+      throw StateError('event not found: $publicId');
+    }
+
+    final normalizedTitle = title.trim();
+    if (normalizedTitle.isEmpty) {
+      throw ArgumentError.value(title, 'title', 'must not be empty');
+    }
+
+    final normalizedMemo = memo.trim();
+    final normalizedNames = <String, String>{};
+    for (final entry in playerDisplayNamesById.entries) {
+      final playerId = entry.key.trim();
+      final displayName = entry.value.trim();
+      if (playerId.isEmpty) {
+        throw ArgumentError.value(entry.key, 'playerId', 'must not be empty');
+      }
+      if (displayName.isEmpty) {
+        throw ArgumentError.value(
+          entry.value,
+          'playerDisplayNamesById[$playerId]',
+          'must not be empty',
+        );
+      }
+      normalizedNames[playerId] = displayName;
+    }
+
+    final players = _playersByEventId[eventId] ?? const <SavedEventPlayer>[];
+    _ensurePlayerIdsMatch(players, normalizedNames.keys.toSet());
+
+    final displayIsUnchanged = event.title == normalizedTitle &&
+        event.memo == normalizedMemo &&
+        players.every(
+          (player) => player.displayName == normalizedNames[player.id],
+        );
+    if (displayIsUnchanged) {
+      return _buildAggregate(event);
+    }
+
+    if (event.revision != expectedRevision) {
+      throw EventRevisionConflictException(
+        eventId: event.id,
+        expectedRevision: expectedRevision,
+        actualRevision: event.revision,
+      );
+    }
+
+    final now = _clock();
+    final updatedEvent = event.copyWith(
+      title: normalizedTitle,
+      memo: normalizedMemo,
+      revision: event.revision + 1,
+      updatedAt: now,
+    );
+    final updatedPlayers = players.map((player) {
+      final nextDisplayName = normalizedNames[player.id]!;
+      if (nextDisplayName == player.displayName) {
+        return player;
+      }
+
+      return player.copyWith(
+        displayName: nextDisplayName,
+        updatedAt: now,
+      );
+    }).toList(growable: false);
+
+    _eventsById[eventId] = updatedEvent;
+    _playersByEventId[eventId] = updatedPlayers;
+
+    return _buildAggregate(updatedEvent);
   }
 
   @override
@@ -177,27 +258,68 @@ class InMemoryEventRepository implements EventRepository {
       throw StateError('event already adopted: $eventId');
     }
 
+    final currentSettings = _courtSettingsByEventId[eventId] ??
+        buildDefaultCourtSettings(event.courtCount);
+    if (_courtSettingsEqual(currentSettings, courtSettings)) {
+      return _buildAggregate(event);
+    }
+
     final updatedEvent = event.copyWith(
       revision: event.revision + 1,
-      updatedAt: DateTime.now(),
+      updatedAt: _clock(),
     );
 
     _eventsById[eventId] = updatedEvent;
     _courtSettingsByEventId[eventId] = List.unmodifiable(courtSettings);
 
-    final share = _sharesByPublicId[updatedEvent.publicId];
+    return _buildAggregate(updatedEvent);
+  }
+
+  SavedEventAggregate _buildAggregate(SavedEvent event) {
+    final share = _sharesByPublicId[event.publicId];
     if (share == null) {
-      throw StateError('share not found: ${updatedEvent.publicId}');
+      throw StateError('share not found: ${event.publicId}');
     }
 
     return SavedEventAggregate(
-      event: updatedEvent,
-      players: _playersByEventId[eventId] ?? const [],
+      event: event,
+      players: _playersByEventId[event.id] ?? const [],
       share: share,
-      importRecord: _importsByEventId[eventId],
-      courtSettings: _courtSettingsByEventId[eventId] ??
-          buildDefaultCourtSettings(updatedEvent.courtCount),
+      importRecord: _importsByEventId[event.id],
+      courtSettings: _courtSettingsByEventId[event.id] ??
+          buildDefaultCourtSettings(event.courtCount),
     );
+  }
+
+  void _ensurePlayerIdsMatch(
+    List<SavedEventPlayer> players,
+    Set<String> inputPlayerIds,
+  ) {
+    final currentPlayerIds = players.map((player) => player.id).toSet();
+    if (currentPlayerIds.length != inputPlayerIds.length ||
+        !currentPlayerIds.containsAll(inputPlayerIds)) {
+      throw ArgumentError.value(
+        inputPlayerIds,
+        'playerDisplayNamesById',
+        'must contain exactly the current event player ids',
+      );
+    }
+  }
+
+  bool _courtSettingsEqual(
+    List<SavedEventCourtSetting> left,
+    List<SavedEventCourtSetting> right,
+  ) {
+    if (left.length != right.length) return false;
+
+    for (var index = 0; index < left.length; index += 1) {
+      if (left[index].courtNumber != right[index].courtNumber ||
+          left[index].displayLabel != right[index].displayLabel) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   String _generateUniquePublicId() {

--- a/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
+++ b/lib/features/doubles_scheduler/data/in_memory_event_repository.dart
@@ -44,15 +44,13 @@ class InMemoryEventRepository implements EventRepository {
     );
 
     final players = draft.players.asMap().entries.map((entry) {
-      final index = entry.key;
       final player = entry.value;
-
       return SavedEventPlayer(
         id: player.id,
         eventId: eventId,
         initialDisplayName: player.displayName,
         displayName: player.displayName,
-        orderNo: index + 1,
+        orderNo: entry.key + 1,
         status: 'active',
         createdAt: now,
         updatedAt: now,
@@ -65,7 +63,6 @@ class InMemoryEventRepository implements EventRepository {
       createdAt: now,
       updatedAt: now,
     );
-
     final importRecord = draft.url.isEmpty
         ? null
         : SavedEventImport(
@@ -91,13 +88,8 @@ class InMemoryEventRepository implements EventRepository {
   @override
   Future<SavedEventAggregate?> findByPublicId(String publicId) async {
     final eventId = _eventIdByPublicId[publicId];
-    if (eventId == null) return null;
-
-    final event = _eventsById[eventId];
-    final share = _sharesByPublicId[publicId];
-    if (event == null || share == null) return null;
-
-    return _buildAggregate(event);
+    final event = eventId == null ? null : _eventsById[eventId];
+    return event == null ? null : _buildAggregate(event);
   }
 
   @override
@@ -110,11 +102,7 @@ class InMemoryEventRepository implements EventRepository {
     required String eventId,
     required String generatedScheduleId,
   }) async {
-    final event = _eventsById[eventId];
-    if (event == null) {
-      throw StateError('event not found: $eventId');
-    }
-
+    final event = _requireEvent(eventId);
     if (event.hasAdoptedSchedule) {
       throw StateError('event already adopted: $eventId');
     }
@@ -125,7 +113,6 @@ class InMemoryEventRepository implements EventRepository {
       revision: event.revision + 1,
       updatedAt: _clock(),
     );
-
     _eventsById[eventId] = updated;
     return updated;
   }
@@ -135,11 +122,7 @@ class InMemoryEventRepository implements EventRepository {
     required String eventId,
     required String generatedScheduleId,
   }) async {
-    final event = _eventsById[eventId];
-    if (event == null) {
-      throw StateError('event not found: $eventId');
-    }
-
+    final event = _requireEvent(eventId);
     final now = _clock();
     final updated = event.copyWith(
       status: SavedEventStatus.adopted,
@@ -149,7 +132,6 @@ class InMemoryEventRepository implements EventRepository {
       revision: event.revision + 1,
       updatedAt: now,
     );
-
     _eventsById[eventId] = updated;
     return updated;
   }
@@ -162,63 +144,28 @@ class InMemoryEventRepository implements EventRepository {
     required String memo,
     required Map<String, String> playerDisplayNamesById,
   }) async {
-    if (expectedRevision < 1) {
-      throw ArgumentError.value(
-        expectedRevision,
-        'expectedRevision',
-        'must be greater than or equal to 1',
-      );
-    }
-
+    _validateExpectedRevision(expectedRevision);
     final eventId = _eventIdByPublicId[publicId];
-    final event = eventId == null ? null : _eventsById[eventId];
-    if (eventId == null || event == null) {
+    if (eventId == null) {
       throw StateError('event not found: $publicId');
     }
-
-    final normalizedTitle = title.trim();
-    if (normalizedTitle.isEmpty) {
-      throw ArgumentError.value(title, 'title', 'must not be empty');
-    }
-
+    final event = _requireEvent(eventId);
+    final normalizedTitle = _requireNonEmpty(title, fieldName: 'title');
     final normalizedMemo = memo.trim();
-    final normalizedNames = <String, String>{};
-    for (final entry in playerDisplayNamesById.entries) {
-      final playerId = entry.key.trim();
-      final displayName = entry.value.trim();
-      if (playerId.isEmpty) {
-        throw ArgumentError.value(entry.key, 'playerId', 'must not be empty');
-      }
-      if (displayName.isEmpty) {
-        throw ArgumentError.value(
-          entry.value,
-          'playerDisplayNamesById[$playerId]',
-          'must not be empty',
-        );
-      }
-      normalizedNames[playerId] = displayName;
-    }
-
+    final normalizedNames = _normalizePlayerNames(playerDisplayNamesById);
     final players = _playersByEventId[eventId] ?? const <SavedEventPlayer>[];
     _ensurePlayerIdsMatch(players, normalizedNames.keys.toSet());
 
-    final displayIsUnchanged = event.title == normalizedTitle &&
+    final isUnchanged = event.title == normalizedTitle &&
         event.memo == normalizedMemo &&
         players.every(
           (player) => player.displayName == normalizedNames[player.id],
         );
-    if (displayIsUnchanged) {
+    if (isUnchanged) {
       return _buildAggregate(event);
     }
 
-    if (event.revision != expectedRevision) {
-      throw EventRevisionConflictException(
-        eventId: event.id,
-        expectedRevision: expectedRevision,
-        actualRevision: event.revision,
-      );
-    }
-
+    _ensureRevision(event, expectedRevision);
     final now = _clock();
     final updatedEvent = event.copyWith(
       title: normalizedTitle,
@@ -228,19 +175,16 @@ class InMemoryEventRepository implements EventRepository {
     );
     final updatedPlayers = players.map((player) {
       final nextDisplayName = normalizedNames[player.id]!;
-      if (nextDisplayName == player.displayName) {
-        return player;
-      }
-
-      return player.copyWith(
-        displayName: nextDisplayName,
-        updatedAt: now,
-      );
+      return nextDisplayName == player.displayName
+          ? player
+          : player.copyWith(
+              displayName: nextDisplayName,
+              updatedAt: now,
+            );
     }).toList(growable: false);
 
     _eventsById[eventId] = updatedEvent;
     _playersByEventId[eventId] = updatedPlayers;
-
     return _buildAggregate(updatedEvent);
   }
 
@@ -248,12 +192,34 @@ class InMemoryEventRepository implements EventRepository {
   Future<SavedEventAggregate> updateCourtSettings({
     required String eventId,
     required List<SavedEventCourtSetting> courtSettings,
-  }) async {
-    final event = _eventsById[eventId];
-    if (event == null) {
-      throw StateError('event not found: $eventId');
-    }
+  }) {
+    return _updateCourtSettings(
+      eventId: eventId,
+      expectedRevision: null,
+      courtSettings: courtSettings,
+    );
+  }
 
+  @override
+  Future<SavedEventAggregate> updateCourtSettingsWithRevision({
+    required String eventId,
+    required int expectedRevision,
+    required List<SavedEventCourtSetting> courtSettings,
+  }) {
+    _validateExpectedRevision(expectedRevision);
+    return _updateCourtSettings(
+      eventId: eventId,
+      expectedRevision: expectedRevision,
+      courtSettings: courtSettings,
+    );
+  }
+
+  Future<SavedEventAggregate> _updateCourtSettings({
+    required String eventId,
+    required int? expectedRevision,
+    required List<SavedEventCourtSetting> courtSettings,
+  }) async {
+    final event = _requireEvent(eventId);
     if (event.hasAdoptedSchedule) {
       throw StateError('event already adopted: $eventId');
     }
@@ -263,16 +229,25 @@ class InMemoryEventRepository implements EventRepository {
     if (_courtSettingsEqual(currentSettings, courtSettings)) {
       return _buildAggregate(event);
     }
+    if (expectedRevision != null) {
+      _ensureRevision(event, expectedRevision);
+    }
 
     final updatedEvent = event.copyWith(
       revision: event.revision + 1,
       updatedAt: _clock(),
     );
-
     _eventsById[eventId] = updatedEvent;
     _courtSettingsByEventId[eventId] = List.unmodifiable(courtSettings);
-
     return _buildAggregate(updatedEvent);
+  }
+
+  SavedEvent _requireEvent(String eventId) {
+    final event = _eventsById[eventId];
+    if (event == null) {
+      throw StateError('event not found: $eventId');
+    }
+    return event;
   }
 
   SavedEventAggregate _buildAggregate(SavedEvent event) {
@@ -289,6 +264,48 @@ class InMemoryEventRepository implements EventRepository {
       courtSettings: _courtSettingsByEventId[event.id] ??
           buildDefaultCourtSettings(event.courtCount),
     );
+  }
+
+  void _validateExpectedRevision(int expectedRevision) {
+    if (expectedRevision < 1) {
+      throw ArgumentError.value(
+        expectedRevision,
+        'expectedRevision',
+        'must be greater than or equal to 1',
+      );
+    }
+  }
+
+  String _requireNonEmpty(String value, {required String fieldName}) {
+    final normalized = value.trim();
+    if (normalized.isEmpty) {
+      throw ArgumentError.value(value, fieldName, 'must not be empty');
+    }
+    return normalized;
+  }
+
+  Map<String, String> _normalizePlayerNames(
+    Map<String, String> playerDisplayNamesById,
+  ) {
+    final normalized = <String, String>{};
+    for (final entry in playerDisplayNamesById.entries) {
+      final playerId = _requireNonEmpty(entry.key, fieldName: 'playerId');
+      normalized[playerId] = _requireNonEmpty(
+        entry.value,
+        fieldName: 'playerDisplayNamesById[$playerId]',
+      );
+    }
+    return normalized;
+  }
+
+  void _ensureRevision(SavedEvent event, int expectedRevision) {
+    if (event.revision != expectedRevision) {
+      throw EventRevisionConflictException(
+        eventId: event.id,
+        expectedRevision: expectedRevision,
+        actualRevision: event.revision,
+      );
+    }
   }
 
   void _ensurePlayerIdsMatch(
@@ -311,30 +328,25 @@ class InMemoryEventRepository implements EventRepository {
     List<SavedEventCourtSetting> right,
   ) {
     if (left.length != right.length) return false;
-
     for (var index = 0; index < left.length; index += 1) {
       if (left[index].courtNumber != right[index].courtNumber ||
           left[index].displayLabel != right[index].displayLabel) {
         return false;
       }
     }
-
     return true;
   }
 
   String _generateUniquePublicId() {
     for (var attempt = 0; attempt < 10; attempt += 1) {
       final candidate = _publicIdGenerator();
-
       if (!isValidPublicId(candidate)) {
         throw StateError('invalid public_id generated: $candidate');
       }
-
       if (!_eventIdByPublicId.containsKey(candidate)) {
         return candidate;
       }
     }
-
     throw StateError('failed to generate unique public_id');
   }
 }

--- a/lib/features/doubles_scheduler/data/json_event_repository.dart
+++ b/lib/features/doubles_scheduler/data/json_event_repository.dart
@@ -81,16 +81,13 @@ class JsonEventRepository implements EventRepository {
     );
 
     await _saveAggregate(aggregate);
-
     return aggregate;
   }
 
   @override
   Future<SavedEventAggregate?> findByPublicId(String publicId) async {
     final data = await _store.findByPublicId(publicId);
-    if (data == null) return null;
-
-    return SavedEventAggregate.fromJson(data);
+    return data == null ? null : SavedEventAggregate.fromJson(data);
   }
 
   @override
@@ -104,11 +101,7 @@ class JsonEventRepository implements EventRepository {
     required String eventId,
     required String generatedScheduleId,
   }) async {
-    final aggregate = await _findByEventId(eventId);
-    if (aggregate == null) {
-      throw StateError('event not found: $eventId');
-    }
-
+    final aggregate = await _requireEventById(eventId);
     final updatedData = await _store.updateByPublicId(
       publicId: aggregate.event.publicId,
       update: (currentData) {
@@ -118,24 +111,19 @@ class JsonEventRepository implements EventRepository {
           throw StateError('event already adopted: $eventId');
         }
 
-        final now = _clock();
         return _buildEventFieldsUpdate(
           currentData,
           <String, dynamic>{
             'status': SavedEventStatus.generated.name,
             'currentGeneratedScheduleId': generatedScheduleId,
             'revision': current.event.revision + 1,
-            'updatedAt': _dateTimeToJson(now),
+            'updatedAt': _dateTimeToJson(_clock()),
           },
         );
       },
     );
 
-    if (updatedData == null) {
-      throw StateError('event not found: $eventId');
-    }
-
-    return SavedEventAggregate.fromJson(updatedData).event;
+    return _requireUpdatedAggregate(updatedData, eventId).event;
   }
 
   @override
@@ -143,37 +131,29 @@ class JsonEventRepository implements EventRepository {
     required String eventId,
     required String generatedScheduleId,
   }) async {
-    final aggregate = await _findByEventId(eventId);
-    if (aggregate == null) {
-      throw StateError('event not found: $eventId');
-    }
-
+    final aggregate = await _requireEventById(eventId);
     final updatedData = await _store.updateByPublicId(
       publicId: aggregate.event.publicId,
       update: (currentData) {
         final current = SavedEventAggregate.fromJson(currentData);
         _ensureEventId(current, eventId);
+        final nowJson = _dateTimeToJson(_clock());
 
-        final now = _clock();
         return _buildEventFieldsUpdate(
           currentData,
           <String, dynamic>{
             'status': SavedEventStatus.adopted.name,
             'currentGeneratedScheduleId': generatedScheduleId,
             'adoptedGeneratedScheduleId': generatedScheduleId,
-            'adoptedAt': _dateTimeToJson(now),
+            'adoptedAt': nowJson,
             'revision': current.event.revision + 1,
-            'updatedAt': _dateTimeToJson(now),
+            'updatedAt': nowJson,
           },
         );
       },
     );
 
-    if (updatedData == null) {
-      throw StateError('event not found: $eventId');
-    }
-
-    return SavedEventAggregate.fromJson(updatedData).event;
+    return _requireUpdatedAggregate(updatedData, eventId).event;
   }
 
   @override
@@ -184,36 +164,10 @@ class JsonEventRepository implements EventRepository {
     required String memo,
     required Map<String, String> playerDisplayNamesById,
   }) async {
-    if (expectedRevision < 1) {
-      throw ArgumentError.value(
-        expectedRevision,
-        'expectedRevision',
-        'must be greater than or equal to 1',
-      );
-    }
-
-    final normalizedTitle = title.trim();
-    if (normalizedTitle.isEmpty) {
-      throw ArgumentError.value(title, 'title', 'must not be empty');
-    }
-
+    _validateExpectedRevision(expectedRevision);
+    final normalizedTitle = _requireNonEmpty(title, fieldName: 'title');
     final normalizedMemo = memo.trim();
-    final normalizedNames = <String, String>{};
-    for (final entry in playerDisplayNamesById.entries) {
-      final playerId = entry.key.trim();
-      final displayName = entry.value.trim();
-      if (playerId.isEmpty) {
-        throw ArgumentError.value(entry.key, 'playerId', 'must not be empty');
-      }
-      if (displayName.isEmpty) {
-        throw ArgumentError.value(
-          entry.value,
-          'playerDisplayNamesById[$playerId]',
-          'must not be empty',
-        );
-      }
-      normalizedNames[playerId] = displayName;
-    }
+    final normalizedNames = _normalizePlayerNames(playerDisplayNamesById);
 
     final updatedData = await _store.updateByPublicId(
       publicId: publicId,
@@ -221,26 +175,17 @@ class JsonEventRepository implements EventRepository {
         final current = SavedEventAggregate.fromJson(currentData);
         _ensurePlayerIdsMatch(current.players, normalizedNames.keys.toSet());
 
-        final displayIsUnchanged = current.event.title == normalizedTitle &&
+        final isUnchanged = current.event.title == normalizedTitle &&
             current.event.memo == normalizedMemo &&
             current.players.every(
-              (player) =>
-                  player.displayName == normalizedNames[player.id],
+              (player) => player.displayName == normalizedNames[player.id],
             );
-        if (displayIsUnchanged) {
+        if (isUnchanged) {
           return SavedEventJsonUpdate.noOp(currentData);
         }
 
-        if (current.event.revision != expectedRevision) {
-          throw EventRevisionConflictException(
-            eventId: current.event.id,
-            expectedRevision: expectedRevision,
-            actualRevision: current.event.revision,
-          );
-        }
-
-        final now = _clock();
-        final nowJson = _dateTimeToJson(now);
+        _ensureRevision(current.event, expectedRevision);
+        final nowJson = _dateTimeToJson(_clock());
         final rawPlayers = _asObjectList(
           currentData['players'] ?? currentData['participants'],
           fieldName: 'players',
@@ -288,11 +233,7 @@ class JsonEventRepository implements EventRepository {
       },
     );
 
-    if (updatedData == null) {
-      throw StateError('event not found: $publicId');
-    }
-
-    return SavedEventAggregate.fromJson(updatedData);
+    return _requireUpdatedAggregate(updatedData, publicId);
   }
 
   @override
@@ -300,11 +241,33 @@ class JsonEventRepository implements EventRepository {
     required String eventId,
     required List<SavedEventCourtSetting> courtSettings,
   }) async {
-    final aggregate = await _findByEventId(eventId);
-    if (aggregate == null) {
-      throw StateError('event not found: $eventId');
-    }
+    return _updateCourtSettings(
+      eventId: eventId,
+      expectedRevision: null,
+      courtSettings: courtSettings,
+    );
+  }
 
+  @override
+  Future<SavedEventAggregate> updateCourtSettingsWithRevision({
+    required String eventId,
+    required int expectedRevision,
+    required List<SavedEventCourtSetting> courtSettings,
+  }) async {
+    _validateExpectedRevision(expectedRevision);
+    return _updateCourtSettings(
+      eventId: eventId,
+      expectedRevision: expectedRevision,
+      courtSettings: courtSettings,
+    );
+  }
+
+  Future<SavedEventAggregate> _updateCourtSettings({
+    required String eventId,
+    required int? expectedRevision,
+    required List<SavedEventCourtSetting> courtSettings,
+  }) async {
+    final aggregate = await _requireEventById(eventId);
     final updatedData = await _store.updateByPublicId(
       publicId: aggregate.event.publicId,
       update: (currentData) {
@@ -317,13 +280,15 @@ class JsonEventRepository implements EventRepository {
         if (_courtSettingsEqual(current.courtSettings, courtSettings)) {
           return SavedEventJsonUpdate.noOp(currentData);
         }
+        if (expectedRevision != null) {
+          _ensureRevision(current.event, expectedRevision);
+        }
 
-        final now = _clock();
         final eventUpdate = _buildEventFieldsUpdate(
           currentData,
           <String, dynamic>{
             'revision': current.event.revision + 1,
-            'updatedAt': _dateTimeToJson(now),
+            'updatedAt': _dateTimeToJson(_clock()),
           },
         );
         final nextCourtSettings = courtSettings
@@ -343,17 +308,29 @@ class JsonEventRepository implements EventRepository {
       },
     );
 
-    if (updatedData == null) {
-      throw StateError('event not found: $eventId');
-    }
-
-    return SavedEventAggregate.fromJson(updatedData);
+    return _requireUpdatedAggregate(updatedData, eventId);
   }
 
   Future<SavedEventAggregate?> _findByEventId(String eventId) async {
     final data = await _store.findByEventId(eventId);
-    if (data == null) return null;
+    return data == null ? null : SavedEventAggregate.fromJson(data);
+  }
 
+  Future<SavedEventAggregate> _requireEventById(String eventId) async {
+    final aggregate = await _findByEventId(eventId);
+    if (aggregate == null) {
+      throw StateError('event not found: $eventId');
+    }
+    return aggregate;
+  }
+
+  SavedEventAggregate _requireUpdatedAggregate(
+    Map<String, dynamic>? data,
+    String identifier,
+  ) {
+    if (data == null) {
+      throw StateError('event not found: $identifier');
+    }
     return SavedEventAggregate.fromJson(data);
   }
 
@@ -372,15 +349,14 @@ class JsonEventRepository implements EventRepository {
       currentData['event'],
       fieldName: 'event',
     );
-    final nextEvent = <String, dynamic>{
-      ...currentEvent,
-      ...eventFields,
-    };
 
     return SavedEventJsonUpdate(
       data: <String, dynamic>{
         ...currentData,
-        'event': nextEvent,
+        'event': <String, dynamic>{
+          ...currentEvent,
+          ...eventFields,
+        },
       },
       fields: <String, dynamic>{
         for (final entry in eventFields.entries)
@@ -389,9 +365,51 @@ class JsonEventRepository implements EventRepository {
     );
   }
 
+  void _validateExpectedRevision(int expectedRevision) {
+    if (expectedRevision < 1) {
+      throw ArgumentError.value(
+        expectedRevision,
+        'expectedRevision',
+        'must be greater than or equal to 1',
+      );
+    }
+  }
+
+  String _requireNonEmpty(String value, {required String fieldName}) {
+    final normalized = value.trim();
+    if (normalized.isEmpty) {
+      throw ArgumentError.value(value, fieldName, 'must not be empty');
+    }
+    return normalized;
+  }
+
+  Map<String, String> _normalizePlayerNames(
+    Map<String, String> playerDisplayNamesById,
+  ) {
+    final normalized = <String, String>{};
+    for (final entry in playerDisplayNamesById.entries) {
+      final playerId = _requireNonEmpty(entry.key, fieldName: 'playerId');
+      normalized[playerId] = _requireNonEmpty(
+        entry.value,
+        fieldName: 'playerDisplayNamesById[$playerId]',
+      );
+    }
+    return normalized;
+  }
+
   void _ensureEventId(SavedEventAggregate aggregate, String eventId) {
     if (aggregate.event.id != eventId) {
       throw StateError('event id mismatch: $eventId');
+    }
+  }
+
+  void _ensureRevision(SavedEvent event, int expectedRevision) {
+    if (event.revision != expectedRevision) {
+      throw EventRevisionConflictException(
+        eventId: event.id,
+        expectedRevision: expectedRevision,
+        actualRevision: event.revision,
+      );
     }
   }
 
@@ -415,14 +433,12 @@ class JsonEventRepository implements EventRepository {
     List<SavedEventCourtSetting> right,
   ) {
     if (left.length != right.length) return false;
-
     for (var index = 0; index < left.length; index += 1) {
       if (left[index].courtNumber != right[index].courtNumber ||
           left[index].displayLabel != right[index].displayLabel) {
         return false;
       }
     }
-
     return true;
   }
 
@@ -433,7 +449,6 @@ class JsonEventRepository implements EventRepository {
     if (value is! Map) {
       throw FormatException('$fieldName must be an object');
     }
-
     return value.map(
       (key, value) => MapEntry(key.toString(), value),
     );
@@ -446,7 +461,6 @@ class JsonEventRepository implements EventRepository {
     if (value is! List) {
       throw FormatException('$fieldName must be a list');
     }
-
     return value.map((item) {
       return _asObjectMap(item, fieldName: '$fieldName item');
     }).toList(growable: false);
@@ -459,17 +473,14 @@ class JsonEventRepository implements EventRepository {
   Future<String> _generateUniquePublicId() async {
     for (var attempt = 0; attempt < 10; attempt += 1) {
       final candidate = _publicIdGenerator();
-
       if (!isValidPublicId(candidate)) {
         throw StateError('invalid public_id generated: $candidate');
       }
-
       final existing = await _store.findByPublicId(candidate);
       if (existing == null) {
         return candidate;
       }
     }
-
     throw StateError('failed to generate unique public_id');
   }
 }

--- a/lib/features/doubles_scheduler/data/json_event_repository.dart
+++ b/lib/features/doubles_scheduler/data/json_event_repository.dart
@@ -10,16 +10,19 @@ class JsonEventRepository implements EventRepository {
   JsonEventRepository({
     required SavedEventJsonStore store,
     String Function()? publicIdGenerator,
+    DateTime Function()? clock,
   })  : _store = store,
-        _publicIdGenerator = publicIdGenerator ?? generatePublicId;
+        _publicIdGenerator = publicIdGenerator ?? generatePublicId,
+        _clock = clock ?? DateTime.now;
 
   final SavedEventJsonStore _store;
   final String Function() _publicIdGenerator;
+  final DateTime Function() _clock;
   final _uuid = const Uuid();
 
   @override
   Future<SavedEventAggregate> createFromDraft(EventDraft draft) async {
-    final now = DateTime.now();
+    final now = _clock();
     final eventId = _uuid.v4();
     final publicId = await _generateUniquePublicId();
 
@@ -43,6 +46,7 @@ class JsonEventRepository implements EventRepository {
       return SavedEventPlayer(
         id: player.id,
         eventId: eventId,
+        initialDisplayName: player.displayName,
         displayName: player.displayName,
         orderNo: index + 1,
         status: 'active',
@@ -105,21 +109,33 @@ class JsonEventRepository implements EventRepository {
       throw StateError('event not found: $eventId');
     }
 
-    final event = aggregate.event;
-    if (event.hasAdoptedSchedule) {
-      throw StateError('event already adopted: $eventId');
-    }
+    final updatedData = await _store.updateByPublicId(
+      publicId: aggregate.event.publicId,
+      update: (currentData) {
+        final current = SavedEventAggregate.fromJson(currentData);
+        _ensureEventId(current, eventId);
+        if (current.event.hasAdoptedSchedule) {
+          throw StateError('event already adopted: $eventId');
+        }
 
-    final updatedEvent = event.copyWith(
-      status: SavedEventStatus.generated,
-      currentGeneratedScheduleId: generatedScheduleId,
-      revision: event.revision + 1,
-      updatedAt: DateTime.now(),
+        final now = _clock();
+        return _buildEventFieldsUpdate(
+          currentData,
+          <String, dynamic>{
+            'status': SavedEventStatus.generated.name,
+            'currentGeneratedScheduleId': generatedScheduleId,
+            'revision': current.event.revision + 1,
+            'updatedAt': _dateTimeToJson(now),
+          },
+        );
+      },
     );
 
-    await _saveAggregate(_replaceEvent(aggregate, updatedEvent));
+    if (updatedData == null) {
+      throw StateError('event not found: $eventId');
+    }
 
-    return updatedEvent;
+    return SavedEventAggregate.fromJson(updatedData).event;
   }
 
   @override
@@ -132,20 +148,151 @@ class JsonEventRepository implements EventRepository {
       throw StateError('event not found: $eventId');
     }
 
-    final event = aggregate.event;
-    final now = DateTime.now();
-    final updatedEvent = event.copyWith(
-      status: SavedEventStatus.adopted,
-      currentGeneratedScheduleId: generatedScheduleId,
-      adoptedGeneratedScheduleId: generatedScheduleId,
-      adoptedAt: now,
-      revision: event.revision + 1,
-      updatedAt: now,
+    final updatedData = await _store.updateByPublicId(
+      publicId: aggregate.event.publicId,
+      update: (currentData) {
+        final current = SavedEventAggregate.fromJson(currentData);
+        _ensureEventId(current, eventId);
+
+        final now = _clock();
+        return _buildEventFieldsUpdate(
+          currentData,
+          <String, dynamic>{
+            'status': SavedEventStatus.adopted.name,
+            'currentGeneratedScheduleId': generatedScheduleId,
+            'adoptedGeneratedScheduleId': generatedScheduleId,
+            'adoptedAt': _dateTimeToJson(now),
+            'revision': current.event.revision + 1,
+            'updatedAt': _dateTimeToJson(now),
+          },
+        );
+      },
     );
 
-    await _saveAggregate(_replaceEvent(aggregate, updatedEvent));
+    if (updatedData == null) {
+      throw StateError('event not found: $eventId');
+    }
 
-    return updatedEvent;
+    return SavedEventAggregate.fromJson(updatedData).event;
+  }
+
+  @override
+  Future<SavedEventAggregate> updateDisplayInfo({
+    required String publicId,
+    required int expectedRevision,
+    required String title,
+    required String memo,
+    required Map<String, String> playerDisplayNamesById,
+  }) async {
+    if (expectedRevision < 1) {
+      throw ArgumentError.value(
+        expectedRevision,
+        'expectedRevision',
+        'must be greater than or equal to 1',
+      );
+    }
+
+    final normalizedTitle = title.trim();
+    if (normalizedTitle.isEmpty) {
+      throw ArgumentError.value(title, 'title', 'must not be empty');
+    }
+
+    final normalizedMemo = memo.trim();
+    final normalizedNames = <String, String>{};
+    for (final entry in playerDisplayNamesById.entries) {
+      final playerId = entry.key.trim();
+      final displayName = entry.value.trim();
+      if (playerId.isEmpty) {
+        throw ArgumentError.value(entry.key, 'playerId', 'must not be empty');
+      }
+      if (displayName.isEmpty) {
+        throw ArgumentError.value(
+          entry.value,
+          'playerDisplayNamesById[$playerId]',
+          'must not be empty',
+        );
+      }
+      normalizedNames[playerId] = displayName;
+    }
+
+    final updatedData = await _store.updateByPublicId(
+      publicId: publicId,
+      update: (currentData) {
+        final current = SavedEventAggregate.fromJson(currentData);
+        _ensurePlayerIdsMatch(current.players, normalizedNames.keys.toSet());
+
+        final displayIsUnchanged = current.event.title == normalizedTitle &&
+            current.event.memo == normalizedMemo &&
+            current.players.every(
+              (player) =>
+                  player.displayName == normalizedNames[player.id],
+            );
+        if (displayIsUnchanged) {
+          return SavedEventJsonUpdate.noOp(currentData);
+        }
+
+        if (current.event.revision != expectedRevision) {
+          throw EventRevisionConflictException(
+            eventId: current.event.id,
+            expectedRevision: expectedRevision,
+            actualRevision: current.event.revision,
+          );
+        }
+
+        final now = _clock();
+        final nowJson = _dateTimeToJson(now);
+        final rawPlayers = _asObjectList(
+          currentData['players'] ?? currentData['participants'],
+          fieldName: 'players',
+        );
+        final updatedPlayers = rawPlayers.map((rawPlayer) {
+          final playerId = rawPlayer['id']?.toString() ?? '';
+          final currentDisplayName = rawPlayer['displayName']?.toString() ?? '';
+          final nextDisplayName = normalizedNames[playerId];
+          if (nextDisplayName == null) {
+            throw StateError('player not found in update input: $playerId');
+          }
+
+          return <String, dynamic>{
+            ...rawPlayer,
+            'initialDisplayName':
+                rawPlayer['initialDisplayName']?.toString() ??
+                    currentDisplayName,
+            'displayName': nextDisplayName,
+            'updatedAt': currentDisplayName == nextDisplayName
+                ? rawPlayer['updatedAt']
+                : nowJson,
+          };
+        }).toList(growable: false);
+
+        final eventUpdate = _buildEventFieldsUpdate(
+          currentData,
+          <String, dynamic>{
+            'title': normalizedTitle,
+            'memo': normalizedMemo,
+            'revision': current.event.revision + 1,
+            'updatedAt': nowJson,
+          },
+        );
+
+        return SavedEventJsonUpdate(
+          data: <String, dynamic>{
+            ...eventUpdate.data,
+            'players': updatedPlayers,
+          },
+          fields: <String, dynamic>{
+            ...eventUpdate.fields,
+            'players': updatedPlayers,
+          },
+        );
+      },
+    );
+
+    if (updatedData == null) {
+      throw StateError('event not found: $publicId');
+    }
+
+    return SavedEventAggregate.fromJson(updatedData);
   }
 
   @override
@@ -158,27 +305,49 @@ class JsonEventRepository implements EventRepository {
       throw StateError('event not found: $eventId');
     }
 
-    final event = aggregate.event;
-    if (event.hasAdoptedSchedule) {
-      throw StateError('event already adopted: $eventId');
+    final updatedData = await _store.updateByPublicId(
+      publicId: aggregate.event.publicId,
+      update: (currentData) {
+        final current = SavedEventAggregate.fromJson(currentData);
+        _ensureEventId(current, eventId);
+        if (current.event.hasAdoptedSchedule) {
+          throw StateError('event already adopted: $eventId');
+        }
+
+        if (_courtSettingsEqual(current.courtSettings, courtSettings)) {
+          return SavedEventJsonUpdate.noOp(currentData);
+        }
+
+        final now = _clock();
+        final eventUpdate = _buildEventFieldsUpdate(
+          currentData,
+          <String, dynamic>{
+            'revision': current.event.revision + 1,
+            'updatedAt': _dateTimeToJson(now),
+          },
+        );
+        final nextCourtSettings = courtSettings
+            .map((setting) => setting.toJson())
+            .toList(growable: false);
+
+        return SavedEventJsonUpdate(
+          data: <String, dynamic>{
+            ...eventUpdate.data,
+            'courtSettings': nextCourtSettings,
+          },
+          fields: <String, dynamic>{
+            ...eventUpdate.fields,
+            'courtSettings': nextCourtSettings,
+          },
+        );
+      },
+    );
+
+    if (updatedData == null) {
+      throw StateError('event not found: $eventId');
     }
 
-    final updatedEvent = event.copyWith(
-      revision: event.revision + 1,
-      updatedAt: DateTime.now(),
-    );
-
-    final updatedAggregate = SavedEventAggregate(
-      event: updatedEvent,
-      players: aggregate.players,
-      share: aggregate.share,
-      importRecord: aggregate.importRecord,
-      courtSettings: courtSettings,
-    );
-
-    await _saveAggregate(updatedAggregate);
-
-    return updatedAggregate;
+    return SavedEventAggregate.fromJson(updatedData);
   }
 
   Future<SavedEventAggregate?> _findByEventId(String eventId) async {
@@ -195,17 +364,96 @@ class JsonEventRepository implements EventRepository {
     );
   }
 
-  SavedEventAggregate _replaceEvent(
-    SavedEventAggregate aggregate,
-    SavedEvent event,
+  SavedEventJsonUpdate _buildEventFieldsUpdate(
+    Map<String, dynamic> currentData,
+    Map<String, dynamic> eventFields,
   ) {
-    return SavedEventAggregate(
-      event: event,
-      players: aggregate.players,
-      share: aggregate.share,
-      importRecord: aggregate.importRecord,
-      courtSettings: aggregate.courtSettings,
+    final currentEvent = _asObjectMap(
+      currentData['event'],
+      fieldName: 'event',
     );
+    final nextEvent = <String, dynamic>{
+      ...currentEvent,
+      ...eventFields,
+    };
+
+    return SavedEventJsonUpdate(
+      data: <String, dynamic>{
+        ...currentData,
+        'event': nextEvent,
+      },
+      fields: <String, dynamic>{
+        for (final entry in eventFields.entries)
+          'event.${entry.key}': entry.value,
+      },
+    );
+  }
+
+  void _ensureEventId(SavedEventAggregate aggregate, String eventId) {
+    if (aggregate.event.id != eventId) {
+      throw StateError('event id mismatch: $eventId');
+    }
+  }
+
+  void _ensurePlayerIdsMatch(
+    List<SavedEventPlayer> players,
+    Set<String> inputPlayerIds,
+  ) {
+    final currentPlayerIds = players.map((player) => player.id).toSet();
+    if (currentPlayerIds.length != inputPlayerIds.length ||
+        !currentPlayerIds.containsAll(inputPlayerIds)) {
+      throw ArgumentError.value(
+        inputPlayerIds,
+        'playerDisplayNamesById',
+        'must contain exactly the current event player ids',
+      );
+    }
+  }
+
+  bool _courtSettingsEqual(
+    List<SavedEventCourtSetting> left,
+    List<SavedEventCourtSetting> right,
+  ) {
+    if (left.length != right.length) return false;
+
+    for (var index = 0; index < left.length; index += 1) {
+      if (left[index].courtNumber != right[index].courtNumber ||
+          left[index].displayLabel != right[index].displayLabel) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  Map<String, dynamic> _asObjectMap(
+    Object? value, {
+    required String fieldName,
+  }) {
+    if (value is! Map) {
+      throw FormatException('$fieldName must be an object');
+    }
+
+    return value.map(
+      (key, value) => MapEntry(key.toString(), value),
+    );
+  }
+
+  List<Map<String, dynamic>> _asObjectList(
+    Object? value, {
+    required String fieldName,
+  }) {
+    if (value is! List) {
+      throw FormatException('$fieldName must be a list');
+    }
+
+    return value.map((item) {
+      return _asObjectMap(item, fieldName: '$fieldName item');
+    }).toList(growable: false);
+  }
+
+  String _dateTimeToJson(DateTime value) {
+    return value.toUtc().toIso8601String();
   }
 
   Future<String> _generateUniquePublicId() async {

--- a/lib/features/doubles_scheduler/data/saved_event_json_store.dart
+++ b/lib/features/doubles_scheduler/data/saved_event_json_store.dart
@@ -34,7 +34,20 @@ abstract class SavedEventJsonStore {
   Future<Map<String, dynamic>?> updateByPublicId({
     required String publicId,
     required SavedEventJsonUpdater update,
-  }) {
-    throw UnimplementedError('updateByPublicId is not implemented');
+  }) async {
+    final current = await findByPublicId(publicId);
+    if (current == null) {
+      return null;
+    }
+
+    final result = update(current);
+    if (!result.isNoOp) {
+      await saveByPublicId(
+        publicId: publicId,
+        data: result.data,
+      );
+    }
+
+    return result.data;
   }
 }

--- a/lib/features/doubles_scheduler/data/saved_event_json_store.dart
+++ b/lib/features/doubles_scheduler/data/saved_event_json_store.dart
@@ -1,3 +1,26 @@
+typedef SavedEventJsonUpdater = SavedEventJsonUpdate Function(
+  Map<String, dynamic> current,
+);
+
+class SavedEventJsonUpdate {
+  const SavedEventJsonUpdate({
+    required this.data,
+    required this.fields,
+  });
+
+  factory SavedEventJsonUpdate.noOp(Map<String, dynamic> data) {
+    return SavedEventJsonUpdate(
+      data: data,
+      fields: const <String, dynamic>{},
+    );
+  }
+
+  final Map<String, dynamic> data;
+  final Map<String, dynamic> fields;
+
+  bool get isNoOp => fields.isEmpty;
+}
+
 abstract class SavedEventJsonStore {
   Future<void> saveByPublicId({
     required String publicId,
@@ -7,4 +30,11 @@ abstract class SavedEventJsonStore {
   Future<Map<String, dynamic>?> findByPublicId(String publicId);
 
   Future<Map<String, dynamic>?> findByEventId(String eventId);
+
+  Future<Map<String, dynamic>?> updateByPublicId({
+    required String publicId,
+    required SavedEventJsonUpdater update,
+  }) {
+    throw UnimplementedError('updateByPublicId is not implemented');
+  }
 }

--- a/lib/features/doubles_scheduler/domain/saved_event_models.dart
+++ b/lib/features/doubles_scheduler/domain/saved_event_models.dart
@@ -30,6 +30,7 @@ class SavedEvent {
     required this.status,
     required this.createdAt,
     required this.updatedAt,
+    this.memo = '',
     this.eventDate,
     this.startTime,
     this.endTime,
@@ -46,6 +47,7 @@ class SavedEvent {
   final String id;
   final String publicId;
   final String title;
+  final String memo;
   final DateTime? eventDate;
   final String? startTime;
   final String? endTime;
@@ -75,6 +77,7 @@ class SavedEvent {
 
   SavedEvent copyWith({
     String? title,
+    String? memo,
     DateTime? eventDate,
     String? startTime,
     String? endTime,
@@ -96,6 +99,7 @@ class SavedEvent {
       id: id,
       publicId: publicId,
       title: title ?? this.title,
+      memo: memo ?? this.memo,
       eventDate: eventDate ?? this.eventDate,
       startTime: startTime ?? this.startTime,
       endTime: endTime ?? this.endTime,
@@ -123,6 +127,7 @@ class SavedEvent {
       'id': id,
       'publicId': publicId,
       'title': title,
+      'memo': memo,
       'eventDate': _nullableDateTimeToJson(eventDate),
       'startTime': startTime,
       'endTime': endTime,
@@ -150,6 +155,7 @@ class SavedEvent {
       id: json['id'].toString(),
       publicId: json['publicId'].toString(),
       title: json['title'].toString(),
+      memo: json['memo']?.toString() ?? '',
       eventDate: _nullableDateTimeFromJson(json['eventDate']),
       startTime: json['startTime']?.toString(),
       endTime: json['endTime']?.toString(),
@@ -183,11 +189,13 @@ class SavedEventPlayer {
     required this.status,
     required this.createdAt,
     required this.updatedAt,
+    String? initialDisplayName,
     this.sourceText,
-  });
+  }) : initialDisplayName = initialDisplayName ?? displayName;
 
   final String id;
   final String eventId;
+  final String initialDisplayName;
   final String displayName;
   final int orderNo;
   final String status;
@@ -195,10 +203,28 @@ class SavedEventPlayer {
   final DateTime createdAt;
   final DateTime updatedAt;
 
+  SavedEventPlayer copyWith({
+    String? displayName,
+    DateTime? updatedAt,
+  }) {
+    return SavedEventPlayer(
+      id: id,
+      eventId: eventId,
+      initialDisplayName: initialDisplayName,
+      displayName: displayName ?? this.displayName,
+      orderNo: orderNo,
+      status: status,
+      sourceText: sourceText,
+      createdAt: createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
   Map<String, dynamic> toJson() {
     return {
       'id': id,
       'eventId': eventId,
+      'initialDisplayName': initialDisplayName,
       'displayName': displayName,
       'orderNo': orderNo,
       'status': status,
@@ -209,10 +235,14 @@ class SavedEventPlayer {
   }
 
   factory SavedEventPlayer.fromJson(Map<String, dynamic> json) {
+    final displayName = json['displayName'].toString();
+
     return SavedEventPlayer(
       id: json['id'].toString(),
       eventId: json['eventId'].toString(),
-      displayName: json['displayName'].toString(),
+      initialDisplayName:
+          json['initialDisplayName']?.toString() ?? displayName,
+      displayName: displayName,
       orderNo: _intFromJson(json['orderNo']),
       status: json['status']?.toString() ?? 'active',
       sourceText: json['sourceText']?.toString(),

--- a/test/features/doubles_scheduler/application/doubles_schedule_refresh_service_test.dart
+++ b/test/features/doubles_scheduler/application/doubles_schedule_refresh_service_test.dart
@@ -263,8 +263,28 @@ class _FakeEventRepository implements EventRepository {
   }
 
   @override
+  Future<SavedEventAggregate> updateDisplayInfo({
+    required String publicId,
+    required int expectedRevision,
+    required String title,
+    required String memo,
+    required Map<String, String> playerDisplayNamesById,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
   Future<SavedEventAggregate> updateCourtSettings({
     required String eventId,
+    required List<SavedEventCourtSetting> courtSettings,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SavedEventAggregate> updateCourtSettingsWithRevision({
+    required String eventId,
+    required int expectedRevision,
     required List<SavedEventCourtSetting> courtSettings,
   }) {
     throw UnimplementedError();

--- a/test/features/doubles_scheduler/data/event_court_revision_update_test.dart
+++ b/test/features/doubles_scheduler/data/event_court_revision_update_test.dart
@@ -92,7 +92,7 @@ EventDraft _draft() {
   );
 }
 
-class _FakeSavedEventJsonStore implements SavedEventJsonStore {
+class _FakeSavedEventJsonStore extends SavedEventJsonStore {
   final Map<String, Map<String, dynamic>> _dataByPublicId = {};
 
   @override

--- a/test/features/doubles_scheduler/data/event_court_revision_update_test.dart
+++ b/test/features/doubles_scheduler/data/event_court_revision_update_test.dart
@@ -1,0 +1,126 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:srp_lanske/features/doubles_scheduler/application/event_repository.dart';
+import 'package:srp_lanske/features/doubles_scheduler/data/in_memory_event_repository.dart';
+import 'package:srp_lanske/features/doubles_scheduler/data/json_event_repository.dart';
+import 'package:srp_lanske/features/doubles_scheduler/data/saved_event_json_store.dart';
+import 'package:srp_lanske/features/doubles_scheduler/domain/player_draft.dart';
+import 'package:srp_lanske/features/doubles_scheduler/domain/saved_event_models.dart';
+import 'package:srp_lanske/features/doubles_scheduler/presentation/models/event_draft.dart';
+
+void main() {
+  final factories = <String, EventRepository Function()>{
+    'InMemoryEventRepository': InMemoryEventRepository.new,
+    'JsonEventRepository': () => JsonEventRepository(
+          store: _FakeSavedEventJsonStore(),
+        ),
+  };
+
+  for (final entry in factories.entries) {
+    group('${entry.key} revision-aware court update', () {
+      test('rejects a changed save when the revision is stale', () async {
+        final repository = entry.value();
+        final created = await repository.createFromDraft(_draft());
+
+        final displayNames = <String, String>{
+          for (final player in created.players)
+            player.id: player.displayName,
+        };
+        final updatedDisplay = await repository.updateDisplayInfo(
+          publicId: created.event.publicId,
+          expectedRevision: created.event.revision,
+          title: '更新後',
+          memo: '',
+          playerDisplayNamesById: displayNames,
+        );
+
+        await expectLater(
+          repository.updateCourtSettingsWithRevision(
+            eventId: created.event.id,
+            expectedRevision: created.event.revision,
+            courtSettings: [
+              SavedEventCourtSetting(courtNumber: 1, displayLabel: 'A'),
+            ],
+          ),
+          throwsA(
+            isA<EventRevisionConflictException>().having(
+              (error) => error.actualRevision,
+              'actualRevision',
+              updatedDisplay.event.revision,
+            ),
+          ),
+        );
+      });
+
+      test('treats identical values as a no-op before conflict checking',
+          () async {
+        final repository = entry.value();
+        final created = await repository.createFromDraft(_draft());
+        final first = await repository.updateCourtSettingsWithRevision(
+          eventId: created.event.id,
+          expectedRevision: created.event.revision,
+          courtSettings: [
+            SavedEventCourtSetting(courtNumber: 1, displayLabel: 'A'),
+          ],
+        );
+
+        final noOp = await repository.updateCourtSettingsWithRevision(
+          eventId: created.event.id,
+          expectedRevision: created.event.revision,
+          courtSettings: [
+            SavedEventCourtSetting(courtNumber: 1, displayLabel: 'A'),
+          ],
+        );
+
+        expect(noOp.event.revision, first.event.revision);
+        expect(noOp.courtSettings.single.displayLabel, 'A');
+      });
+    });
+  }
+}
+
+EventDraft _draft() {
+  return EventDraft(
+    url: '',
+    courts: 1,
+    eventName: 'イベント',
+    players: [
+      for (var index = 1; index <= 6; index += 1)
+        PlayerDraft.create(displayName: '参加者$index'),
+    ],
+  );
+}
+
+class _FakeSavedEventJsonStore implements SavedEventJsonStore {
+  final Map<String, Map<String, dynamic>> _dataByPublicId = {};
+
+  @override
+  Future<void> saveByPublicId({
+    required String publicId,
+    required Map<String, dynamic> data,
+  }) async {
+    _dataByPublicId[publicId] = _copy(data);
+  }
+
+  @override
+  Future<Map<String, dynamic>?> findByPublicId(String publicId) async {
+    final data = _dataByPublicId[publicId];
+    return data == null ? null : _copy(data);
+  }
+
+  @override
+  Future<Map<String, dynamic>?> findByEventId(String eventId) async {
+    for (final data in _dataByPublicId.values) {
+      final event = data['event'];
+      if (event is Map && event['id'] == eventId) {
+        return _copy(data);
+      }
+    }
+    return null;
+  }
+
+  Map<String, dynamic> _copy(Map<String, dynamic> data) {
+    return jsonDecode(jsonEncode(data)) as Map<String, dynamic>;
+  }
+}

--- a/test/features/doubles_scheduler/data/event_display_update_repository_test.dart
+++ b/test/features/doubles_scheduler/data/event_display_update_repository_test.dart
@@ -1,0 +1,225 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:srp_lanske/features/doubles_scheduler/application/event_repository.dart';
+import 'package:srp_lanske/features/doubles_scheduler/data/in_memory_event_repository.dart';
+import 'package:srp_lanske/features/doubles_scheduler/data/json_event_repository.dart';
+import 'package:srp_lanske/features/doubles_scheduler/data/saved_event_json_store.dart';
+import 'package:srp_lanske/features/doubles_scheduler/domain/player_draft.dart';
+import 'package:srp_lanske/features/doubles_scheduler/domain/saved_event_models.dart';
+import 'package:srp_lanske/features/doubles_scheduler/presentation/models/event_draft.dart';
+
+void main() {
+  final repositoryFactories = <String, EventRepository Function()>{
+    'InMemoryEventRepository': InMemoryEventRepository.new,
+    'JsonEventRepository': () => JsonEventRepository(
+          store: _FakeSavedEventJsonStore(),
+        ),
+  };
+
+  for (final entry in repositoryFactories.entries) {
+    group('${entry.key} display update', () {
+      test('stores initial display names when an event is created', () async {
+        final repository = entry.value();
+
+        final created = await repository.createFromDraft(_buildDraft());
+
+        expect(created.event.memo, isEmpty);
+        expect(created.players[0].initialDisplayName, '参加者1');
+        expect(created.players[0].displayName, '参加者1');
+        expect(created.players[5].initialDisplayName, '参加者6');
+        expect(created.players[5].displayName, '参加者6');
+      });
+
+      test('updates display fields without changing schedule data', () async {
+        final repository = entry.value();
+        final created = await repository.createFromDraft(_buildDraft());
+
+        await repository.updateCurrentGeneratedScheduleId(
+          eventId: created.event.id,
+          generatedScheduleId: 'generated-1',
+        );
+        await repository.updateCourtSettings(
+          eventId: created.event.id,
+          courtSettings: [
+            SavedEventCourtSetting(courtNumber: 1, displayLabel: 'A'),
+          ],
+        );
+        final beforeUpdate =
+            await repository.findByPublicId(created.event.publicId);
+        final names = <String, String>{
+          for (final player in beforeUpdate!.players)
+            player.id: '${player.displayName}・更新',
+        };
+
+        final updated = await repository.updateDisplayInfo(
+          publicId: created.event.publicId,
+          expectedRevision: beforeUpdate.event.revision,
+          title: ' 更新後イベント ',
+          memo: ' 運営メモ ',
+          playerDisplayNamesById: names,
+        );
+
+        expect(updated.event.title, '更新後イベント');
+        expect(updated.event.memo, '運営メモ');
+        expect(updated.event.revision, beforeUpdate.event.revision + 1);
+        expect(updated.event.currentGeneratedScheduleId, 'generated-1');
+        expect(updated.courtSettings.single.displayLabel, 'A');
+        expect(updated.players[0].initialDisplayName, '参加者1');
+        expect(updated.players[0].displayName, '参加者1・更新');
+
+        final restored =
+            await repository.findByPublicId(created.event.publicId);
+        expect(restored, isNotNull);
+        expect(restored!.event.title, '更新後イベント');
+        expect(restored.event.memo, '運営メモ');
+        expect(restored.event.currentGeneratedScheduleId, 'generated-1');
+        expect(restored.courtSettings.single.displayLabel, 'A');
+        expect(restored.players[0].initialDisplayName, '参加者1');
+        expect(restored.players[0].displayName, '参加者1・更新');
+      });
+
+      test('rejects a changed save when the revision is stale', () async {
+        final repository = entry.value();
+        final created = await repository.createFromDraft(_buildDraft());
+        final initialNames = <String, String>{
+          for (final player in created.players)
+            player.id: player.displayName,
+        };
+
+        final first = await repository.updateDisplayInfo(
+          publicId: created.event.publicId,
+          expectedRevision: created.event.revision,
+          title: '先に保存されたイベント',
+          memo: '',
+          playerDisplayNamesById: initialNames,
+        );
+
+        await expectLater(
+          repository.updateDisplayInfo(
+            publicId: created.event.publicId,
+            expectedRevision: created.event.revision,
+            title: '古い画面からの変更',
+            memo: '',
+            playerDisplayNamesById: initialNames,
+          ),
+          throwsA(
+            isA<EventRevisionConflictException>()
+                .having(
+                  (error) => error.expectedRevision,
+                  'expectedRevision',
+                  created.event.revision,
+                )
+                .having(
+                  (error) => error.actualRevision,
+                  'actualRevision',
+                  first.event.revision,
+                ),
+          ),
+        );
+
+        final restored =
+            await repository.findByPublicId(created.event.publicId);
+        expect(restored!.event.title, '先に保存されたイベント');
+        expect(restored.event.revision, first.event.revision);
+      });
+
+      test('accepts a stale revision when the saved values are identical',
+          () async {
+        final repository = entry.value();
+        final created = await repository.createFromDraft(_buildDraft());
+        final names = <String, String>{
+          for (final player in created.players)
+            player.id: '${player.displayName}・更新',
+        };
+
+        final first = await repository.updateDisplayInfo(
+          publicId: created.event.publicId,
+          expectedRevision: created.event.revision,
+          title: '更新後イベント',
+          memo: 'メモ',
+          playerDisplayNamesById: names,
+        );
+
+        final noOp = await repository.updateDisplayInfo(
+          publicId: created.event.publicId,
+          expectedRevision: created.event.revision,
+          title: '更新後イベント',
+          memo: 'メモ',
+          playerDisplayNamesById: names,
+        );
+
+        expect(noOp.event.revision, first.event.revision);
+        expect(noOp.event.updatedAt, first.event.updatedAt);
+      });
+
+      test('requires exactly the current player ids', () async {
+        final repository = entry.value();
+        final created = await repository.createFromDraft(_buildDraft());
+
+        await expectLater(
+          repository.updateDisplayInfo(
+            publicId: created.event.publicId,
+            expectedRevision: created.event.revision,
+            title: created.event.title,
+            memo: '',
+            playerDisplayNamesById: {
+              created.players.first.id: '参加者1',
+            },
+          ),
+          throwsArgumentError,
+        );
+      });
+    });
+  }
+}
+
+EventDraft _buildDraft() {
+  return EventDraft(
+    url: 'https://example.com/events/1',
+    courts: 1,
+    eventName: 'テストイベント',
+    players: [
+      PlayerDraft.create(displayName: '参加者1'),
+      PlayerDraft.create(displayName: '参加者2'),
+      PlayerDraft.create(displayName: '参加者3'),
+      PlayerDraft.create(displayName: '参加者4'),
+      PlayerDraft.create(displayName: '参加者5'),
+      PlayerDraft.create(displayName: '参加者6'),
+    ],
+  );
+}
+
+class _FakeSavedEventJsonStore implements SavedEventJsonStore {
+  final Map<String, Map<String, dynamic>> _dataByPublicId = {};
+
+  @override
+  Future<void> saveByPublicId({
+    required String publicId,
+    required Map<String, dynamic> data,
+  }) async {
+    _dataByPublicId[publicId] = _copy(data);
+  }
+
+  @override
+  Future<Map<String, dynamic>?> findByPublicId(String publicId) async {
+    final data = _dataByPublicId[publicId];
+    return data == null ? null : _copy(data);
+  }
+
+  @override
+  Future<Map<String, dynamic>?> findByEventId(String eventId) async {
+    for (final data in _dataByPublicId.values) {
+      final event = data['event'];
+      if (event is Map && event['id'] == eventId) {
+        return _copy(data);
+      }
+    }
+
+    return null;
+  }
+
+  Map<String, dynamic> _copy(Map<String, dynamic> data) {
+    return jsonDecode(jsonEncode(data)) as Map<String, dynamic>;
+  }
+}

--- a/test/features/doubles_scheduler/data/event_display_update_repository_test.dart
+++ b/test/features/doubles_scheduler/data/event_display_update_repository_test.dart
@@ -190,7 +190,7 @@ EventDraft _buildDraft() {
   );
 }
 
-class _FakeSavedEventJsonStore implements SavedEventJsonStore {
+class _FakeSavedEventJsonStore extends SavedEventJsonStore {
   final Map<String, Map<String, dynamic>> _dataByPublicId = {};
 
   @override

--- a/test/features/doubles_scheduler/data/json_event_repository_test.dart
+++ b/test/features/doubles_scheduler/data/json_event_repository_test.dart
@@ -66,7 +66,7 @@ void main() {
   });
 }
 
-class FakeSavedEventJsonStore implements SavedEventJsonStore {
+class FakeSavedEventJsonStore extends SavedEventJsonStore {
   final Map<String, Map<String, dynamic>> _dataByPublicId = {};
 
   @override

--- a/test/features/doubles_scheduler/domain/saved_event_display_metadata_test.dart
+++ b/test/features/doubles_scheduler/domain/saved_event_display_metadata_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:srp_lanske/features/doubles_scheduler/domain/saved_event_models.dart';
+
+void main() {
+  group('SavedEvent display metadata compatibility', () {
+    final createdAt = DateTime.utc(2026, 8, 1, 0);
+
+    test('round trips event memo and initial player display name', () {
+      final event = SavedEvent(
+        id: 'event-1',
+        publicId: 'ABCD1234',
+        title: 'イベント',
+        memo: '運営メモ',
+        courtCount: 1,
+        sourceType: EventSourceType.manual,
+        sourceUrl: null,
+        status: SavedEventStatus.draft,
+        createdAt: createdAt,
+        updatedAt: createdAt,
+      );
+      final aggregate = SavedEventAggregate(
+        event: event,
+        players: [
+          SavedEventPlayer(
+            id: 'player-1',
+            eventId: event.id,
+            initialDisplayName: '生成時名',
+            displayName: '現在名',
+            orderNo: 1,
+            status: 'active',
+            createdAt: createdAt,
+            updatedAt: createdAt,
+          ),
+        ],
+        share: SavedEventShare(
+          publicId: event.publicId,
+          eventId: event.id,
+          createdAt: createdAt,
+          updatedAt: createdAt,
+        ),
+      );
+
+      final restored = SavedEventAggregate.fromJson(aggregate.toJson());
+
+      expect(restored.event.memo, '運営メモ');
+      expect(restored.players.single.initialDisplayName, '生成時名');
+      expect(restored.players.single.displayName, '現在名');
+    });
+
+    test('uses legacy values when new display fields are missing', () {
+      final aggregate = SavedEventAggregate.fromJson({
+        'schemaVersion': savedEventAggregateSchemaVersion,
+        'event': {
+          'id': 'event-1',
+          'publicId': 'ABCD1234',
+          'title': 'イベント',
+          'courtCount': 1,
+          'sourceType': 'manual',
+          'sourceUrl': null,
+          'status': 'draft',
+          'createdAt': createdAt.toIso8601String(),
+          'updatedAt': createdAt.toIso8601String(),
+        },
+        'players': [
+          {
+            'id': 'player-1',
+            'eventId': 'event-1',
+            'displayName': '従来の表示名',
+            'orderNo': 1,
+            'status': 'active',
+            'createdAt': createdAt.toIso8601String(),
+            'updatedAt': createdAt.toIso8601String(),
+          },
+        ],
+        'share': {
+          'publicId': 'ABCD1234',
+          'eventId': 'event-1',
+          'createdAt': createdAt.toIso8601String(),
+          'updatedAt': createdAt.toIso8601String(),
+        },
+      });
+
+      expect(aggregate.event.memo, isEmpty);
+      expect(aggregate.players.single.initialDisplayName, '従来の表示名');
+      expect(aggregate.players.single.displayName, '従来の表示名');
+    });
+  });
+}


### PR DESCRIPTION
## 概要

Closes #153

ダブルスイベントの表示情報を編集する際に、古いaggregate全体を保存して他端末の変更を巻き戻さないよう、部分更新とrevisionによる楽観ロックを追加します。

後続の #137「✏️ ダブルス対戦表のイベント情報・プレイヤー表示名を編集する」から利用する保存基盤です。

## 主な変更

### イベント・プレイヤーの保存モデル

- イベント情報へ `memo` を追加
- プレイヤー情報へ以下を追加
  - `initialDisplayName`
    - 対戦表生成時の表示名
  - `displayName`
    - 現在表示する名前
- 新規イベント作成時は、両方の表示名へ初期値を保存
- 既存Documentで `initialDisplayName` がない場合は、既存の `displayName` を初期表示名として復元
- 既存Documentで `memo` がない場合は空文字として復元
- 後方互換可能な省略可能フィールドの追加として、schema versionは `1` のままとする

### 表示情報の一括更新

`EventRepository`へ、以下を一括更新するAPIを追加しました。

- イベントタイトル
- イベントメモ
- 全プレイヤーの現在の表示名

保存時には `expectedRevision` を指定します。

### 楽観ロックとno-op

- Firestore transaction内で最新Documentを取得
- 保存内容が現在値と同じ場合はno-op成功
  - revisionは増加させない
  - staleな `expectedRevision` でも同一内容なら成功
- 保存内容が異なり、revisionが一致しない場合は
  `EventRevisionConflictException` を返して保存を中止
- revision一致時のみ、イベントrevisionを1増加して保存

### 部分更新

Firestoreの親Documentを古いaggregate全体で無条件に `set()` せず、変更対象のフィールドだけを更新するようにしました。

対象:

- イベントタイトル
- イベントメモ
- プレイヤー表示名
- event revision / updatedAt
- コート表示設定
- 生成済み対戦表ID
- 採用済み対戦表ID

これにより、更新対象外の以下を維持します。

- 生成済み・採用済み対戦表情報
- import情報
- 共有情報
- コート表示設定
- その他のイベント情報

### コート表示設定

- `expectedRevision` 付きの更新APIを追加
- revision不一致時は保存を中止
- 同一内容の場合はno-op成功
- 既存APIとの互換性は維持

### in-memory実装

Firestore実装と同じ条件で動作するよう、in-memory repositoryにも以下を追加しました。

- 表示情報の一括更新
- revision競合検出
- no-op処理
- revision付きコート表示設定更新

### Docs

以下を追加しました。

- `docs/doubles-event-display-persistence.md`
  - 表示情報の保存単位
  - revision境界
  - no-opと競合時の扱い
  - 既存schemaとの互換方針
  - 後続Issueとの責務分担

## テスト

以下を確認しました。

- イベントメモのJSON保存・復元
- `initialDisplayName` / `displayName` のJSON保存・復元
- 既存Documentからの後方互換復元
- タイトル・メモ・全表示名の一括更新
- stale revisionによる競合検出
- stale revisionでも同一内容ならno-op成功
- 更新対象外の対戦表情報・コート設定を維持
- プレイヤーID不足・不一致時の保存拒否
- revision付きコート表示設定更新
- 既存repository contractとの互換性

実行結果:

- `dart format lib/ test/`
- `flutter analyze` 成功
- `flutter test` 成功
- 既存画面がこれまでどおり動作することを手動確認

## Firestore Rules

既存の `events/{publicId}` のupdate権限内で親Documentを更新するため、Firestore Rulesの変更はありません。

## このPRで扱わないこと

- イベント情報・表示名を編集するUI
  - #137で対応
- プレイヤーごとの個別編集
- プレイヤー単位のrevision
- 外部サービス由来のID・レベル・年代・性別等の詳細情報
- 高度な3-way競合解消UI
  - #151で対応
- プレイヤー追加・削除
- 対戦組み合わせや参加人数の変更
- リアルタイム同期・編集ロック