### PR TITLE
🚀 Release ver0.1.6+2 and refine team UI refs #171

### DIFF
--- a/lib/app/config/app_config.dart
+++ b/lib/app/config/app_config.dart
@@ -1,6 +1,6 @@
 class AppConfig {
   static const String appName = 'Lanske';
-  static const String releaseVersion = '0.1.5';
+  static const String releaseVersion = '0.1.6+2';
 
   static const String coreApiBaseUrl = String.fromEnvironment(
     'LANSKE_CORE_API_BASE_URL',

--- a/lib/features/team_scheduler/presentation/team_schedule_page.dart
+++ b/lib/features/team_scheduler/presentation/team_schedule_page.dart
@@ -1375,9 +1375,6 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
   }
 
   Widget _buildRoundCard(BuildContext context, _TeamRoundViewData round) {
-    final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context);
-
     return Card(
       elevation: 0,
       color: Colors.white,
@@ -1389,19 +1386,12 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Row(
-              children: [
-                Text(
-                  l10n.teamRoundTitle(round.roundNo),
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
             for (final match in round.matches) ...[
-              _buildMatchRow(context, match),
+              _buildMatchRow(
+                context,
+                roundNo: round.roundNo,
+                match: match,
+              ),
               if (match != round.matches.last) const Divider(height: 24),
             ],
           ],
@@ -1427,6 +1417,45 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       icon: const Icon(Icons.edit_note),
       label: Text(
         hasScore ? l10n.editBocciaScoreButton : l10n.inputBocciaScoreButton,
+      ),
+    );
+  }
+
+  Widget _buildMatchHeader(
+    BuildContext context, {
+    required int roundNo,
+    required _TeamMatchViewData match,
+  }) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    return SizedBox(
+      width: double.infinity,
+      child: Wrap(
+        alignment: WrapAlignment.spaceBetween,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        spacing: 12,
+        runSpacing: 8,
+        children: [
+          Wrap(
+            spacing: 12,
+            runSpacing: 4,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              Text(
+                l10n.teamRoundTitle(roundNo),
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              Text(
+                l10n.teamCourtTitle(match.courtNo),
+                style: theme.textTheme.labelLarge,
+              ),
+            ],
+          ),
+          _buildMatchScoreAction(context, match),
+        ],
       ),
     );
   }
@@ -1506,7 +1535,11 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     );
   }
 
-  Widget _buildMatchRow(BuildContext context, _TeamMatchViewData match) {
+  Widget _buildMatchRow(
+    BuildContext context, {
+    required int roundNo,
+    required _TeamMatchViewData match,
+  }) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
     final display = _matchDisplayOrder(match);
@@ -1516,11 +1549,12 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
       return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            l10n.teamCourtTitle(match.courtNo),
-            style: theme.textTheme.labelLarge,
+          _buildMatchHeader(
+            context,
+            roundNo: roundNo,
+            match: match,
           ),
-          const SizedBox(height: 6),
+          const SizedBox(height: 8),
           Text(
             _matchTitle(context, match),
             style: theme.textTheme.bodyLarge?.copyWith(
@@ -1536,8 +1570,6 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
                 _buildMatchTeamPill(context, teamSlot: teamSlot),
             ],
           ),
-          const SizedBox(height: 12),
-          _buildMatchScoreAction(context, match),
         ],
       );
     }
@@ -1545,9 +1577,10 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          l10n.teamCourtTitle(match.courtNo),
-          style: theme.textTheme.labelLarge,
+        _buildMatchHeader(
+          context,
+          roundNo: roundNo,
+          match: match,
         ),
         const SizedBox(height: 8),
         Wrap(
@@ -1579,8 +1612,6 @@ class _TeamSchedulePageState extends State<TeamSchedulePage> {
             ),
           ],
         ),
-        const SizedBox(height: 12),
-        _buildMatchScoreAction(context, match),
       ],
     );
   }

--- a/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
+++ b/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
@@ -874,13 +874,13 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
             const minCardWidth = 92.0;
             const maxCardWidth = 120.0;
             final cardCount = assignments.length;
