### PR TITLE
🗂️ feat: show doubles schedule list in right drawer refs #138

### DIFF
--- a/lib/features/doubles_scheduler/presentation/doubles_schedule_list_drawer.dart
+++ b/lib/features/doubles_scheduler/presentation/doubles_schedule_list_drawer.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
+
+import '../data/local_schedule_history_item.dart';
+import 'widgets/schedule_history_list_view.dart';
+
+class DoublesScheduleListDrawer extends StatelessWidget {
+  const DoublesScheduleListDrawer({
+    super.key,
+    required this.onOpenSchedule,
+    this.reloadToken = 0,
+  });
+
+  final ValueChanged<LocalScheduleHistoryItem> onOpenSchedule;
+  final int reloadToken;
+
+  static double widthFor(BuildContext context) {
+    final screenWidth = MediaQuery.sizeOf(context).width;
+    return (screenWidth * 0.75).clamp(0.0, 300.0);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return Drawer(
+      width: widthFor(context),
+      child: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.list_alt_outlined),
+              title: Text(
+                l10n.matchTableList,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+              ),
+              trailing: IconButton(
+                tooltip: l10n.closeButton,
+                onPressed: () => Navigator.of(context).pop(),
+                icon: const Icon(Icons.close),
+              ),
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: ScheduleHistoryListView(
+                padding: const EdgeInsets.all(12),
+                reloadToken: reloadToken,
+                onOpenSchedule: onOpenSchedule,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/doubles_schedule_list_drawer.dart
+++ b/lib/features/doubles_scheduler/presentation/doubles_schedule_list_drawer.dart
@@ -16,44 +16,62 @@ class DoublesScheduleListDrawer extends StatelessWidget {
 
   static double widthFor(BuildContext context) {
     final screenWidth = MediaQuery.sizeOf(context).width;
-    return (screenWidth * 0.75).clamp(0.0, 300.0).toDouble();
+    return screenWidth * 0.85;
   }
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      width: widthFor(context),
+      child: SafeArea(
+        child: DoublesScheduleListPanel(
+          reloadToken: reloadToken,
+          onBack: () => Navigator.of(context).pop(),
+          onOpenSchedule: onOpenSchedule,
+        ),
+      ),
+    );
+  }
+}
+
+class DoublesScheduleListPanel extends StatelessWidget {
+  const DoublesScheduleListPanel({
+    super.key,
+    required this.onBack,
+    required this.onOpenSchedule,
+    this.reloadToken = 0,
+  });
+
+  final VoidCallback onBack;
+  final ValueChanged<LocalScheduleHistoryItem> onOpenSchedule;
+  final int reloadToken;
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
 
-    return Drawer(
-      width: widthFor(context),
-      child: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            ListTile(
-              leading: const Icon(Icons.list_alt_outlined),
-              title: Text(
-                l10n.matchTableList,
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.w700,
-                    ),
-              ),
-              trailing: IconButton(
-                tooltip: l10n.closeButton,
-                onPressed: () => Navigator.of(context).pop(),
-                icon: const Icon(Icons.close),
-              ),
-            ),
-            const Divider(height: 1),
-            Expanded(
-              child: ScheduleHistoryListView(
-                padding: const EdgeInsets.all(12),
-                reloadToken: reloadToken,
-                onOpenSchedule: onOpenSchedule,
-              ),
-            ),
-          ],
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ListTile(
+          leading: const Icon(Icons.arrow_back),
+          title: Text(
+            l10n.matchTableList,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+          onTap: onBack,
         ),
-      ),
+        const Divider(height: 1),
+        Expanded(
+          child: ScheduleHistoryListView(
+            padding: const EdgeInsets.all(12),
+            reloadToken: reloadToken,
+            onOpenSchedule: onOpenSchedule,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/doubles_scheduler/presentation/doubles_schedule_list_drawer.dart
+++ b/lib/features/doubles_scheduler/presentation/doubles_schedule_list_drawer.dart
@@ -16,7 +16,7 @@ class DoublesScheduleListDrawer extends StatelessWidget {
 
   static double widthFor(BuildContext context) {
     final screenWidth = MediaQuery.sizeOf(context).width;
-    return (screenWidth * 0.75).clamp(0.0, 300.0);
+    return (screenWidth * 0.75).clamp(0.0, 300.0).toDouble();
   }
 
   @override

--- a/lib/features/doubles_scheduler/presentation/event_list_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_list_page.dart
@@ -4,9 +4,11 @@ import 'package:srp_lanske/shared/presentation/app_message_type.dart';
 import 'package:srp_lanske/shared/presentation/app_snack_bar.dart';
 import 'package:srp_lanske/shared/utils/browser_url.dart';
 
+import '../application/schedule_share_url.dart';
 import '../data/local_schedule_history_item.dart';
 import '../data/local_schedule_history_store.dart';
 import 'restored_schedule_page.dart';
+import 'widgets/schedule_history_list_view.dart';
 
 class EventListPage extends StatefulWidget {
   const EventListPage({
@@ -23,29 +25,13 @@ class EventListPage extends StatefulWidget {
 class _EventListPageState extends State<EventListPage> {
   final _historyStore = LocalScheduleHistoryStore();
 
-  late Future<List<LocalScheduleHistoryItem>> _itemsFuture;
   bool _canClearHistory = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _itemsFuture = _loadItems();
-  }
+  int _reloadToken = 0;
 
   String? get _currentPublicId {
     final publicId = widget.currentPublicId?.trim().toUpperCase();
     if (publicId == null || publicId.isEmpty) return null;
     return publicId;
-  }
-
-  String _formatDateTime(DateTime dateTime) {
-    final y = dateTime.year.toString().padLeft(4, '0');
-    final m = dateTime.month.toString().padLeft(2, '0');
-    final d = dateTime.day.toString().padLeft(2, '0');
-    final hh = dateTime.hour.toString().padLeft(2, '0');
-    final mm = dateTime.minute.toString().padLeft(2, '0');
-
-    return '$y/$m/$d $hh:$mm';
   }
 
   void _openSchedule(LocalScheduleHistoryItem item) {
@@ -56,29 +42,12 @@ class _EventListPageState extends State<EventListPage> {
       ),
     );
 
-    _replaceBrowserUrlWithPublicId(item.publicId);
-  }
-
-  void _replaceBrowserUrlWithPublicId(String publicId) {
     replaceUrl(
-      Uri.base.replace(
-        queryParameters: {
-          ...Uri.base.queryParameters,
-          'sid': publicId,
-        },
-      ).toString(),
+      buildScheduleShareUrl(
+        baseUri: Uri.base,
+        publicId: item.publicId,
+      ),
     );
-  }
-
-  Future<List<LocalScheduleHistoryItem>> _loadItems() async {
-    final items = await _historyStore.findAll();
-    if (!mounted) return items;
-
-    setState(() {
-      _canClearHistory = _hasClearableHistory(items);
-    });
-
-    return items;
   }
 
   bool _hasClearableHistory(List<LocalScheduleHistoryItem> items) {
@@ -90,9 +59,19 @@ class _EventListPageState extends State<EventListPage> {
     );
   }
 
+  void _handleItemsLoaded(List<LocalScheduleHistoryItem> items) {
+    final canClearHistory = _hasClearableHistory(items);
+    if (canClearHistory == _canClearHistory) return;
+
+    setState(() {
+      _canClearHistory = canClearHistory;
+    });
+  }
+
   void _reloadItems() {
     setState(() {
-      _itemsFuture = _loadItems();
+      _canClearHistory = false;
+      _reloadToken += 1;
     });
   }
 
@@ -158,57 +137,11 @@ class _EventListPageState extends State<EventListPage> {
             ),
         ],
       ),
-      body: FutureBuilder<List<LocalScheduleHistoryItem>>(
-        future: _itemsFuture,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState != ConnectionState.done) {
-            return const Center(
-              child: CircularProgressIndicator(),
-            );
-          }
-
-          if (snapshot.hasError) {
-            return Center(
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Text(
-                  l10n.reloadScheduleFailedMessage(snapshot.error.toString()),
-                  textAlign: TextAlign.center,
-                ),
-              ),
-            );
-          }
-
-          final items = snapshot.data ?? const [];
-
-          if (items.isEmpty) {
-            return Center(
-              child: Text(l10n.scheduleHistoryEmptyMessage),
-            );
-          }
-
-          return ListView.separated(
-            padding: const EdgeInsets.all(4),
-            itemCount: items.length,
-            separatorBuilder: (_, __) => const SizedBox(height: 12),
-            itemBuilder: (context, index) {
-              final item = items[index];
-
-              return Card(
-                child: ListTile(
-                  title: Text(item.title),
-                  subtitle: Text(
-                    '${l10n.schedulePlayersTitle(item.courtCount, item.playerCount)}\n'
-                    '${l10n.lastOpenedAtLabel(_formatDateTime(item.lastOpenedAt))}',
-                  ),
-                  isThreeLine: true,
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () => _openSchedule(item),
-                ),
-              );
-            },
-          );
-        },
+      body: ScheduleHistoryListView(
+        padding: const EdgeInsets.all(4),
+        reloadToken: _reloadToken,
+        onItemsLoaded: _handleItemsLoaded,
+        onOpenSchedule: _openSchedule,
       ),
     );
   }

--- a/lib/features/doubles_scheduler/presentation/event_list_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_list_page.dart
@@ -138,7 +138,6 @@ class _EventListPageState extends State<EventListPage> {
         ],
       ),
       body: ScheduleHistoryListView(
-        padding: const EdgeInsets.all(4),
         reloadToken: _reloadToken,
         onItemsLoaded: _handleItemsLoaded,
         onOpenSchedule: _openSchedule,

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -17,11 +17,12 @@ import '../application/generated_schedule_service.dart';
 import '../application/local_schedule_history_mapper.dart';
 import '../application/saved_event_aggregate_helpers.dart';
 import '../application/schedule_share_url.dart';
+import '../data/local_schedule_history_item.dart';
 import '../data/local_schedule_history_store.dart';
 import '../domain/player_draft.dart';
 import '../domain/public_id.dart';
 import '../domain/saved_event_models.dart';
-import 'event_list_page.dart';
+import 'doubles_schedule_list_drawer.dart';
 import 'models/event_draft.dart';
 import 'widgets/court_display_settings_dialog.dart';
 import 'widgets/schedule_event_summary_card.dart';
@@ -45,7 +46,7 @@ class RestoredSchedulePage extends StatefulWidget {
   State<RestoredSchedulePage> createState() => _RestoredSchedulePageState();
 }
 
-enum _ScheduleMenuAction { top, list, support }
+enum _ScheduleMenuAction { top, support }
 
 class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   late final GeneratedScheduleService _service;
@@ -57,6 +58,7 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   bool _isCheckingRegenerate = false;
   bool _isOpeningSharedDataDialog = false;
   int _refreshRequestSequence = 0;
+  int _scheduleListReloadToken = 0;
   String? _errorMessage;
 
   SavedEventAggregate? _savedEvent;
@@ -178,6 +180,29 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
   void _toggleSelectedPlayer(String playerId) {
     setState(() {
       _selectedPlayerId = _selectedPlayerId == playerId ? null : playerId;
+    });
+  }
+
+  void _openScheduleFromHistory(LocalScheduleHistoryItem item) {
+    Navigator.of(context).pop();
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute<void>(
+        builder: (_) => RestoredSchedulePage(publicId: item.publicId),
+      ),
+    );
+    replaceUrl(
+      buildScheduleShareUrl(
+        baseUri: Uri.base,
+        publicId: item.publicId,
+      ),
+    );
+  }
+
+  void _handleEndDrawerChanged(bool isOpened) {
+    if (!isOpened) return;
+
+    setState(() {
+      _scheduleListReloadToken += 1;
     });
   }
 
