### PR TITLE
📐 feat: move app footer to scroll end refs #167

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ flutter pub get
 flutter run -d web-server --web-hostname 0.0.0.0 --web-port 3000
 ```
 
+Codespaces で起動した開発中の画面をスマートフォンやタブレットから確認する場合は、[Codespaces での実機表示確認](docs/codespaces-device-testing.md) を参照してください。
+
 ---
 
 ## 🔌 core API URL の指定
@@ -207,6 +209,7 @@ flutter run -d chrome \
 
 - [Architecture](docs/architecture.md)
 - [Contributing Guide](docs/contributing.md)
+- [Codespaces での実機表示確認](docs/codespaces-device-testing.md)
 - [Firebase Hosting deploy memo](docs/firebase-hosting-deploy.md)
 - [ver0.1 リリース前チェックリスト](docs/release-checklist-ver0.1.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Lanske を使う人が、機能・使い方・注意点を確認するための�
 
 - [Architecture](architecture.md)
 - [Contributing Guide](contributing.md)
+- [Codespaces での実機表示確認](codespaces-device-testing.md)
 - [Firebase Hosting deploy memo](firebase-hosting-deploy.md)
 - [ver0.1 リリース前チェックリスト](release-checklist-ver0.1.md)
 
@@ -45,6 +46,7 @@ docs/
 ├─ known-limitations-ver0.1.md     # 公開ユーザー向けの制限事項
 ├─ architecture.md                 # 開発者向け設計メモ
 ├─ contributing.md                 # 開発ルール・運用方針
+├─ codespaces-device-testing.md    # Codespaces での実機表示確認
 ├─ firebase-hosting-deploy.md      # Firebase Hosting deploy memo
 ├─ release-checklist-ver0.1.md     # リリース前確認
 ├─ support/

--- a/docs/codespaces-device-testing.md
+++ b/docs/codespaces-device-testing.md
@@ -1,0 +1,113 @@
+# Codespaces で開発中の Flutter Web を実機確認する
+
+## 目的
+
+GitHub Codespaces で起動した開発中の Flutter Web を、PC の別タブやスマートフォン、タブレットの実機ブラウザから確認するための手順をまとめる。
+
+Firebase Hosting へ preview deploy する前でも、作業ブランチの表示やレスポンシブレイアウトを実機で確認できる。
+
+## 前提
+
+- `srp-lanske-web` の Codespace を起動している
+- Flutter の依存関係を取得済みである
+- 開発中のブランチへ checkout 済みである
+- 実機からアクセスする間だけ、Codespaces の forwarded port を Public にできる
+
+同じ Wi-Fi に接続している必要はない。Public にした forwarded URL へインターネット経由でアクセスする。
+
+## Flutter Web を起動する
+
+repository root で以下を実行する。
+
+```bash
+flutter pub get
+
+flutter run -d web-server \
+  --web-hostname 0.0.0.0 \
+  --web-port 3000 \
+  --dart-define=LANSKE_CORE_API_BASE_URL=https://<core-api-url> \
+  --dart-define=LANSKE_EVENT_REPOSITORY=firestore
+```
+
+`<core-api-url>` には、確認に使用する公開 core API URL を指定する。
+
+本番の core API と Firestore を指定した場合、開発中の画面から本番データを作成・更新する可能性がある。表示確認だけのつもりでも、保存操作を行う場合は接続先を確認する。
+
+Flutter の起動ログと、Codespaces の `PORTS` タブに `3000` / `Flutter Web` が表示されることを確認する。
+
+## forwarded port を公開する
+
+1. Codespaces の `PORTS` タブを開く
+2. `3000` / `Flutter Web` を右クリックする
+3. `Port Visibility` を `Public` に変更する
+4. `Forwarded Address` をコピーする
+
+Public にした forwarded port は、URLを知っている人が認証なしでアクセスできる。実機確認中だけ Public にし、確認後は Private に戻すか forwarding を停止する。
+
+Codespace を停止・再起動すると、Public にした port は Private に戻る。その場合は再度 Public に変更する。
+
+## PC・スマートフォン・タブレットで確認する
+
+コピーした forwarded URL を、確認したい端末のブラウザで開く。
+
+主な確認項目:
+
+- PC 幅で主要画面が表示される
+- スマートフォン幅で表示領域やスクロールが崩れない
+- タブレット幅で余白やレイアウトが不自然にならない
+- メニュー、ダイアログ、SnackBar、キーボード表示が崩れない
+- 作業対象の変更が意図どおり反映されている
+
+初回表示は、Flutter Web の開発ビルド、Codespaces の port forwarding、端末側の通信環境により時間がかかる場合がある。
+
+## Codespace 再開後
+
+Codespace の停止後や timeout 後に再開した場合は、次を確認する。
+
+1. Flutter Web を再起動する
+2. `PORTS` タブに `3000` が表示されていることを確認する
+3. 実機確認する場合は Port Visibility を再度 Public にする
+4. `PORTS` タブから現在の Forwarded Address をコピーする
+
+古いタブや保存済みURLではなく、現在の `PORTS` タブに表示されているURLを使用する。
+
+## 404 の簡易切り分け
+
+forwarded URL が 404 になる場合は、最初に Codespace 内の Flutter Web を確認する。
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/
+```
+
+### `200` の場合
+
+Flutter Web は正常に応答しているため、Codespaces の port forwarding 側を確認する。
+
+- Port Visibility を `Private` から `Public` へ設定し直す
+- `Stop Forwarding Port` 後に `Add Port` で `3000` を追加し直す
+- `PORTS` タブから現在の Forwarded Address をコピーし直す
+
+### `200` 以外の場合
+
+Flutter Web の起動状態を確認する。
+
+```bash
+ss -ltnp | grep ':3000'
+```
+
+process が存在しない場合や、別 port で起動している場合は、Flutter Web を `--web-port 3000` で起動し直す。
+
+表示確認を始めるだけであれば、`gcloud login` や Application Default Credentials は必須ではない。Cloud Run の管理操作や、別途認証が必要な処理を行う場合に確認する。
+
+## 確認終了後
+
+- Port Visibility を Private に戻す、または forwarding を停止する
+- Codespace を使い終えた場合は停止する
+- 本番接続で作成した不要な確認データがないか確認する
+
+## 関連
+
+- [README](../README.md)
+- [Firebase Hosting deploy memo](firebase-hosting-deploy.md)
+- [GitHub Docs: Forwarding ports in your codespace](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace)
+- [GitHub Docs: Security in GitHub Codespaces](https://docs.github.com/en/codespaces/reference/security-in-github-codespaces)

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -6,11 +6,33 @@ import '../features/doubles_scheduler/presentation/restored_schedule_page.dart';
 import '../features/team_scheduler/presentation/team_schedule_list_page.dart';
 import '../features/team_scheduler/presentation/team_schedule_page.dart';
 import '../features/team_scheduler/presentation/team_setup_page.dart';
-import '../shared/presentation/app_footer.dart';
+import '../shared/presentation/app_footer_host.dart';
 import 'theme/app_theme.dart';
 
-class App extends StatelessWidget {
+class App extends StatefulWidget {
   const App({super.key});
+
+  @override
+  State<App> createState() => _AppState();
+}
+
+class _AppState extends State<App> {
+  late final AppFooterResetController _footerResetController;
+  late final AppFooterNavigatorObserver _footerNavigatorObserver;
+
+  @override
+  void initState() {
+    super.initState();
+    _footerResetController = AppFooterResetController();
+    _footerNavigatorObserver =
+        AppFooterNavigatorObserver(_footerResetController);
+  }
+
+  @override
+  void dispose() {
+    _footerResetController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -28,12 +50,11 @@ class App extends StatelessWidget {
       supportedLocales: AppLocalizations.supportedLocales,
       locale: const Locale('ja'),
       theme: appTheme,
+      navigatorObservers: [_footerNavigatorObserver],
       builder: (context, child) {
-        return Column(
-          children: [
-            Expanded(child: child ?? const SizedBox.shrink()),
-            const AppFooter(),
-          ],
+        return AppFooterHost(
+          resetListenable: _footerResetController,
+          child: child ?? const SizedBox.shrink(),
         );
       },
       home: home,

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -17,20 +17,19 @@ class App extends StatefulWidget {
 }
 
 class _AppState extends State<App> {
-  late final AppFooterResetController _footerResetController;
+  late final AppFooterController _footerController;
   late final AppFooterNavigatorObserver _footerNavigatorObserver;
 
   @override
   void initState() {
     super.initState();
-    _footerResetController = AppFooterResetController();
-    _footerNavigatorObserver =
-        AppFooterNavigatorObserver(_footerResetController);
+    _footerController = AppFooterController();
+    _footerNavigatorObserver = AppFooterNavigatorObserver(_footerController);
   }
 
   @override
   void dispose() {
-    _footerResetController.dispose();
+    _footerController.dispose();
     super.dispose();
   }
 
@@ -53,7 +52,7 @@ class _AppState extends State<App> {
       navigatorObservers: [_footerNavigatorObserver],
       builder: (context, child) {
         return AppFooterHost(
-          resetListenable: _footerResetController,
+          controller: _footerController,
           child: child ?? const SizedBox.shrink(),
         );
       },

--- a/lib/shared/presentation/app_footer_host.dart
+++ b/lib/shared/presentation/app_footer_host.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'app_footer.dart';
@@ -23,27 +25,31 @@ class AppFooterNavigatorObserver extends NavigatorObserver {
   final AppFooterResetController controller;
 
   void _scheduleReset() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      controller.reset();
-    });
+    scheduleMicrotask(controller.reset);
   }
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
-    _scheduleReset();
+    if (route is PageRoute<dynamic>) {
+      _scheduleReset();
+    }
   }
 
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPop(route, previousRoute);
-    _scheduleReset();
+    if (route is PageRoute<dynamic>) {
+      _scheduleReset();
+    }
   }
 
   @override
   void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didRemove(route, previousRoute);
-    _scheduleReset();
+    if (route is PageRoute<dynamic>) {
+      _scheduleReset();
+    }
   }
 
   @override
@@ -52,7 +58,9 @@ class AppFooterNavigatorObserver extends NavigatorObserver {
     Route<dynamic>? oldRoute,
   }) {
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
-    _scheduleReset();
+    if (newRoute is PageRoute<dynamic> || oldRoute is PageRoute<dynamic>) {
+      _scheduleReset();
+    }
   }
 }
 

--- a/lib/shared/presentation/app_footer_host.dart
+++ b/lib/shared/presentation/app_footer_host.dart
@@ -4,11 +4,33 @@ import 'package:flutter/material.dart';
 
 import 'app_footer.dart';
 
-class AppFooterResetController extends ChangeNotifier {
+class AppFooterController extends ChangeNotifier {
   bool _isDisposed = false;
+  int _resetRevision = 0;
+  int _suspensionDepth = 0;
+
+  int get resetRevision => _resetRevision;
+  bool get isSuspended => _suspensionDepth > 0;
 
   void reset() {
     if (_isDisposed) return;
+
+    _resetRevision += 1;
+    _suspensionDepth = 0;
+    notifyListeners();
+  }
+
+  void suspend() {
+    if (_isDisposed) return;
+
+    _suspensionDepth += 1;
+    notifyListeners();
+  }
+
+  void resume() {
+    if (_isDisposed || _suspensionDepth == 0) return;
+
+    _suspensionDepth -= 1;
     notifyListeners();
   }
 
@@ -22,33 +44,42 @@ class AppFooterResetController extends ChangeNotifier {
 class AppFooterNavigatorObserver extends NavigatorObserver {
   AppFooterNavigatorObserver(this.controller);
 
-  final AppFooterResetController controller;
+  final AppFooterController controller;
 
-  void _scheduleReset() {
-    scheduleMicrotask(controller.reset);
+  void _schedule(VoidCallback action) {
+    scheduleMicrotask(action);
   }
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
+
     if (route is PageRoute<dynamic>) {
-      _scheduleReset();
+      _schedule(controller.reset);
+    } else if (route is PopupRoute<dynamic>) {
+      _schedule(controller.suspend);
     }
   }
 
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPop(route, previousRoute);
+
     if (route is PageRoute<dynamic>) {
-      _scheduleReset();
+      _schedule(controller.reset);
+    } else if (route is PopupRoute<dynamic>) {
+      _schedule(controller.resume);
     }
   }
 
   @override
   void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didRemove(route, previousRoute);
+
     if (route is PageRoute<dynamic>) {
-      _scheduleReset();
+      _schedule(controller.reset);
+    } else if (route is PopupRoute<dynamic>) {
+      _schedule(controller.resume);
     }
   }
 
@@ -58,8 +89,21 @@ class AppFooterNavigatorObserver extends NavigatorObserver {
     Route<dynamic>? oldRoute,
   }) {
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+
     if (newRoute is PageRoute<dynamic> || oldRoute is PageRoute<dynamic>) {
-      _scheduleReset();
+      _schedule(controller.reset);
+      return;
+    }
+
+    final replacesPopupWithPopup =
+        newRoute is PopupRoute<dynamic> && oldRoute is PopupRoute<dynamic>;
+    if (replacesPopupWithPopup) return;
+
+    if (oldRoute is PopupRoute<dynamic>) {
+      _schedule(controller.resume);
+    }
+    if (newRoute is PopupRoute<dynamic>) {
+      _schedule(controller.suspend);
     }
   }
 }
@@ -68,11 +112,11 @@ class AppFooterHost extends StatefulWidget {
   const AppFooterHost({
     super.key,
     required this.child,
-    required this.resetListenable,
+    required this.controller,
   });
 
   final Widget child;
-  final Listenable resetListenable;
+  final AppFooterController controller;
 
   @override
   State<AppFooterHost> createState() => _AppFooterHostState();
@@ -85,27 +129,38 @@ class _AppFooterHostState extends State<AppFooterHost> {
   bool _showFooter = true;
   bool _revealedAtScrollableEnd = false;
   bool _suppressReveal = false;
+  late int _lastResetRevision;
 
   @override
   void initState() {
     super.initState();
-    widget.resetListenable.addListener(_resetFooter);
+    _lastResetRevision = widget.controller.resetRevision;
+    widget.controller.addListener(_handleControllerChanged);
   }
 
   @override
   void didUpdateWidget(AppFooterHost oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.resetListenable == widget.resetListenable) return;
+    if (oldWidget.controller == widget.controller) return;
 
-    oldWidget.resetListenable.removeListener(_resetFooter);
-    widget.resetListenable.addListener(_resetFooter);
+    oldWidget.controller.removeListener(_handleControllerChanged);
+    _lastResetRevision = widget.controller.resetRevision;
+    widget.controller.addListener(_handleControllerChanged);
     _resetFooter();
   }
 
   @override
   void dispose() {
-    widget.resetListenable.removeListener(_resetFooter);
+    widget.controller.removeListener(_handleControllerChanged);
     super.dispose();
+  }
+
+  void _handleControllerChanged() {
+    final resetRevision = widget.controller.resetRevision;
+    if (_lastResetRevision == resetRevision) return;
+
+    _lastResetRevision = resetRevision;
+    _resetFooter();
   }
 
   void _resetFooter() {
@@ -119,13 +174,19 @@ class _AppFooterHostState extends State<AppFooterHost> {
   bool _handleScrollMetricsNotification(
     ScrollMetricsNotification notification,
   ) {
-    if (notification.depth != 0) return false;
+    if (widget.controller.isSuspended || notification.depth != 0) {
+      return false;
+    }
+
     _updateFromMetrics(notification.metrics, isScrollEvent: false);
     return false;
   }
 
   bool _handleScrollNotification(ScrollNotification notification) {
-    if (notification.depth != 0) return false;
+    if (widget.controller.isSuspended || notification.depth != 0) {
+      return false;
+    }
+
     _updateFromMetrics(notification.metrics, isScrollEvent: true);
     return false;
   }

--- a/lib/shared/presentation/app_footer_host.dart
+++ b/lib/shared/presentation/app_footer_host.dart
@@ -1,0 +1,226 @@
+import 'package:flutter/material.dart';
+
+import 'app_footer.dart';
+
+class AppFooterResetController extends ChangeNotifier {
+  bool _isDisposed = false;
+
+  void reset() {
+    if (_isDisposed) return;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    super.dispose();
+  }
+}
+
+class AppFooterNavigatorObserver extends NavigatorObserver {
+  AppFooterNavigatorObserver(this.controller);
+
+  final AppFooterResetController controller;
+
+  void _scheduleReset() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      controller.reset();
+    });
+  }
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    _scheduleReset();
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    _scheduleReset();
+  }
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didRemove(route, previousRoute);
+    _scheduleReset();
+  }
+
+  @override
+  void didReplace({
+    Route<dynamic>? newRoute,
+    Route<dynamic>? oldRoute,
+  }) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    _scheduleReset();
+  }
+}
+
+class AppFooterHost extends StatefulWidget {
+  const AppFooterHost({
+    super.key,
+    required this.child,
+    required this.resetListenable,
+  });
+
+  final Widget child;
+  final Listenable resetListenable;
+
+  @override
+  State<AppFooterHost> createState() => _AppFooterHostState();
+}
+
+class _AppFooterHostState extends State<AppFooterHost> {
+  static const _endTolerance = 1.0;
+  static const _hideDistanceFromEnd = 48.0;
+
+  bool _showFooter = true;
+  bool _revealedAtScrollableEnd = false;
+  bool _suppressReveal = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.resetListenable.addListener(_resetFooter);
+  }
+
+  @override
+  void didUpdateWidget(AppFooterHost oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.resetListenable == widget.resetListenable) return;
+
+    oldWidget.resetListenable.removeListener(_resetFooter);
+    widget.resetListenable.addListener(_resetFooter);
+    _resetFooter();
+  }
+
+  @override
+  void dispose() {
+    widget.resetListenable.removeListener(_resetFooter);
+    super.dispose();
+  }
+
+  void _resetFooter() {
+    _updateFooterState(
+      showFooter: true,
+      revealedAtScrollableEnd: false,
+      suppressReveal: false,
+    );
+  }
+
+  bool _handleScrollMetricsNotification(
+    ScrollMetricsNotification notification,
+  ) {
+    if (notification.depth != 0) return false;
+    _updateFromMetrics(notification.metrics, isScrollEvent: false);
+    return false;
+  }
+
+  bool _handleScrollNotification(ScrollNotification notification) {
+    if (notification.depth != 0) return false;
+    _updateFromMetrics(notification.metrics, isScrollEvent: true);
+    return false;
+  }
+
+  void _updateFromMetrics(
+    ScrollMetrics metrics, {
+    required bool isScrollEvent,
+  }) {
+    if (metrics.axis != Axis.vertical) return;
+
+    final maxScrollExtent = metrics.maxScrollExtent;
+    if (!maxScrollExtent.isFinite) return;
+
+    if (maxScrollExtent <= _endTolerance) {
+      _updateFooterState(
+        showFooter: true,
+        revealedAtScrollableEnd: false,
+        suppressReveal: false,
+      );
+      return;
+    }
+
+    final distanceFromEnd = maxScrollExtent - metrics.pixels;
+    final isAtEnd = distanceFromEnd <= _endTolerance;
+
+    if (isAtEnd) {
+      if (_suppressReveal && !isScrollEvent) return;
+
+      _updateFooterState(
+        showFooter: true,
+        revealedAtScrollableEnd: true,
+        suppressReveal: false,
+      );
+      return;
+    }
+
+    if (_revealedAtScrollableEnd) {
+      if (isScrollEvent && distanceFromEnd > _hideDistanceFromEnd) {
+        _updateFooterState(
+          showFooter: false,
+          revealedAtScrollableEnd: false,
+          suppressReveal: true,
+        );
+      }
+      return;
+    }
+
+    if (_suppressReveal && isScrollEvent) {
+      _updateFooterState(
+        showFooter: false,
+        revealedAtScrollableEnd: false,
+        suppressReveal: false,
+      );
+      return;
+    }
+
+    _updateFooterState(
+      showFooter: false,
+      revealedAtScrollableEnd: false,
+      suppressReveal: _suppressReveal,
+    );
+  }
+
+  void _updateFooterState({
+    required bool showFooter,
+    required bool revealedAtScrollableEnd,
+    required bool suppressReveal,
+  }) {
+    if (_showFooter == showFooter &&
+        _revealedAtScrollableEnd == revealedAtScrollableEnd &&
+        _suppressReveal == suppressReveal) {
+      return;
+    }
+
+    if (!mounted) return;
+
+    setState(() {
+      _showFooter = showFooter;
+      _revealedAtScrollableEnd = revealedAtScrollableEnd;
+      _suppressReveal = suppressReveal;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final keyboardIsVisible = MediaQuery.of(context).viewInsets.bottom > 0;
+    final showFooter = _showFooter && !keyboardIsVisible;
+
+    return NotificationListener<ScrollMetricsNotification>(
+      onNotification: _handleScrollMetricsNotification,
+      child: NotificationListener<ScrollNotification>(
+        onNotification: _handleScrollNotification,
+        child: Column(
+          children: [
+            Expanded(child: widget.child),
+            if (showFooter)
+              const SafeArea(
+                top: false,
+                child: AppFooter(),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/shared/presentation/app_footer_host_test.dart
+++ b/test/shared/presentation/app_footer_host_test.dart
@@ -6,12 +6,12 @@ import 'package:srp_lanske/shared/presentation/app_footer_host.dart';
 
 void main() {
   testWidgets('shows the footer when the page does not scroll', (tester) async {
-    final resetController = AppFooterResetController();
-    addTearDown(resetController.dispose);
+    final footerController = AppFooterController();
+    addTearDown(footerController.dispose);
 
     await tester.pumpWidget(
       _testApp(
-        resetController: resetController,
+        footerController: footerController,
         child: const Center(child: Text('short page')),
       ),
     );
@@ -21,14 +21,14 @@ void main() {
 
   testWidgets('shows the footer only near the end of a long page',
       (tester) async {
-    final resetController = AppFooterResetController();
+    final footerController = AppFooterController();
     final scrollController = ScrollController();
-    addTearDown(resetController.dispose);
+    addTearDown(footerController.dispose);
     addTearDown(scrollController.dispose);
 
     await tester.pumpWidget(
       _testApp(
-        resetController: resetController,
+        footerController: footerController,
         child: ListView(
           controller: scrollController,
           children: const [
@@ -56,10 +56,47 @@ void main() {
 
     expect(find.byType(AppFooter), findsNothing);
   });
+
+  testWidgets('ignores scroll notifications while a popup is active',
+      (tester) async {
+    final footerController = AppFooterController();
+    final scrollController = ScrollController();
+    addTearDown(footerController.dispose);
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      _testApp(
+        footerController: footerController,
+        child: ListView(
+          controller: scrollController,
+          children: const [
+            SizedBox(height: 1600),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AppFooter), findsNothing);
+
+    footerController.suspend();
+    scrollController.jumpTo(scrollController.position.maxScrollExtent);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(AppFooter), findsNothing);
+
+    footerController.resume();
+    scrollController.jumpTo(scrollController.position.maxScrollExtent);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(AppFooter), findsOneWidget);
+  });
 }
 
 Widget _testApp({
-  required AppFooterResetController resetController,
+  required AppFooterController footerController,
   required Widget child,
 }) {
   return MaterialApp(
@@ -68,7 +105,7 @@ Widget _testApp({
     supportedLocales: AppLocalizations.supportedLocales,
     home: Scaffold(
       body: AppFooterHost(
-        resetListenable: resetController,
+        controller: footerController,
         child: child,
       ),
     ),

--- a/test/shared/presentation/app_footer_host_test.dart
+++ b/test/shared/presentation/app_footer_host_test.dart
@@ -87,6 +87,11 @@ void main() {
     expect(find.byType(AppFooter), findsNothing);
 
     footerController.resume();
+    final awayFromEnd = (scrollController.position.maxScrollExtent - 100)
+        .clamp(0.0, double.infinity)
+        .toDouble();
+    scrollController.jumpTo(awayFromEnd);
+    await tester.pump();
     scrollController.jumpTo(scrollController.position.maxScrollExtent);
     await tester.pump();
     await tester.pump();

--- a/test/shared/presentation/app_footer_host_test.dart
+++ b/test/shared/presentation/app_footer_host_test.dart
@@ -47,8 +47,9 @@ void main() {
 
     expect(find.byType(AppFooter), findsOneWidget);
 
-    final awayFromEnd =
-        (scrollController.position.maxScrollExtent - 100).clamp(0.0, double.infinity);
+    final awayFromEnd = (scrollController.position.maxScrollExtent - 100)
+        .clamp(0.0, double.infinity)
+        .toDouble();
     scrollController.jumpTo(awayFromEnd);
     await tester.pump();
     await tester.pump();

--- a/test/shared/presentation/app_footer_host_test.dart
+++ b/test/shared/presentation/app_footer_host_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
+import 'package:srp_lanske/shared/presentation/app_footer.dart';
+import 'package:srp_lanske/shared/presentation/app_footer_host.dart';
+
+void main() {
+  testWidgets('shows the footer when the page does not scroll', (tester) async {
+    final resetController = AppFooterResetController();
+    addTearDown(resetController.dispose);
+
+    await tester.pumpWidget(
+      _testApp(
+        resetController: resetController,
+        child: const Center(child: Text('short page')),
+      ),
+    );
+
+    expect(find.byType(AppFooter), findsOneWidget);
+  });
+
+  testWidgets('shows the footer only near the end of a long page',
+      (tester) async {
+    final resetController = AppFooterResetController();
+    final scrollController = ScrollController();
+    addTearDown(resetController.dispose);
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      _testApp(
+        resetController: resetController,
+        child: ListView(
+          controller: scrollController,
+          children: const [
+            SizedBox(height: 1600),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AppFooter), findsNothing);
+
+    scrollController.jumpTo(scrollController.position.maxScrollExtent);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(AppFooter), findsOneWidget);
+
+    final awayFromEnd =
+        (scrollController.position.maxScrollExtent - 100).clamp(0.0, double.infinity);
+    scrollController.jumpTo(awayFromEnd);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(AppFooter), findsNothing);
+  });
+}
+
+Widget _testApp({
+  required AppFooterResetController resetController,
+  required Widget child,
+}) {
+  return MaterialApp(
+    locale: const Locale('ja'),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: AppFooterHost(
+        resetListenable: resetController,
+        child: child,
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## 概要

アプリ共通フッターが画面下部を常時占有していた構成を変更し、ページのスクロール状態に応じて末尾で表示されるようにしました。

これにより、特にモバイルの長い対戦表画面で、本文に利用できる表示領域を広げます。

Closes #167

## 変更内容

### 共通フッターの表示制御

- `MaterialApp.builder` でフッターを常時固定する構成を廃止
- アプリ全体で共通利用する `AppFooterHost` を追加
- 各ページを個別修正せず、共通hostで縦スクロールの状態を監視
- ダブルス／チームを含むアプリ内の主要画面へ共通して適用

### 長いページ

- 通常のスクロール中はフッターを表示しない
- ページ末尾までスクロールした場合にフッターを表示
- 末尾から上方向へ戻った場合はフッターを再び非表示
- フッター表示後もページ末尾の内容を確認できる構成を維持

### 短いページ

- スクロール量がない短いページではフッターを表示
- 画面中央ではなく、画面下部付近へ配置

### ページ遷移・一時表示への対応

- `NavigatorObserver` を使ってページ遷移時にフッター状態をリセット
- ダイアログやポップアップ表示中は、背景ページのスクロール通知による状態変更を停止
- ダイアログを閉じた後は、元のページのスクロール状態を再評価
- ソフトウェアキーボード表示中はフッターを非表示
- `SafeArea` を考慮して画面下部との重なりを防止

## テスト

`AppFooterHost` のwidgetテストを追加しました。

確認内容:

- 短いページではフッターが画面下部に表示される
- 長いページでは通常表示中にフッターが固定されない
- 長いページの末尾でフッターが表示される
- 末尾から上へ戻るとフッターが非表示になる
- ポップアップ表示中に背景ページのフッター状態が変化しない

## 手動確認

- [x] PC幅で表示確認
- [x] iPad実機でタブレット幅の表示確認
- [x] スマートフォン実機で表示確認
- [x] 長いページの通常スクロール中にフッターが表示されない
- [x] ページ末尾でフッターが表示される
- [x] 末尾から上へ戻るとフッターが非表示になる
- [x] ページ末尾の内容とフッターが不自然に重ならない
- [x] 短いページでフッターの位置が不自然にならない
- [x] Codespacesの転送URLからPC・スマートフォン・iPad実機で確認

## 確認コマンド

- [x] `dart format lib/ test/`
  - formatによる追加差分なし
- [x] `flutter analyze`
- [x] `flutter test`

## Docs

Codespacesで開発中のFlutter Webを、PC・スマートフォン・タブレットの実機から確認する手順として、`docs/codespaces-device-testing.md` を追加しました。

主な内容:

- Flutter Webの起動手順
- Codespacesのforwarded portを一時的にPublicへ変更する手順
- PC・スマートフォン・タブレットからの確認方法
- 本番Core API／Firestoreへ接続する場合の注意
- Codespace再開後の確認事項
- forwarded URLが404になった場合の簡易切り分け

あわせて、ルートREADMEとDocs indexから参照できるようにしました。

## 今回扱わないこと

- フッター文言・デザインの変更
- 参加者一覧のsticky表示
- AppBar・ハンバーガーメニューの変更
- 対戦表画面全体のスクロール構造刷新
- 画面下部への新しい固定ナビゲーション追加