-            final spacingWidth = cardCount > 1 ? spacing * (cardCount - 1) : 0.0;
+            final spacingWidth =
+                cardCount > 1 ? spacing * (cardCount - 1) : 0.0;
             final fittedWidth = cardCount == 0
                 ? minCardWidth
                 : (constraints.maxWidth - spacingWidth) / cardCount;
-            final cardWidth = fittedWidth
-                .clamp(minCardWidth, maxCardWidth)
-                .toDouble();
+            final cardWidth =
+                fittedWidth.clamp(minCardWidth, maxCardWidth).toDouble();
             final rowWidth = cardCount * cardWidth + spacingWidth;
             final contentWidth = rowWidth < constraints.maxWidth
                 ? constraints.maxWidth

--- a/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
+++ b/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
@@ -868,21 +868,49 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           style: theme.textTheme.bodySmall,
         ),
         const SizedBox(height: 8),
-        SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          child: Row(
-            children: [
-              for (final assignment in assignments) ...[
-                _buildThrowingBoxCard(
-                  context,
-                  assignment,
-                  isEditing:
-                      _isEditingThrowingBoxAssignments && canEditAssignments,
+        LayoutBuilder(
+          builder: (context, constraints) {
+            const spacing = 8.0;
+            const minCardWidth = 92.0;
+            const maxCardWidth = 120.0;
+            final cardCount = assignments.length;
+            final spacingWidth = cardCount > 1 ? spacing * (cardCount - 1) : 0.0;
+            final fittedWidth = cardCount == 0
+                ? minCardWidth
+                : (constraints.maxWidth - spacingWidth) / cardCount;
+            final cardWidth = fittedWidth
+                .clamp(minCardWidth, maxCardWidth)
+                .toDouble();
+            final rowWidth = cardCount * cardWidth + spacingWidth;
+            final contentWidth = rowWidth < constraints.maxWidth
+                ? constraints.maxWidth
+                : rowWidth;
+
+            return SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: SizedBox(
+                width: contentWidth,
+                child: Center(
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      for (final assignment in assignments) ...[
+                        _buildThrowingBoxCard(
+                          context,
+                          assignment,
+                          width: cardWidth,
+                          isEditing: _isEditingThrowingBoxAssignments &&
+                              canEditAssignments,
+                        ),
+                        if (assignment != assignments.last)
+                          const SizedBox(width: spacing),
+                      ],
+                    ],
+                  ),
                 ),
-                if (assignment != assignments.last) const SizedBox(width: 8),
-              ],
-            ],
-          ),
+              ),
+            );
+          },
         ),
         const SizedBox(height: 16),
         _buildThrowOrderSection(context),