@@ -777,16 +802,6 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       case _ScheduleMenuAction.top:
         _goTop();
         break;
-      case _ScheduleMenuAction.list:
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => EventListPage(
-              currentPublicId: _savedEvent?.event.publicId ?? widget.publicId,
-            ),
-          ),
-        );
-        break;
       case _ScheduleMenuAction.support:
         openUrlInCurrentTab(_supportPagePath);
         break;
@@ -968,16 +983,21 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
         automaticallyImplyLeading: false,
         title: Text(l10n.eventSetupTitle),
         actions: [
+          Builder(
+            builder: (context) {
+              return IconButton(
+                tooltip: l10n.matchTableList,
+                onPressed: () => Scaffold.of(context).openEndDrawer(),
+                icon: const Icon(Icons.list_alt_outlined),
+              );
+            },
+          ),
           PopupMenuButton<_ScheduleMenuAction>(
             onSelected: _handleMenu,
             itemBuilder: (context) => [
               PopupMenuItem(
                 value: _ScheduleMenuAction.top,
                 child: Text(l10n.topPageMenu),
-              ),
-              PopupMenuItem(
-                value: _ScheduleMenuAction.list,
-                child: Text(l10n.matchTableList),
               ),
               PopupMenuItem(
                 value: _ScheduleMenuAction.support,
@@ -987,6 +1007,11 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
           ),
         ],
       ),
+      endDrawer: DoublesScheduleListDrawer(
+        reloadToken: _scheduleListReloadToken,
+        onOpenSchedule: _openScheduleFromHistory,
+      ),
+      onEndDrawerChanged: _handleEndDrawerChanged,
       body: SafeArea(
         child: showInitialLoading
             ? const Center(

--- a/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/restored_schedule_page.dart
@@ -46,9 +46,11 @@ class RestoredSchedulePage extends StatefulWidget {
   State<RestoredSchedulePage> createState() => _RestoredSchedulePageState();
 }
 
-enum _ScheduleMenuAction { top, support }
+enum _ScheduleMenuAction { top, list, support }
 
 class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
+  final _scaffoldKey = GlobalKey<ScaffoldState>();
+
   late final GeneratedScheduleService _service;
   late final DoublesScheduleRefreshService _refreshService;
 
@@ -497,7 +499,6 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       final scheduleWasReplaced = previousGeneratedScheduleId != null &&
           previousGeneratedScheduleId.isNotEmpty &&
           latestGeneratedScheduleId != previousGeneratedScheduleId;
-
       if (scheduleWasReplaced) {
         _showMessage(
           l10n.scheduleUpdatedReloadMessage,
@@ -802,6 +803,9 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
       case _ScheduleMenuAction.top:
         _goTop();
         break;
+      case _ScheduleMenuAction.list:
+        _scaffoldKey.currentState?.openEndDrawer();
+        break;
       case _ScheduleMenuAction.support:
         openUrlInCurrentTab(_supportPagePath);
         break;
@@ -979,25 +983,21 @@ class _RestoredSchedulePageState extends State<RestoredSchedulePage> {
     final showInitialLoading = _isLoading && _savedEvent == null;
 
     return Scaffold(
+      key: _scaffoldKey,
       appBar: AppBar(
         automaticallyImplyLeading: false,
         title: Text(l10n.eventSetupTitle),
         actions: [
-          Builder(
-            builder: (context) {
-              return IconButton(
-                tooltip: l10n.matchTableList,
-                onPressed: () => Scaffold.of(context).openEndDrawer(),
-                icon: const Icon(Icons.list_alt_outlined),
-              );
-            },
-          ),
           PopupMenuButton<_ScheduleMenuAction>(
             onSelected: _handleMenu,
             itemBuilder: (context) => [
               PopupMenuItem(
                 value: _ScheduleMenuAction.top,
                 child: Text(l10n.topPageMenu),
+              ),
+              PopupMenuItem(
+                value: _ScheduleMenuAction.list,
+                child: Text(l10n.matchTableList),
               ),
               PopupMenuItem(
                 value: _ScheduleMenuAction.support,

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -42,9 +42,11 @@ class SchedulePage extends StatefulWidget {
   State<SchedulePage> createState() => _SchedulePageState();
 }
 
-enum _ScheduleMenuAction { top, support }
+enum _ScheduleMenuAction { top, list, support }
 
 class _SchedulePageState extends State<SchedulePage> {
+  final _scaffoldKey = GlobalKey<ScaffoldState>();
+
   late final GeneratedScheduleService _service;
   late final DoublesScheduleRefreshService _refreshService;
 
@@ -852,6 +854,9 @@ class _SchedulePageState extends State<SchedulePage> {
       case _ScheduleMenuAction.top:
         _goTop();
         break;
+      case _ScheduleMenuAction.list:
+        _scaffoldKey.currentState?.openEndDrawer();
+        break;
       case _ScheduleMenuAction.support:
         openUrlInCurrentTab(_supportPagePath);
         break;
@@ -969,25 +974,21 @@ class _SchedulePageState extends State<SchedulePage> {
     final showInitialLoading = _isLoading && _scheduleResponse == null;
 
     return Scaffold(
+      key: _scaffoldKey,
       appBar: AppBar(
         automaticallyImplyLeading: false,
         title: Text(l10n.eventSetupTitle),
         actions: [
-          Builder(
-            builder: (context) {
-              return IconButton(
-                tooltip: l10n.matchTableList,
-                onPressed: () => Scaffold.of(context).openEndDrawer(),
-                icon: const Icon(Icons.list_alt_outlined),
-              );
-            },
-          ),
           PopupMenuButton<_ScheduleMenuAction>(
             onSelected: _handleMenu,
             itemBuilder: (context) => [
               PopupMenuItem(
                 value: _ScheduleMenuAction.top,
                 child: Text(l10n.topPageMenu),
+              ),
+              PopupMenuItem(
+                value: _ScheduleMenuAction.list,
+                child: Text(l10n.matchTableList),
               ),
               PopupMenuItem(
                 value: _ScheduleMenuAction.support,

--- a/lib/features/doubles_scheduler/presentation/schedule_page.dart
+++ b/lib/features/doubles_scheduler/presentation/schedule_page.dart
@@ -16,11 +16,13 @@ import '../application/generated_schedule_service.dart';
 import '../application/local_schedule_history_mapper.dart';
 import '../application/saved_event_aggregate_helpers.dart';
 import '../application/schedule_share_url.dart';
+import '../data/local_schedule_history_item.dart';
 import '../data/local_schedule_history_store.dart';
 import '../domain/saved_event_models.dart';
-import 'event_list_page.dart';
+import 'doubles_schedule_list_drawer.dart';
 import 'event_setup_page.dart';
 import 'models/event_draft.dart';
+import 'restored_schedule_page.dart';
 import 'widgets/court_display_settings_dialog.dart';
 import 'widgets/schedule_event_summary_card.dart';
 import 'widgets/schedule_operation_panel.dart';
@@ -40,7 +42,7 @@ class SchedulePage extends StatefulWidget {
   State<SchedulePage> createState() => _SchedulePageState();
 }
 
-enum _ScheduleMenuAction { top, list, support }
+enum _ScheduleMenuAction { top, support }
 
 class _SchedulePageState extends State<SchedulePage> {
   late final GeneratedScheduleService _service;
@@ -52,6 +54,7 @@ class _SchedulePageState extends State<SchedulePage> {
   bool _isCheckingRegenerate = false;
   bool _isOpeningSharedDataDialog = false;
   int _refreshRequestSequence = 0;
+  int _scheduleListReloadToken = 0;
   String? _errorMessage;
   String? _generatedScheduleId;
   String? _selectedPlayerId;
@@ -204,6 +207,29 @@ class _SchedulePageState extends State<SchedulePage> {
   void _toggleSelectedPlayer(String playerId) {
     setState(() {
       _selectedPlayerId = _selectedPlayerId == playerId ? null : playerId;
+    });
+  }
+
+  void _openScheduleFromHistory(LocalScheduleHistoryItem item) {
+    Navigator.of(context).pop();
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute<void>(
+        builder: (_) => RestoredSchedulePage(publicId: item.publicId),
+      ),
+    );
+    replaceUrl(
+      buildScheduleShareUrl(
+        baseUri: Uri.base,
+        publicId: item.publicId,
+      ),
+    );
+  }
+
+  void _handleEndDrawerChanged(bool isOpened) {
+    if (!isOpened) return;
+
+    setState(() {
+      _scheduleListReloadToken += 1;
     });
   }
 
@@ -826,16 +852,6 @@ class _SchedulePageState extends State<SchedulePage> {
       case _ScheduleMenuAction.top:
         _goTop();
         break;
-      case _ScheduleMenuAction.list:
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => EventListPage(
-              currentPublicId: _savedEvent?.event.publicId,
-            ),
-          ),
-        );
-        break;
       case _ScheduleMenuAction.support:
         openUrlInCurrentTab(_supportPagePath);
         break;
@@ -957,16 +973,21 @@ class _SchedulePageState extends State<SchedulePage> {
         automaticallyImplyLeading: false,
         title: Text(l10n.eventSetupTitle),
         actions: [
+          Builder(
+            builder: (context) {
+              return IconButton(
+                tooltip: l10n.matchTableList,
+                onPressed: () => Scaffold.of(context).openEndDrawer(),
+                icon: const Icon(Icons.list_alt_outlined),
+              );
+            },
+          ),
           PopupMenuButton<_ScheduleMenuAction>(
             onSelected: _handleMenu,
             itemBuilder: (context) => [
               PopupMenuItem(
                 value: _ScheduleMenuAction.top,
                 child: Text(l10n.topPageMenu),
-              ),
-              PopupMenuItem(
-                value: _ScheduleMenuAction.list,
-                child: Text(l10n.matchTableList),
               ),
               PopupMenuItem(
                 value: _ScheduleMenuAction.support,
@@ -976,6 +997,11 @@ class _SchedulePageState extends State<SchedulePage> {
           ),
         ],
       ),
+      endDrawer: DoublesScheduleListDrawer(
+        reloadToken: _scheduleListReloadToken,
+        onOpenSchedule: _openScheduleFromHistory,
+      ),
+      onEndDrawerChanged: _handleEndDrawerChanged,
       body: SafeArea(
         child: showInitialLoading
             ? const Center(

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
@@ -69,17 +69,6 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
     await future;
   }
 
-  String _formatDateTime(DateTime dateTime) {
-    final local = dateTime.toLocal();
-    final y = local.year.toString().padLeft(4, '0');
-    final m = local.month.toString().padLeft(2, '0');
-    final d = local.day.toString().padLeft(2, '0');
-    final hh = local.hour.toString().padLeft(2, '0');
-    final mm = local.minute.toString().padLeft(2, '0');
-
-    return '$y/$m/$d $hh:$mm';
-  }
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
@@ -119,22 +108,137 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
             itemBuilder: (context, index) {
               final item = items[index];
 
-              return Card(
-                child: ListTile(
-                  title: Text(item.title),
-                  subtitle: Text(
-                    '${l10n.schedulePlayersTitle(item.courtCount, item.playerCount)}\n'
-                    '${l10n.lastOpenedAtLabel(_formatDateTime(item.lastOpenedAt))}',
-                  ),
-                  isThreeLine: true,
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () => widget.onOpenSchedule(item),
-                ),
+              return _ScheduleHistoryListItem(
+                item: item,
+                onTap: () => widget.onOpenSchedule(item),
               );
             },
           ),
         );
       },
+    );
+  }
+}
+
+class _ScheduleHistoryListItem extends StatelessWidget {
+  const _ScheduleHistoryListItem({
+    required this.item,
+    required this.onTap,
+  });
+
+  final LocalScheduleHistoryItem item;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              CircleAvatar(
+                backgroundColor: colorScheme.primary.withValues(alpha: 0.12),
+                foregroundColor: colorScheme.primary,
+                child: const Icon(Icons.sports_tennis_outlined),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _ScheduleHistoryListItemBody(item: item),
+              ),
+              const SizedBox(width: 8),
+              Icon(
+                Icons.chevron_right,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ScheduleHistoryListItemBody extends StatelessWidget {
+  const _ScheduleHistoryListItemBody({required this.item});
+
+  final LocalScheduleHistoryItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final textTheme = Theme.of(context).textTheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          item.title,
+          style: textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Wrap(
+          spacing: 8,
+          runSpacing: 4,
+          children: [
+            _ScheduleHistoryListChip(
+              icon: Icons.grid_view_outlined,
+              label: '${l10n.courtCountLabel} ${item.courtCount}',
+            ),
+            _ScheduleHistoryListChip(
+              icon: Icons.person_outline,
+              label: '${l10n.playerCountLabel} ${item.playerCount}',
+            ),
+            _ScheduleHistoryListChip(
+              icon: Icons.schedule_outlined,
+              label: l10n.lastOpenedAtLabel(
+                _formatDateTime(item.lastOpenedAt),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  String _formatDateTime(DateTime dateTime) {
+    final local = dateTime.toLocal();
+    final y = local.year.toString().padLeft(4, '0');
+    final m = local.month.toString().padLeft(2, '0');
+    final d = local.day.toString().padLeft(2, '0');
+    final hh = local.hour.toString().padLeft(2, '0');
+    final mm = local.minute.toString().padLeft(2, '0');
+
+    return '$y/$m/$d $hh:$mm';
+  }
+}
+
+class _ScheduleHistoryListChip extends StatelessWidget {
+  const _ScheduleHistoryListChip({
+    required this.icon,
+    required this.label,
+  });
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Chip(
+      avatar: Icon(icon, size: 16),
+      label: Text(label),
+      visualDensity: VisualDensity.compact,
+      backgroundColor: colorScheme.surfaceContainerHighest,
+      side: BorderSide.none,
     );
   }
 }

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
@@ -142,12 +142,6 @@ class _ScheduleHistoryListItem extends StatelessWidget {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              CircleAvatar(
-                backgroundColor: colorScheme.primary.withValues(alpha: 0.12),
-                foregroundColor: colorScheme.primary,
-                child: const Icon(Icons.sports_tennis_outlined),
-              ),
-              const SizedBox(width: 12),
               Expanded(
                 child: _ScheduleHistoryListItemBody(item: item),
               ),

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
+
+import '../../data/local_schedule_history_item.dart';
+import '../../data/local_schedule_history_store.dart';
+
+class ScheduleHistoryListView extends StatefulWidget {
+  const ScheduleHistoryListView({
+    super.key,
+    required this.onOpenSchedule,
+    this.padding = const EdgeInsets.all(16),
+    this.reloadToken = 0,
+    this.onItemsLoaded,
+  });
+
+  final ValueChanged<LocalScheduleHistoryItem> onOpenSchedule;
+  final EdgeInsetsGeometry padding;
+  final int reloadToken;
+  final ValueChanged<List<LocalScheduleHistoryItem>>? onItemsLoaded;
+
+  @override
+  State<ScheduleHistoryListView> createState() =>
+      _ScheduleHistoryListViewState();
+}
+
+class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
+  final LocalScheduleHistoryStore _historyStore = LocalScheduleHistoryStore();
+
+  late Future<List<LocalScheduleHistoryItem>> _itemsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _itemsFuture = _loadItems();
+  }
+
+  @override
+  void didUpdateWidget(covariant ScheduleHistoryListView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.reloadToken != widget.reloadToken) {
+      _reloadItems();
+    }
+  }
+
+  Future<List<LocalScheduleHistoryItem>> _loadItems() async {
+    final items = await _historyStore.findAll();
+
+    if (mounted) {
+      widget.onItemsLoaded?.call(items);
+    }
+
+    return items;
+  }
+
+  void _reloadItems() {
+    setState(() {
+      _itemsFuture = _loadItems();
+    });
+  }
+
+  Future<void> _refreshItems() async {
+    final future = _loadItems();
+
+    setState(() {
+      _itemsFuture = future;
+    });
+
+    await future;
+  }
+
+  String _formatDateTime(DateTime dateTime) {
+    final local = dateTime.toLocal();
+    final y = local.year.toString().padLeft(4, '0');
+    final m = local.month.toString().padLeft(2, '0');
+    final d = local.day.toString().padLeft(2, '0');
+    final hh = local.hour.toString().padLeft(2, '0');
+    final mm = local.minute.toString().padLeft(2, '0');
+
+    return '$y/$m/$d $hh:$mm';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return FutureBuilder<List<LocalScheduleHistoryItem>>(
+      future: _itemsFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (snapshot.hasError) {
+          return _ScheduleHistoryMessage(
+            message: l10n.reloadScheduleFailedMessage(
+              snapshot.error.toString(),
+            ),
+            actionLabel: l10n.refreshLatestButton,
+            onActionPressed: _reloadItems,
+          );
+        }
+
+        final items = snapshot.data ?? const [];
+
+        if (items.isEmpty) {
+          return _ScheduleHistoryMessage(
+            message: l10n.scheduleHistoryEmptyMessage,
+          );
+        }
+
+        return RefreshIndicator(
+          onRefresh: _refreshItems,
+          child: ListView.separated(
+            padding: widget.padding,
+            physics: const AlwaysScrollableScrollPhysics(),
+            itemCount: items.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
+            itemBuilder: (context, index) {
+              final item = items[index];
+
+              return Card(
+                child: ListTile(
+                  title: Text(item.title),
+                  subtitle: Text(
+                    '${l10n.schedulePlayersTitle(item.courtCount, item.playerCount)}\n'
+                    '${l10n.lastOpenedAtLabel(_formatDateTime(item.lastOpenedAt))}',
+                  ),
+                  isThreeLine: true,
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () => widget.onOpenSchedule(item),
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ScheduleHistoryMessage extends StatelessWidget {
+  const _ScheduleHistoryMessage({
+    required this.message,
+    this.actionLabel,
+    this.onActionPressed,
+  });
+
+  final String message;
+  final String? actionLabel;
+  final VoidCallback? onActionPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              message,
+              textAlign: TextAlign.center,
+            ),
+            if (actionLabel != null && onActionPressed != null) ...[
+              const SizedBox(height: 12),
+              FilledButton.icon(
+                onPressed: onActionPressed,
+                icon: const Icon(Icons.refresh),
+                label: Text(actionLabel!),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
@@ -39,7 +39,7 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
     super.didUpdateWidget(oldWidget);
 
     if (oldWidget.reloadToken != widget.reloadToken) {
-      _reloadItems();
+      _itemsFuture = _loadItems();
     }
   }
 

--- a/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
+++ b/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
@@ -1,0 +1,87 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:srp_lanske/features/doubles_scheduler/data/local_schedule_history_item.dart';
+import 'package:srp_lanske/features/doubles_scheduler/presentation/doubles_schedule_list_drawer.dart';
+import 'package:srp_lanske/l10n/l10n.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(const {});
+  });
+
+  testWidgets('uses 75 percent width on narrow screens', (tester) async {
+    await _pumpDrawer(tester, width: 320);
+
+    final drawer = tester.widget<Drawer>(find.byType(Drawer));
+    expect(drawer.width, 240);
+  });
+
+  testWidgets('caps drawer width at 300 pixels', (tester) async {
+    await _pumpDrawer(tester, width: 800);
+
+    final drawer = tester.widget<Drawer>(find.byType(Drawer));
+    expect(drawer.width, 300);
+  });
+
+  testWidgets('opens the selected local schedule', (tester) async {
+    final item = LocalScheduleHistoryItem(
+      publicId: 'ABCDEFGH',
+      title: 'テスト対戦表',
+      courtCount: 2,
+      playerCount: 8,
+      createdAt: DateTime(2026, 8, 10, 10),
+      firstSavedAt: DateTime(2026, 8, 10, 10),
+      lastOpenedAt: DateTime(2026, 8, 10, 12),
+    );
+    SharedPreferences.setMockInitialValues({
+      'lanske_recent_schedules': jsonEncode([item.toJson()]),
+    });
+
+    LocalScheduleHistoryItem? openedItem;
+    await _pumpDrawer(
+      tester,
+      width: 400,
+      onOpenSchedule: (item) {
+        openedItem = item;
+      },
+    );
+
+    expect(find.text('テスト対戦表'), findsOneWidget);
+
+    await tester.tap(find.text('テスト対戦表'));
+    await tester.pump();
+
+    expect(openedItem?.publicId, 'ABCDEFGH');
+  });
+}
+
+Future<void> _pumpDrawer(
+  WidgetTester tester, {
+  required double width,
+  ValueChanged<LocalScheduleHistoryItem>? onOpenSchedule,
+}) async {
+  final scaffoldKey = GlobalKey<ScaffoldState>();
+
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('ja'),
+      home: MediaQuery(
+        data: MediaQueryData(size: Size(width, 800)),
+        child: Scaffold(
+          key: scaffoldKey,
+          endDrawer: DoublesScheduleListDrawer(
+            onOpenSchedule: onOpenSchedule ?? (_) {},
+          ),
+        ),
+      ),
+    ),
+  );
+
+  scaffoldKey.currentState!.openEndDrawer();
+  await tester.pumpAndSettle();
+}

--- a/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
+++ b/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
@@ -27,6 +27,32 @@ void main() {
     expect(drawer.width, 680);
   });
 
+  testWidgets('schedule list panel delegates its back action', (tester) async {
+    var backCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('ja'),
+        home: Scaffold(
+          body: DoublesScheduleListPanel(
+            onBack: () {
+              backCount += 1;
+            },
+            onOpenSchedule: (_) {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.arrow_back));
+    await tester.pump();
+
+    expect(backCount, 1);
+  });
+
   testWidgets('opens the selected local schedule with team-style list cards',
       (tester) async {
     final item = LocalScheduleHistoryItem(

--- a/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
+++ b/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
@@ -53,7 +53,7 @@ void main() {
     expect(backCount, 1);
   });
 
-  testWidgets('opens the selected local schedule with team-style list cards',
+  testWidgets('opens the selected local schedule with compact list cards',
       (tester) async {
     final item = LocalScheduleHistoryItem(
       publicId: 'ABCDEFGH',
@@ -80,7 +80,7 @@ void main() {
     expect(find.text('テスト対戦表'), findsOneWidget);
     expect(find.text('面数 2'), findsOneWidget);
     expect(find.text('人数 8'), findsOneWidget);
-    expect(find.byIcon(Icons.sports_tennis_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.sports_tennis_outlined), findsNothing);
     expect(find.byIcon(Icons.chevron_right), findsOneWidget);
 
     await tester.tap(find.text('テスト対戦表'));

--- a/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
+++ b/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
@@ -12,21 +12,23 @@ void main() {
     SharedPreferences.setMockInitialValues(const {});
   });
 
-  testWidgets('uses 75 percent width on narrow screens', (tester) async {
+  testWidgets('uses 85 percent width on narrow screens', (tester) async {
     await _pumpDrawer(tester, width: 320);
 
     final drawer = tester.widget<Drawer>(find.byType(Drawer));
-    expect(drawer.width, 240);
+    expect(drawer.width, 272);
   });
 
-  testWidgets('caps drawer width at 300 pixels', (tester) async {
+  testWidgets('uses 85 percent width on wide screens without a max cap',
+      (tester) async {
     await _pumpDrawer(tester, width: 800);
 
     final drawer = tester.widget<Drawer>(find.byType(Drawer));
-    expect(drawer.width, 300);
+    expect(drawer.width, 680);
   });
 
-  testWidgets('opens the selected local schedule', (tester) async {
+  testWidgets('opens the selected local schedule with team-style list cards',
+      (tester) async {
     final item = LocalScheduleHistoryItem(
       publicId: 'ABCDEFGH',
       title: 'テスト対戦表',
@@ -50,6 +52,10 @@ void main() {
     );
 
     expect(find.text('テスト対戦表'), findsOneWidget);
+    expect(find.text('面数 2'), findsOneWidget);
+    expect(find.text('人数 8'), findsOneWidget);
+    expect(find.byIcon(Icons.sports_tennis_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.chevron_right), findsOneWidget);
 
     await tester.tap(find.text('テスト対戦表'));
     await tester.pump();


### PR DESCRIPTION
## 概要

Closes #138

ダブルス対戦表画面から、保存済み対戦表一覧を画面遷移ではなく右側 Drawer で表示できるようにしました。

チーム側の対戦表一覧を基準に、一覧本体をページ表示／Drawer表示で共通利用できる構成へ整理し、一覧から別の対戦表へ切り替えた際はブラウザURLの `sid` も更新します。

## 対応内容

- ダブルス対戦表画面へ右側の対戦表一覧 Drawer を追加
  - 通常生成画面
  - 共有URL復元画面
- 既存メニューの「対戦表一覧」から Drawer を開くよう変更
  - TOP / サポートなど既存メニュー項目は維持
  - AppBar / ハンバーガーメニュー全体の整理は #141 で対応
- Drawer幅をチーム側と同様に画面幅の85%へ設定
- Drawer外タップ／戻る操作で閉じられるFlutter標準の挙動を利用
- 保存済み一覧の本体を `ScheduleHistoryListView` として分離
  - standalone の `EventListPage`
  - 右側 Drawer
  で共通利用
- Drawer用の一覧表示を `DoublesScheduleListPanel` として分離
  - #141 で操作メニューと一覧をDrawer内切り替えする構成を想定
  - 戻る操作を外部callbackで差し替え可能にした
- 一覧カードをチーム側の表示に近い構成へ整理
  - イベント名
  - 面数
  - 人数
  - 最終表示日時
  - 対戦表を開く導線
- 狭幅での情報表示を優先し、一覧カード先頭の装飾アイコンは表示しない構成とした
- Drawerを開くたびにローカル履歴を再取得
- 一覧から別の対戦表を選択した場合
  - 対象の `RestoredSchedulePage` へ切り替え
  - ブラウザURLの `sid` を対象publicIdへ更新
- standalone の対戦表一覧画面と既存の履歴削除操作は維持
- Drawer幅・一覧カード・選択操作・将来のDrawer内切り替えを対象としたwidget testを追加

## 後続 Issue との関係

- #139
  - 本PRで共通化した一覧Widgetを前提に、作成日時・進行状況表示を追加する
- #140
  - 削除対象マーク・非表示フローの実処理を扱う
- #141
  - ダブルス側の AppBar / ハンバーガーメニューを整理する
  - 「操作メニュー → 対戦表一覧」を同じ Drawer 内で切り替える構成へ移行する
- #177
  - ver0.1.6 の主要機能実装後に、一覧を含むUI全体を横断して微調整する

## 確認

- `dart format lib/ test/`
  - 変更なし
- `flutter analyze`
  - 問題なし
- `flutter test test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart`
  - 成功
- `flutter test`
  - 成功
- `git status --short`
  - 問題なし
- 実画面確認
  - 通常生成画面から対戦表一覧 Drawer を表示
  - 共有URL復元画面から対戦表一覧 Drawer を表示
  - 一覧から別の対戦表へ切り替え
  - 狭幅表示を確認
  - 約340px幅でも面数・人数が不要に折り返さないことを確認

## Docs / l10n

- 新規文言は不要のため ARB 変更なし
- 本Issue単体での docs 更新は不要
- AppBar / Drawer / 操作一覧を含むUI方針は後続 #141 および #177 で整理する