@@ -893,6 +921,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
   Widget _buildThrowingBoxCard(
     BuildContext context,
     BocciaThrowingBoxAssignment assignment, {
+    required double width,
     required bool isEditing,
   }) {
     final theme = Theme.of(context);
@@ -916,7 +945,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
         !isEditing;
 
     return Container(
-      width: 92,
+      width: width,
       padding: const EdgeInsets.all(8),
       decoration: BoxDecoration(
         color: isRed ? Colors.red.shade50 : Colors.blue.shade50,

--- a/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
+++ b/lib/features/team_scheduler/presentation/widgets/boccia_score_dialog.dart
@@ -598,6 +598,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
         isSelected ? _bocciaAccentBackgroundColor : _bocciaInputBackgroundColor;
     final textColor =
         isSelected ? _bocciaAccentTextColor : theme.colorScheme.onSurface;
+    final baseFontSize = theme.textTheme.bodySmall?.fontSize ?? 12;
 
     return InkWell(
       onTap: () {
@@ -606,7 +607,7 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
       borderRadius: BorderRadius.circular(7),
       child: Container(
         padding: const EdgeInsets.symmetric(
-          horizontal: 8,
+          horizontal: 4,
           vertical: 4,
         ),
         decoration: BoxDecoration(
@@ -619,9 +620,11 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
         ),
         child: Text(
           l10n.bocciaEndLabel(endNo),
+          maxLines: 1,
           textAlign: TextAlign.center,
           style: theme.textTheme.bodySmall?.copyWith(
             color: textColor,
+            fontSize: baseFontSize + 2,
             fontWeight: isSelected ? FontWeight.bold : null,
           ),
         ),
@@ -632,102 +635,112 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
   Widget _buildScoreTable(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
+    final headerFontSize = (theme.textTheme.bodySmall?.fontSize ?? 12) + 2;
 
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: DataTable(
-        horizontalMargin: 4,
-        columnSpacing: 8,
-        headingRowHeight: 34,
-        dataRowMinHeight: 40,
-        dataRowMaxHeight: 42,
-        columns: [
-          for (final endScore in _draftScore.endScores)
-            DataColumn(
-              label: _buildEndHeader(context, endScore.endNo),
-            ),
-          DataColumn(
-            label: Text(
-              l10n.bocciaTotalLabel,
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodySmall,
-            ),
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              for (final endScore in _draftScore.endScores)
+                Expanded(
+                  flex: 10,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 2),
+                    child: _buildEndHeader(context, endScore.endNo),
+                  ),
+                ),
+              Expanded(
+                flex: 12,
+                child: Text(
+                  l10n.bocciaTotalLabel,
+                  maxLines: 1,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontSize: headerFontSize,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
           ),
+          const SizedBox(height: 4),
+          _buildScoreRow(context, isRed: true),
+          _buildScoreRow(context, isRed: false),
         ],
-        rows: [
-          DataRow(
-            color: WidgetStatePropertyAll(Colors.red.shade50),
-            cells: [
-              for (final endScore in _draftScore.endScores)
-                DataCell(
-                  _buildScoreDropdown(
-                    value: endScore.red,
-                    onChanged: (value) {
-                      if (value == null) {
-                        return;
-                      }
+      ),
+    );
+  }
 
-                      _setEndScore(
-                        endNo: endScore.endNo,
-                        red: value,
-                      );
-                    },
-                  ),
-                ),
-              DataCell(
-                SizedBox(
-                  width: 32,
-                  child: Text(
-                    _draftScore.totalRedScore.toString(),
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(fontWeight: FontWeight.bold),
-                  ),
+  Widget _buildScoreRow(
+    BuildContext context, {
+    required bool isRed,
+  }) {
+    final theme = Theme.of(context);
+    final totalFontSize = (theme.textTheme.bodyMedium?.fontSize ?? 14) + 2;
+
+    return Container(
+      color: isRed ? Colors.red.shade50 : Colors.blue.shade50,
+      constraints: const BoxConstraints(minHeight: 42),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          for (final endScore in _draftScore.endScores)
+            Expanded(
+              flex: 10,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 2),
+                child: _buildScoreDropdown(
+                  context,
+                  value: isRed ? endScore.red : endScore.blue,
+                  onChanged: (value) {
+                    if (value == null) {
+                      return;
+                    }
+
+                    _setEndScore(
+                      endNo: endScore.endNo,
+                      red: isRed ? value : null,
+                      blue: isRed ? null : value,
+                    );
+                  },
                 ),
               ),
-            ],
-          ),
-          DataRow(
-            color: WidgetStatePropertyAll(Colors.blue.shade50),
-            cells: [
-              for (final endScore in _draftScore.endScores)
-                DataCell(
-                  _buildScoreDropdown(
-                    value: endScore.blue,
-                    onChanged: (value) {
-                      if (value == null) {
-                        return;
-                      }
-
-                      _setEndScore(
-                        endNo: endScore.endNo,
-                        blue: value,
-                      );
-                    },
-                  ),
-                ),
-              DataCell(
-                SizedBox(
-                  width: 32,
-                  child: Text(
-                    _draftScore.totalBlueScore.toString(),
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                ),
+            ),
+          Expanded(
+            flex: 12,
+            child: Text(
+              (isRed ? _draftScore.totalRedScore : _draftScore.totalBlueScore)
+                  .toString(),
+              maxLines: 1,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontSize: totalFontSize,
+                fontWeight: FontWeight.bold,
               ),
-            ],
+            ),
           ),
         ],
       ),
     );
   }
 
-  Widget _buildScoreDropdown({
+  Widget _buildScoreDropdown(
+    BuildContext context, {
     required int value,
     required ValueChanged<int?> onChanged,
   }) {
+    final theme = Theme.of(context);
+    final fontSize = (theme.textTheme.bodyMedium?.fontSize ?? 14) + 2;
+    final scoreStyle = theme.textTheme.bodyMedium?.copyWith(
+      fontSize: fontSize,
+      color: theme.colorScheme.onSurface,
+    );
+
     return SizedBox(
-      width: 36,
+      width: double.infinity,
       child: DropdownButtonHideUnderline(
         child: DropdownButton<int>(
           value: value,
@@ -735,13 +748,17 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           isExpanded: true,
           alignment: Alignment.center,
           iconSize: 14,
+          style: scoreStyle,
           dropdownColor: _bocciaSectionBackgroundColor,
           onChanged: _isBusy ? null : onChanged,
           selectedItemBuilder: (context) {
             return [
               for (var score = 0; score <= 6; score += 1)
                 Center(
-                  child: Text(score.toString()),
+                  child: Text(
+                    score.toString(),
+                    style: scoreStyle,
+                  ),
                 ),
             ];
           },
@@ -750,7 +767,10 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
               DropdownMenuItem<int>(
                 value: score,
                 child: Center(
-                  child: Text(score.toString()),
+                  child: Text(
+                    score.toString(),
+                    style: scoreStyle,
+                  ),
                 ),
               ),
           ],
@@ -896,8 +916,8 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
         !isEditing;
 
     return Container(
-      width: 150,
-      padding: const EdgeInsets.all(10),
+      width: 92,
+      padding: const EdgeInsets.all(8),
       decoration: BoxDecoration(
         color: isRed ? Colors.red.shade50 : Colors.blue.shade50,
         border: Border.all(
@@ -937,11 +957,12 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
                 ),
                 disabledBorder: OutlineInputBorder(
                   borderSide: BorderSide(
-                      color: _bocciaAccentBorderColor.withValues(alpha: 0.6)),
+                    color: _bocciaAccentBorderColor.withValues(alpha: 0.6),
+                  ),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 8,
+                  horizontal: 6,
                   vertical: 8,
                 ),
               ),
@@ -956,13 +977,18 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
               items: [
                 DropdownMenuItem<int?>(
                   value: null,
-                  child: Text(l10n.bocciaUnusedThrowingBoxLabel),
+                  child: Text(
+                    l10n.bocciaUnusedThrowingBoxLabel,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
                 for (final option in playerOptions)
                   DropdownMenuItem<int?>(
                     value: option.playerSlot,
                     child: Text(
                       option.displayName,
+                      maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),
@@ -971,6 +997,8 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           else ...[
             Text(
               playerName,
+              maxLines: 1,
+              softWrap: false,
               textAlign: TextAlign.center,
               overflow: TextOverflow.ellipsis,
               style: theme.textTheme.bodyMedium?.copyWith(
@@ -982,7 +1010,9 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
               assignment.hasPlayer
                   ? l10n.bocciaThrowCountForBox(throwCount)
                   : '',
+              maxLines: 1,
               textAlign: TextAlign.center,
+              overflow: TextOverflow.ellipsis,
               style: theme.textTheme.bodySmall,
             ),
             const SizedBox(height: 8),
@@ -1111,10 +1141,11 @@ class _BocciaScoreDialogState extends State<BocciaScoreDialog> {
           Expanded(
             child: Text(
               l10n.bocciaThrowOrderItem(
-                  log.throwNo,
-                  _playerNameForThrowLog(log, l10n),
-                  _throwingSideLabel(log.side, l10n),
-                  log.boxNo),
+                log.throwNo,
+                _playerNameForThrowLog(log, l10n),
+                _throwingSideLabel(log.side, l10n),
+                log.boxNo,
+              ),
               overflow: TextOverflow.ellipsis,
               style: theme.textTheme.bodySmall,
             ),

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -202,7 +202,7 @@
   },
   "shareUrlCopiedMessage": "URLをコピーしました",
   "@shareUrlCopiedMessage": {
-    "description": "Snack bar message shown when the share URL was copied."
+    "description": "Message shown when the share URL was copied."
   },
   "generateScheduleFailedMessage": "対戦表を生成できませんでした: {error}",
   "@generateScheduleFailedMessage": {
@@ -360,7 +360,7 @@
   },
   "courtDisplaySectionTitle": "コート表示",
   "@courtDisplaySectionTitle": {
-    "description": "Section title for display settings."
+    "description": "Section title for court display settings."
   },
   "courtDisplayPresetNumbers": "1 / 2",
   "@courtDisplayPresetNumbers": {
@@ -394,7 +394,7 @@
   },
   "courtDisplayEmptyError": "コート表示を入力してください",
   "@courtDisplayEmptyError": {
-    "description": "Validation error shown when court display label is empty."
+    "description": "Validation error shown when a court display label is empty."
   },
   "courtDisplayDuplicateError": "コート表示が重複しています",
   "@courtDisplayDuplicateError": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -202,7 +202,7 @@
   },
   "shareUrlCopiedMessage": "URLをコピーしました",
   "@shareUrlCopiedMessage": {
-    "description": "Message shown when the share URL was copied."
+    "description": "Snack bar message shown when the share URL was copied."
   },
   "generateScheduleFailedMessage": "対戦表を生成できませんでした: {error}",
   "@generateScheduleFailedMessage": {
@@ -360,7 +360,7 @@
   },
   "courtDisplaySectionTitle": "コート表示",
   "@courtDisplaySectionTitle": {
-    "description": "Section title for court display settings."
+    "description": "Section title for display settings."
   },
   "courtDisplayPresetNumbers": "1 / 2",
   "@courtDisplayPresetNumbers": {
@@ -394,7 +394,7 @@
   },
   "courtDisplayEmptyError": "コート表示を入力してください",
   "@courtDisplayEmptyError": {
-    "description": "Validation error shown when a court display label is empty."
+    "description": "Validation error shown when court display label is empty."
   },
   "courtDisplayDuplicateError": "コート表示が重複しています",
   "@courtDisplayDuplicateError": {
@@ -960,7 +960,7 @@
       }
     }
   },
-  "teamCourtTitle": "コート{courtNo}",
+  "teamCourtTitle": "{courtNo}コート",
   "@teamCourtTitle": {
     "description": "Title for a team schedule court.",
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1224,7 +1224,7 @@ abstract class AppLocalizations {
   /// Title for a team schedule court.
   ///
   /// In ja, this message translates to:
-  /// **'コート{courtNo}'**
+  /// **'{courtNo}コート'**
   String teamCourtTitle(int courtNo);
 
   /// Title combining a court number and match title.

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -647,7 +647,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String teamCourtTitle(int courtNo) {
-    return 'コート$courtNo';
+    return '$courtNoコート';
   }
 
   @override


### PR DESCRIPTION
## 概要

ver0.1.6 全体の完了を待たず、現時点の安定した main を途中版 `ver0.1.6+2` としてリリースするための変更です。

リリース前の画面確認で見つかった、チーム対戦表およびボッチャスコア入力画面の軽微な表示調整もあわせて行いました。

refs #171

## 変更内容

- 表示バージョンを `ver0.1.6+2` へ更新
- チーム対戦カードの表示を省スペース化
  - `第1ラウンド` と `1コート` をカード上部へ集約
  - スコア入力 / 編集ボタンを右上へ移動
  - 狭幅では自然に折り返す構成とした
- コート表記をダブルス側に合わせて `コート1` から `1コート` へ変更
- ボッチャスコア入力画面を調整
  - 1E〜6Eと合計得点を画面幅に合わせて表示
  - 合計列を少し広くし、点数表示の文字サイズを調整
  - 点数入力表の不要な横スクロールを解消
  - 投球場所カードを画面幅に応じた可変幅とし、中央寄せ
  - 狭幅では最低幅を維持し、必要な場合のみ横スクロール
  - 長い参加者名は省略表示
- l10n生成ファイルを更新

## 確認

- PC / タブレット横幅で表示確認
- スマートフォン幅で表示確認
- チーム対戦カードの表示確認
- ボッチャのスコア入力・投球ログ表示確認
- `dart format lib/ test/`
- `flutter analyze`
- `flutter test`
- `git diff --check`

すべて問題なし。

## リリース

PR merge 後、Firebase Hosting 本番環境へ `ver0.1.6+2` を反映し、本番スモーク確認を行います。