### PR TITLE
📅 Show creation date and progress in doubles schedule list refs #139

### DIFF
--- a/lib/features/doubles_scheduler/application/doubles_match_progress_service.dart
+++ b/lib/features/doubles_scheduler/application/doubles_match_progress_service.dart
@@ -1,6 +1,8 @@
 import 'package:srp_lanske/features/schedule_progress/application/schedule_progress_repository.dart';
 import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_models.dart';
 
+import '../data/local_schedule_history_store.dart';
+
 class DoublesMatchProgressInput {
   const DoublesMatchProgressInput({
     required this.status,
@@ -60,6 +62,18 @@ class DoublesMatchProgressService {
     final summary = await _repository.findSummary(scope);
     if (summary == null) {
       throw StateError('schedule progress summary was not saved');
+    }
+
+    try {
+      await LocalScheduleHistoryStore().updateProgress(
+        publicId: scope.shareId,
+        generatedScheduleId: scope.generatedScheduleId,
+        completedMatchCount: summary.completedMatchCount,
+        totalMatchCount: summary.totalMatchCount,
+        lastOpenedAt: _clock(),
+      );
+    } catch (_) {
+      // Local history is a best-effort display index and must not fail a save.
     }
 
     return DoublesMatchProgressSaveResult(

--- a/lib/features/doubles_scheduler/application/doubles_schedule_refresh_service.dart
+++ b/lib/features/doubles_scheduler/application/doubles_schedule_refresh_service.dart
@@ -1,8 +1,11 @@
 import 'package:srp_lanske/features/schedule_progress/application/schedule_progress_repository.dart';
 import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_models.dart';
 
+import '../data/local_schedule_history_store.dart';
 import '../domain/saved_event_models.dart';
+import 'doubles_match_progress_service.dart';
 import 'event_repository.dart';
+import 'local_schedule_history_mapper.dart';
 
 typedef GeneratedScheduleByIdLoader = Future<Map<String, dynamic>> Function(
   String generatedScheduleId,
@@ -162,6 +165,19 @@ class DoublesScheduleRefreshService {
     } else {
       progressChanged = current?.progressSummary != null ||
           (current?.matches.isNotEmpty ?? false);
+    }
+
+    try {
+      await LocalScheduleHistoryStore().upsert(
+        buildLocalScheduleHistoryItem(
+          aggregate,
+          now: DateTime.now(),
+          progressSummary: progressSummary,
+          totalMatchCount: countDoublesScheduleMatches(scheduleResponse),
+        ),
+      );
+    } catch (_) {
+      // Local history is a best-effort display index and must not fail refresh.
     }
 
     return DoublesScheduleRefreshSnapshot(

--- a/lib/features/doubles_scheduler/application/local_schedule_history_mapper.dart
+++ b/lib/features/doubles_scheduler/application/local_schedule_history_mapper.dart
@@ -1,10 +1,25 @@
+import 'package:srp_lanske/features/schedule_progress/domain/schedule_progress_models.dart';
+
 import '../data/local_schedule_history_item.dart';
 import '../domain/saved_event_models.dart';
 
 LocalScheduleHistoryItem buildLocalScheduleHistoryItem(
   SavedEventAggregate aggregate, {
   required DateTime now,
+  ScheduleProgressSummary? progressSummary,
+  int? totalMatchCount,
 }) {
+  final generatedScheduleId = aggregate.event.displayGeneratedScheduleId;
+  final matchingSummary = progressSummary != null &&
+          generatedScheduleId != null &&
+          progressSummary.generatedScheduleId == generatedScheduleId
+      ? progressSummary
+      : null;
+  final knownTotalMatchCount = matchingSummary?.totalMatchCount ??
+      ((totalMatchCount ?? 0) > 0 ? totalMatchCount : null);
+  final completedMatchCount = matchingSummary?.completedMatchCount ??
+      (knownTotalMatchCount == null ? null : 0);
+
   return LocalScheduleHistoryItem(
     publicId: aggregate.event.publicId,
     title: aggregate.event.title,
@@ -13,5 +28,9 @@ LocalScheduleHistoryItem buildLocalScheduleHistoryItem(
     createdAt: aggregate.event.createdAt,
     firstSavedAt: now,
     lastOpenedAt: now,
+    generatedScheduleId: generatedScheduleId,
+    isAdopted: aggregate.event.hasAdoptedSchedule,
+    completedMatchCount: completedMatchCount,
+    totalMatchCount: knownTotalMatchCount,
   );
 }

--- a/lib/features/doubles_scheduler/data/local_schedule_history_item.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_item.dart
@@ -7,6 +7,10 @@ class LocalScheduleHistoryItem {
     required this.createdAt,
     required this.firstSavedAt,
     required this.lastOpenedAt,
+    this.generatedScheduleId,
+    this.isAdopted,
+    this.completedMatchCount,
+    this.totalMatchCount,
   });
 
   final String publicId;
@@ -16,6 +20,10 @@ class LocalScheduleHistoryItem {
   final DateTime createdAt;
   final DateTime firstSavedAt;
   final DateTime lastOpenedAt;
+  final String? generatedScheduleId;
+  final bool? isAdopted;
+  final int? completedMatchCount;
+  final int? totalMatchCount;
 
   Map<String, dynamic> toJson() {
     return {
@@ -26,27 +34,42 @@ class LocalScheduleHistoryItem {
       'created_at': createdAt.toIso8601String(),
       'first_saved_at': firstSavedAt.toIso8601String(),
       'last_opened_at': lastOpenedAt.toIso8601String(),
+      'generated_schedule_id': generatedScheduleId,
+      'is_adopted': isAdopted,
+      'completed_match_count': completedMatchCount,
+      'total_match_count': totalMatchCount,
     };
   }
 
   static LocalScheduleHistoryItem fromJson(Map<String, dynamic> json) {
     // TODO(ver0.2): Remove the legacy participant_count fallback.
     final rawPlayerCount = json['player_count'] ?? json['participant_count'];
+    final fallbackNow = DateTime.now();
+    final lastOpenedAt =
+        DateTime.tryParse(json['last_opened_at'] as String? ?? '') ?? fallbackNow;
     final firstSavedAt =
         DateTime.tryParse(json['first_saved_at'] as String? ?? '') ??
-            DateTime.now();
+            lastOpenedAt;
+    final createdAt =
+        DateTime.tryParse(json['created_at'] as String? ?? '') ?? firstSavedAt;
+    final rawGeneratedScheduleId = json['generated_schedule_id'] as String?;
+    final generatedScheduleId = rawGeneratedScheduleId?.trim();
 
     return LocalScheduleHistoryItem(
       publicId: json['public_id'] as String? ?? '',
       title: json['title'] as String? ?? 'Untitled match table',
       courtCount: json['court_count'] as int? ?? 0,
       playerCount: rawPlayerCount as int? ?? 0,
-      createdAt: DateTime.tryParse(json['created_at'] as String? ?? '') ??
-          firstSavedAt,
+      createdAt: createdAt,
       firstSavedAt: firstSavedAt,
-      lastOpenedAt:
-          DateTime.tryParse(json['last_opened_at'] as String? ?? '') ??
-              DateTime.now(),
+      lastOpenedAt: lastOpenedAt,
+      generatedScheduleId:
+          generatedScheduleId == null || generatedScheduleId.isEmpty
+              ? null
+              : generatedScheduleId,
+      isAdopted: json['is_adopted'] as bool?,
+      completedMatchCount: json['completed_match_count'] as int?,
+      totalMatchCount: json['total_match_count'] as int?,
     );
   }
 }

--- a/lib/features/doubles_scheduler/data/local_schedule_history_item.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_item.dart
@@ -46,7 +46,8 @@ class LocalScheduleHistoryItem {
     final rawPlayerCount = json['player_count'] ?? json['participant_count'];
     final fallbackNow = DateTime.now();
     final lastOpenedAt =
-        DateTime.tryParse(json['last_opened_at'] as String? ?? '') ?? fallbackNow;
+        DateTime.tryParse(json['last_opened_at'] as String? ?? '') ??
+            fallbackNow;
     final firstSavedAt =
         DateTime.tryParse(json['first_saved_at'] as String? ?? '') ??
             lastOpenedAt;

--- a/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
@@ -46,16 +46,16 @@ class LocalScheduleHistoryStore {
       generatedScheduleId:
           item.generatedScheduleId ?? previous?.generatedScheduleId,
       isAdopted: item.isAdopted ??
-          (sameGeneratedSchedule ? previous?.isAdopted : null),
+          (sameGeneratedSchedule ? previous.isAdopted : null),
       completedMatchCount: hasIncomingProgress
           ? item.completedMatchCount
           : sameGeneratedSchedule
-              ? previous?.completedMatchCount
+              ? previous.completedMatchCount
               : null,
       totalMatchCount: hasIncomingProgress
           ? item.totalMatchCount
           : sameGeneratedSchedule
-              ? previous?.totalMatchCount
+              ? previous.totalMatchCount
               : null,
     );
 

--- a/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
@@ -6,48 +6,107 @@ import 'local_schedule_history_item.dart';
 
 class LocalScheduleHistoryStore {
   static const _key = 'lanske_recent_schedules';
+  static const _maxItems = 20;
 
   Future<List<LocalScheduleHistoryItem>> findAll() async {
-    final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(_key);
-    if (raw == null || raw.isEmpty) return const [];
+    final items = await _readAll();
 
-    final decoded = jsonDecode(raw);
-    if (decoded is! List) return const [];
-
-    return decoded
-        .whereType<Map<String, dynamic>>()
-        .map(LocalScheduleHistoryItem.fromJson)
-        .where((item) => item.publicId.isNotEmpty)
-        .toList(growable: false)
-      ..sort((a, b) => b.lastOpenedAt.compareTo(a.lastOpenedAt));
+    return items
+      ..sort((a, b) {
+        final createdAtComparison = b.createdAt.compareTo(a.createdAt);
+        if (createdAtComparison != 0) {
+          return createdAtComparison;
+        }
+        return b.lastOpenedAt.compareTo(a.lastOpenedAt);
+      });
   }
 
   Future<void> upsert(LocalScheduleHistoryItem item) async {
     final prefs = await SharedPreferences.getInstance();
-    final current = await findAll();
-
+    final current = await _readAll();
     final existing = {
       for (final currentItem in current) currentItem.publicId: currentItem,
     };
 
     final previous = existing[item.publicId];
+    final sameGeneratedSchedule = previous?.generatedScheduleId != null &&
+        item.generatedScheduleId != null &&
+        previous!.generatedScheduleId == item.generatedScheduleId;
+    final hasIncomingProgress =
+        item.completedMatchCount != null && item.totalMatchCount != null;
+
     existing[item.publicId] = LocalScheduleHistoryItem(
       publicId: item.publicId,
       title: item.title,
       courtCount: item.courtCount,
       playerCount: item.playerCount,
-      createdAt: previous?.createdAt ?? item.createdAt,
+      createdAt: item.createdAt,
       firstSavedAt: previous?.firstSavedAt ?? item.firstSavedAt,
       lastOpenedAt: item.lastOpenedAt,
+      generatedScheduleId:
+          item.generatedScheduleId ?? previous?.generatedScheduleId,
+      isAdopted: item.isAdopted ??
+          (sameGeneratedSchedule ? previous?.isAdopted : null),
+      completedMatchCount: hasIncomingProgress
+          ? item.completedMatchCount
+          : sameGeneratedSchedule
+              ? previous?.completedMatchCount
+              : null,
+      totalMatchCount: hasIncomingProgress
+          ? item.totalMatchCount
+          : sameGeneratedSchedule
+              ? previous?.totalMatchCount
+              : null,
     );
 
-    final next = existing.values.toList(growable: false)
-      ..sort((a, b) => b.lastOpenedAt.compareTo(a.lastOpenedAt));
+    await _saveRetained(prefs, existing.values);
+  }
 
-    final limited = next.take(20).map((item) => item.toJson()).toList();
+  Future<void> updateProgress({
+    required String publicId,
+    required String generatedScheduleId,
+    required int completedMatchCount,
+    required int totalMatchCount,
+    DateTime? lastOpenedAt,
+  }) async {
+    final normalizedPublicId = publicId.trim().toUpperCase();
+    final normalizedGeneratedScheduleId = generatedScheduleId.trim();
+    if (normalizedPublicId.isEmpty || normalizedGeneratedScheduleId.isEmpty) {
+      return;
+    }
 
-    await prefs.setString(_key, jsonEncode(limited));
+    final prefs = await SharedPreferences.getInstance();
+    final current = await _readAll();
+    final index = current.indexWhere(
+      (item) => item.publicId.trim().toUpperCase() == normalizedPublicId,
+    );
+    if (index < 0) {
+      return;
+    }
+
+    final item = current[index];
+    final storedGeneratedScheduleId = item.generatedScheduleId?.trim();
+    if (storedGeneratedScheduleId != null &&
+        storedGeneratedScheduleId.isNotEmpty &&
+        storedGeneratedScheduleId != normalizedGeneratedScheduleId) {
+      return;
+    }
+
+    current[index] = LocalScheduleHistoryItem(
+      publicId: item.publicId,
+      title: item.title,
+      courtCount: item.courtCount,
+      playerCount: item.playerCount,
+      createdAt: item.createdAt,
+      firstSavedAt: item.firstSavedAt,
+      lastOpenedAt: lastOpenedAt ?? DateTime.now(),
+      generatedScheduleId: normalizedGeneratedScheduleId,
+      isAdopted: true,
+      completedMatchCount: completedMatchCount,
+      totalMatchCount: totalMatchCount,
+    );
+
+    await _saveRetained(prefs, current);
   }
 
   Future<void> clearAll() async {
@@ -63,8 +122,7 @@ class LocalScheduleHistoryStore {
     }
 
     final prefs = await SharedPreferences.getInstance();
-    final current = await findAll();
-
+    final current = await _readAll();
     final kept = current
         .where((item) => item.publicId.trim().toUpperCase() == keepPublicId)
         .map((item) => item.toJson())
@@ -76,5 +134,34 @@ class LocalScheduleHistoryStore {
     }
 
     await prefs.setString(_key, jsonEncode(kept));
+  }
+
+  Future<List<LocalScheduleHistoryItem>> _readAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return <LocalScheduleHistoryItem>[];
+
+    final decoded = jsonDecode(raw);
+    if (decoded is! List) return <LocalScheduleHistoryItem>[];
+
+    return decoded
+        .whereType<Map<String, dynamic>>()
+        .map(LocalScheduleHistoryItem.fromJson)
+        .where((item) => item.publicId.isNotEmpty)
+        .toList(growable: true);
+  }
+
+  Future<void> _saveRetained(
+    SharedPreferences prefs,
+    Iterable<LocalScheduleHistoryItem> items,
+  ) async {
+    final retained = items.toList(growable: false)
+      ..sort((a, b) => b.lastOpenedAt.compareTo(a.lastOpenedAt));
+    final encoded = retained
+        .take(_maxItems)
+        .map((item) => item.toJson())
+        .toList(growable: false);
+
+    await prefs.setString(_key, jsonEncode(encoded));
   }
 }

--- a/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
@@ -45,8 +45,8 @@ class LocalScheduleHistoryStore {
       lastOpenedAt: item.lastOpenedAt,
       generatedScheduleId:
           item.generatedScheduleId ?? previous?.generatedScheduleId,
-      isAdopted: item.isAdopted ??
-          (sameGeneratedSchedule ? previous.isAdopted : null),
+      isAdopted:
+          item.isAdopted ?? (sameGeneratedSchedule ? previous.isAdopted : null),
       completedMatchCount: hasIncomingProgress
           ? item.completedMatchCount
           : sameGeneratedSchedule

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
@@ -167,6 +167,8 @@ class _ScheduleHistoryListItemBody extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final textTheme = Theme.of(context).textTheme;
+    final completedMatchCount = item.completedMatchCount;
+    final totalMatchCount = item.totalMatchCount;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -191,26 +193,39 @@ class _ScheduleHistoryListItemBody extends StatelessWidget {
               label: '${l10n.playerCountLabel} ${item.playerCount}',
             ),
             _ScheduleHistoryListChip(
-              icon: Icons.schedule_outlined,
-              label: l10n.lastOpenedAtLabel(
-                _formatDateTime(item.lastOpenedAt),
+              icon: Icons.calendar_today_outlined,
+              label: l10n.scheduleHistoryCreatedAtLabel(
+                _formatDate(item.createdAt),
               ),
             ),
+            if (item.isAdopted == false)
+              _ScheduleHistoryListChip(
+                icon: Icons.pending_outlined,
+                label: l10n.scheduleHistoryUnconfirmedLabel,
+              )
+            else if (item.isAdopted == true &&
+                completedMatchCount != null &&
+                totalMatchCount != null)
+              _ScheduleHistoryListChip(
+                icon: Icons.check_circle_outline,
+                label: l10n.scheduleHistoryCompletedMatchesLabel(
+                  completedMatchCount,
+                  totalMatchCount,
+                ),
+              ),
           ],
         ),
       ],
     );
   }
 
-  String _formatDateTime(DateTime dateTime) {
+  String _formatDate(DateTime dateTime) {
     final local = dateTime.toLocal();
     final y = local.year.toString().padLeft(4, '0');
     final m = local.month.toString().padLeft(2, '0');
     final d = local.day.toString().padLeft(2, '0');
-    final hh = local.hour.toString().padLeft(2, '0');
-    final mm = local.minute.toString().padLeft(2, '0');
 
-    return '$y/$m/$d $hh:$mm';
+    return '$y/$m/$d';
   }
 }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -250,7 +250,7 @@
   },
   "adoptScheduleFailedMessage": "Could not confirm the match table: {error}",
   "@adoptScheduleFailedMessage": {
-    "description": "Message shown when schedule adoption failed.",
+    "description": "Error message shown when schedule adoption failed.",
     "placeholders": {
       "error": {
         "type": "String",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -250,7 +250,7 @@
   },
   "adoptScheduleFailedMessage": "Could not confirm the match table: {error}",
   "@adoptScheduleFailedMessage": {
-    "description": "Error message shown when schedule adoption failed.",
+    "description": "Message shown when schedule adoption failed.",
     "placeholders": {
       "error": {
         "type": "String",
@@ -329,6 +329,34 @@
       "lastOpenedAt": {
         "type": "String",
         "example": "2026/05/22 23:10"
+      }
+    }
+  },
+  "scheduleHistoryCreatedAtLabel": "Created {createdAt}",
+  "@scheduleHistoryCreatedAtLabel": {
+    "description": "Label showing the creation date of a saved doubles schedule.",
+    "placeholders": {
+      "createdAt": {
+        "type": "String",
+        "example": "2026/08/14"
+      }
+    }
+  },
+  "scheduleHistoryUnconfirmedLabel": "Unconfirmed",
+  "@scheduleHistoryUnconfirmedLabel": {
+    "description": "Label shown for a saved doubles schedule that has not been confirmed."
+  },
+  "scheduleHistoryCompletedMatchesLabel": "{completedMatchCount} / {totalMatchCount} matches completed",
+  "@scheduleHistoryCompletedMatchesLabel": {
+    "description": "Progress label showing completed and total match counts in doubles schedule history.",
+    "placeholders": {
+      "completedMatchCount": {
+        "type": "int",
+        "example": "8"
+      },
+      "totalMatchCount": {
+        "type": "int",
+        "example": "12"
       }
     }
   },

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -306,7 +306,7 @@
   },
   "scheduleDataEmptyMessage": "対戦表データがありません",
   "@scheduleDataEmptyMessage": {
-    "description": "Message shown when the schedule response contains no rounds."
+    "description": "Message shown when no schedule response contains rounds."
   },
   "restLabel": "休憩",
   "@restLabel": {
@@ -329,6 +329,34 @@
       "lastOpenedAt": {
         "type": "String",
         "example": "2026/05/22 23:10"
+      }
+    }
+  },
+  "scheduleHistoryCreatedAtLabel": "{createdAt} 作成",
+  "@scheduleHistoryCreatedAtLabel": {
+    "description": "Label showing the creation date of a saved doubles schedule.",
+    "placeholders": {
+      "createdAt": {
+        "type": "String",
+        "example": "2026/08/14"
+      }
+    }
+  },
+  "scheduleHistoryUnconfirmedLabel": "未確定",
+  "@scheduleHistoryUnconfirmedLabel": {
+    "description": "Label shown for a saved doubles schedule that has not been confirmed."
+  },
+  "scheduleHistoryCompletedMatchesLabel": "{completedMatchCount} / {totalMatchCount} 試合終了",
+  "@scheduleHistoryCompletedMatchesLabel": {
+    "description": "Progress label showing completed and total match counts in doubles schedule history.",
+    "placeholders": {
+      "completedMatchCount": {
+        "type": "int",
+        "example": "8"
+      },
+      "totalMatchCount": {
+        "type": "int",
+        "example": "12"
       }
     }
   },
@@ -1410,11 +1438,11 @@
   },
   "doublesMatchStartTimeLabel": "開始時間",
   "@doublesMatchStartTimeLabel": {
-    "description": "Label for a doubles match start time."
+    "description": "Input label for a doubles match start time."
   },
   "doublesMatchEndTimeLabel": "終了時間",
   "@doublesMatchEndTimeLabel": {
-    "description": "Label for a doubles match end time."
+    "description": "Input label for a doubles match end time."
   },
   "doublesMatchSetCurrentTimeTooltip": "現在時刻を設定",
   "@doublesMatchSetCurrentTimeTooltip": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -250,7 +250,7 @@
   },
   "adoptScheduleFailedMessage": "対戦表を確定できませんでした: {error}",
   "@adoptScheduleFailedMessage": {
-    "description": "Message shown when schedule adoption failed.",
+    "description": "Error message shown when schedule adoption failed.",
     "placeholders": {
       "error": {
         "type": "String",
@@ -306,7 +306,7 @@
   },
   "scheduleDataEmptyMessage": "対戦表データがありません",
   "@scheduleDataEmptyMessage": {
-    "description": "Message shown when no schedule response contains rounds."
+    "description": "Message shown when the schedule response contains no rounds."
   },
   "restLabel": "休憩",
   "@restLabel": {
@@ -1438,11 +1438,11 @@
   },
   "doublesMatchStartTimeLabel": "開始時間",
   "@doublesMatchStartTimeLabel": {
-    "description": "Input label for a doubles match start time."
+    "description": "Label for a doubles match start time."
   },
   "doublesMatchEndTimeLabel": "終了時間",
   "@doublesMatchEndTimeLabel": {
-    "description": "Input label for a doubles match end time."
+    "description": "Label for a doubles match end time."
   },
   "doublesMatchSetCurrentTimeTooltip": "現在時刻を設定",
   "@doublesMatchSetCurrentTimeTooltip": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -422,7 +422,7 @@ abstract class AppLocalizations {
   /// **'この対戦表を確定しました'**
   String get adoptScheduleCompletedMessage;
 
-  /// Message shown when schedule adoption failed.
+  /// Error message shown when schedule adoption failed.
   ///
   /// In ja, this message translates to:
   /// **'対戦表を確定できませんでした: {error}'**
@@ -482,7 +482,7 @@ abstract class AppLocalizations {
   /// **'対戦表を取得できていません'**
   String get scheduleNotLoadedMessage;
 
-  /// Message shown when no schedule response contains rounds.
+  /// Message shown when the schedule response contains no rounds.
   ///
   /// In ja, this message translates to:
   /// **'対戦表データがありません'**
@@ -1704,13 +1704,13 @@ abstract class AppLocalizations {
   /// **'スコアを未入力に戻す'**
   String get doublesMatchScoreUnsetLabel;
 
-  /// Input label for a doubles match start time.
+  /// Label for a doubles match start time.
   ///
   /// In ja, this message translates to:
   /// **'開始時間'**
   String get doublesMatchStartTimeLabel;
 
-  /// Input label for a doubles match end time.
+  /// Label for a doubles match end time.
   ///
   /// In ja, this message translates to:
   /// **'終了時間'**

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -482,7 +482,7 @@ abstract class AppLocalizations {
   /// **'対戦表を取得できていません'**
   String get scheduleNotLoadedMessage;
 
-  /// Message shown when the schedule response contains no rounds.
+  /// Message shown when no schedule response contains rounds.
   ///
   /// In ja, this message translates to:
   /// **'対戦表データがありません'**
@@ -505,6 +505,25 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'最終表示: {lastOpenedAt}'**
   String lastOpenedAtLabel(String lastOpenedAt);
+
+  /// Label showing the creation date of a saved doubles schedule.
+  ///
+  /// In ja, this message translates to:
+  /// **'{createdAt} 作成'**
+  String scheduleHistoryCreatedAtLabel(String createdAt);
+
+  /// Label shown for a saved doubles schedule that has not been confirmed.
+  ///
+  /// In ja, this message translates to:
+  /// **'未確定'**
+  String get scheduleHistoryUnconfirmedLabel;
+
+  /// Progress label showing completed and total match counts in doubles schedule history.
+  ///
+  /// In ja, this message translates to:
+  /// **'{completedMatchCount} / {totalMatchCount} 試合終了'**
+  String scheduleHistoryCompletedMatchesLabel(
+      int completedMatchCount, int totalMatchCount);
 
   /// Tooltip for removing a player input field.
   ///
@@ -1685,13 +1704,13 @@ abstract class AppLocalizations {
   /// **'スコアを未入力に戻す'**
   String get doublesMatchScoreUnsetLabel;
 
-  /// Label for a doubles match start time.
+  /// Input label for a doubles match start time.
   ///
   /// In ja, this message translates to:
   /// **'開始時間'**
   String get doublesMatchStartTimeLabel;
 
-  /// Label for a doubles match end time.
+  /// Input label for a doubles match end time.
   ///
   /// In ja, this message translates to:
   /// **'終了時間'**

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -241,6 +241,20 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String scheduleHistoryCreatedAtLabel(String createdAt) {
+    return 'Created $createdAt';
+  }
+
+  @override
+  String get scheduleHistoryUnconfirmedLabel => 'Unconfirmed';
+
+  @override
+  String scheduleHistoryCompletedMatchesLabel(
+      int completedMatchCount, int totalMatchCount) {
+    return '$completedMatchCount / $totalMatchCount matches completed';
+  }
+
+  @override
   String get removePlayerTooltip => 'Remove this player';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -234,6 +234,20 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String scheduleHistoryCreatedAtLabel(String createdAt) {
+    return '$createdAt 作成';
+  }
+
+  @override
+  String get scheduleHistoryUnconfirmedLabel => '未確定';
+
+  @override
+  String scheduleHistoryCompletedMatchesLabel(
+      int completedMatchCount, int totalMatchCount) {
+    return '$completedMatchCount / $totalMatchCount 試合終了';
+  }
+
+  @override
   String get removePlayerTooltip => 'この参加者を削除';
 
   @override

--- a/test/features/doubles_scheduler/data/local_schedule_history_item_test.dart
+++ b/test/features/doubles_scheduler/data/local_schedule_history_item_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:srp_lanske/features/doubles_scheduler/data/local_schedule_history_item.dart';
+
+void main() {
+  test('round trips schedule list metadata', () {
+    final item = LocalScheduleHistoryItem(
+      publicId: 'ABCDEFGH',
+      title: 'Test event',
+      courtCount: 2,
+      playerCount: 8,
+      createdAt: DateTime.utc(2026, 8, 10, 1),
+      firstSavedAt: DateTime.utc(2026, 8, 10, 2),
+      lastOpenedAt: DateTime.utc(2026, 8, 10, 3),
+      generatedScheduleId: 'schedule-1',
+      isAdopted: true,
+      completedMatchCount: 8,
+      totalMatchCount: 12,
+    );
+
+    final restored = LocalScheduleHistoryItem.fromJson(item.toJson());
+
+    expect(restored.generatedScheduleId, 'schedule-1');
+    expect(restored.isAdopted, isTrue);
+    expect(restored.completedMatchCount, 8);
+    expect(restored.totalMatchCount, 12);
+    expect(restored.createdAt, item.createdAt);
+  });
+
+  test('keeps new metadata nullable for legacy history', () {
+    final restored = LocalScheduleHistoryItem.fromJson({
+      'public_id': 'ABCDEFGH',
+      'title': 'Legacy event',
+      'court_count': 1,
+      'player_count': 6,
+      'created_at': '2026-08-10T01:00:00.000Z',
+      'first_saved_at': '2026-08-10T02:00:00.000Z',
+      'last_opened_at': '2026-08-10T03:00:00.000Z',
+    });
+
+    expect(restored.generatedScheduleId, isNull);
+    expect(restored.isAdopted, isNull);
+    expect(restored.completedMatchCount, isNull);
+    expect(restored.totalMatchCount, isNull);
+  });
+
+  test('uses last opened time as stable legacy created-at fallback', () {
+    final restored = LocalScheduleHistoryItem.fromJson({
+      'public_id': 'ABCDEFGH',
+      'title': 'Legacy event',
+      'court_count': 1,
+      'participant_count': 6,
+      'last_opened_at': '2026-08-10T03:00:00.000Z',
+    });
+
+    final expected = DateTime.parse('2026-08-10T03:00:00.000Z');
+    expect(restored.createdAt, expected);
+    expect(restored.firstSavedAt, expected);
+    expect(restored.lastOpenedAt, expected);
+    expect(restored.playerCount, 6);
+  });
+}

--- a/test/features/doubles_scheduler/data/local_schedule_history_store_test.dart
+++ b/test/features/doubles_scheduler/data/local_schedule_history_store_test.dart
@@ -78,7 +78,8 @@ void main() {
     expect(item.totalMatchCount, 12);
   });
 
-  test('upsert clears stale progress when generated schedule changes', () async {
+  test('upsert clears stale progress when generated schedule changes',
+      () async {
     final store = LocalScheduleHistoryStore();
     await store.upsert(
       _item(

--- a/test/features/doubles_scheduler/data/local_schedule_history_store_test.dart
+++ b/test/features/doubles_scheduler/data/local_schedule_history_store_test.dart
@@ -1,0 +1,197 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:srp_lanske/features/doubles_scheduler/data/local_schedule_history_item.dart';
+import 'package:srp_lanske/features/doubles_scheduler/data/local_schedule_history_store.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(const {});
+  });
+
+  test('findAll sorts by createdAt instead of lastOpenedAt', () async {
+    final store = LocalScheduleHistoryStore();
+    await store.upsert(
+      _item(
+        publicId: 'OLDER',
+        createdAt: DateTime(2026, 8, 10),
+        lastOpenedAt: DateTime(2026, 8, 14),
+      ),
+    );
+    await store.upsert(
+      _item(
+        publicId: 'NEWER',
+        createdAt: DateTime(2026, 8, 13),
+        lastOpenedAt: DateTime(2026, 8, 13),
+      ),
+    );
+
+    final items = await store.findAll();
+
+    expect(items.map((item) => item.publicId), ['NEWER', 'OLDER']);
+  });
+
+  test('retains the 20 most recently opened items', () async {
+    final store = LocalScheduleHistoryStore();
+
+    for (var i = 0; i < 21; i += 1) {
+      await store.upsert(
+        _item(
+          publicId: 'ID$i',
+          createdAt: DateTime(2026, 8, 1).add(Duration(days: i)),
+          lastOpenedAt: DateTime(2026, 8, 1).add(Duration(hours: i)),
+        ),
+      );
+    }
+
+    final items = await store.findAll();
+
+    expect(items, hasLength(20));
+    expect(items.any((item) => item.publicId == 'ID0'), isFalse);
+  });
+
+  test('upsert preserves progress for the same generated schedule', () async {
+    final store = LocalScheduleHistoryStore();
+    await store.upsert(
+      _item(
+        publicId: 'ABCDEFGH',
+        createdAt: DateTime(2026, 8, 10),
+        lastOpenedAt: DateTime(2026, 8, 10),
+        generatedScheduleId: 'schedule-1',
+        isAdopted: true,
+        completedMatchCount: 4,
+        totalMatchCount: 12,
+      ),
+    );
+
+    await store.upsert(
+      _item(
+        publicId: 'ABCDEFGH',
+        createdAt: DateTime(2026, 8, 10),
+        lastOpenedAt: DateTime(2026, 8, 11),
+        generatedScheduleId: 'schedule-1',
+        isAdopted: true,
+      ),
+    );
+
+    final item = (await store.findAll()).single;
+    expect(item.completedMatchCount, 4);
+    expect(item.totalMatchCount, 12);
+  });
+
+  test('upsert clears stale progress when generated schedule changes', () async {
+    final store = LocalScheduleHistoryStore();
+    await store.upsert(
+      _item(
+        publicId: 'ABCDEFGH',
+        createdAt: DateTime(2026, 8, 10),
+        lastOpenedAt: DateTime(2026, 8, 10),
+        generatedScheduleId: 'schedule-1',
+        isAdopted: false,
+        completedMatchCount: 4,
+        totalMatchCount: 12,
+      ),
+    );
+
+    await store.upsert(
+      _item(
+        publicId: 'ABCDEFGH',
+        createdAt: DateTime(2026, 8, 10),
+        lastOpenedAt: DateTime(2026, 8, 11),
+        generatedScheduleId: 'schedule-2',
+        isAdopted: false,
+      ),
+    );
+
+    final item = (await store.findAll()).single;
+    expect(item.generatedScheduleId, 'schedule-2');
+    expect(item.completedMatchCount, isNull);
+    expect(item.totalMatchCount, isNull);
+  });
+
+  test('updateProgress updates matching schedule without changing metadata',
+      () async {
+    final store = LocalScheduleHistoryStore();
+    final createdAt = DateTime(2026, 8, 10);
+    final firstSavedAt = DateTime(2026, 8, 10, 1);
+    await store.upsert(
+      _item(
+        publicId: 'ABCDEFGH',
+        createdAt: createdAt,
+        firstSavedAt: firstSavedAt,
+        lastOpenedAt: DateTime(2026, 8, 10, 2),
+        generatedScheduleId: 'schedule-1',
+        isAdopted: true,
+        completedMatchCount: 0,
+        totalMatchCount: 12,
+      ),
+    );
+
+    final updatedAt = DateTime(2026, 8, 10, 3);
+    await store.updateProgress(
+      publicId: 'ABCDEFGH',
+      generatedScheduleId: 'schedule-1',
+      completedMatchCount: 5,
+      totalMatchCount: 12,
+      lastOpenedAt: updatedAt,
+    );
+
+    final item = (await store.findAll()).single;
+    expect(item.createdAt, createdAt);
+    expect(item.firstSavedAt, firstSavedAt);
+    expect(item.lastOpenedAt, updatedAt);
+    expect(item.completedMatchCount, 5);
+    expect(item.totalMatchCount, 12);
+    expect(item.isAdopted, isTrue);
+  });
+
+  test('updateProgress ignores a stale generated schedule', () async {
+    final store = LocalScheduleHistoryStore();
+    await store.upsert(
+      _item(
+        publicId: 'ABCDEFGH',
+        createdAt: DateTime(2026, 8, 10),
+        lastOpenedAt: DateTime(2026, 8, 10),
+        generatedScheduleId: 'schedule-2',
+        isAdopted: false,
+      ),
+    );
+
+    await store.updateProgress(
+      publicId: 'ABCDEFGH',
+      generatedScheduleId: 'schedule-1',
+      completedMatchCount: 5,
+      totalMatchCount: 12,
+    );
+
+    final item = (await store.findAll()).single;
+    expect(item.generatedScheduleId, 'schedule-2');
+    expect(item.completedMatchCount, isNull);
+    expect(item.totalMatchCount, isNull);
+    expect(item.isAdopted, isFalse);
+  });
+}
+
+LocalScheduleHistoryItem _item({
+  required String publicId,
+  required DateTime createdAt,
+  required DateTime lastOpenedAt,
+  DateTime? firstSavedAt,
+  String? generatedScheduleId,
+  bool? isAdopted,
+  int? completedMatchCount,
+  int? totalMatchCount,
+}) {
+  return LocalScheduleHistoryItem(
+    publicId: publicId,
+    title: publicId,
+    courtCount: 2,
+    playerCount: 8,
+    createdAt: createdAt,
+    firstSavedAt: firstSavedAt ?? createdAt,
+    lastOpenedAt: lastOpenedAt,
+    generatedScheduleId: generatedScheduleId,
+    isAdopted: isAdopted,
+    completedMatchCount: completedMatchCount,
+    totalMatchCount: totalMatchCount,
+  );
+}


### PR DESCRIPTION
Closes #139

## Summary

ダブルス対戦表一覧に、作成日・確定状態・試合進行状況を表示するようにしました。

- ローカル履歴に確定状態と試合進行情報を保持
- 対戦表一覧を作成日の新しい順で表示
- 作成日時は日付のみ表示
- 未確定の対戦表は「未確定」と表示
- 確定済みの対戦表は「終了試合数 / 全試合数 試合終了」と表示
- 一覧表示時の追加リモート取得は行わず、対戦表を開いた際や試合結果保存時にローカル履歴を更新
- 再生成時に旧 generated schedule の進行情報を引き継がないように対応
- 旧ローカル履歴との互換性を維持
- 表示順とは別に、ローカル履歴20件の保持は最終表示日時を基準に継続

## Verification

- `flutter gen-l10n`
- `dart format lib/ test/`
- `flutter analyze`
- `flutter test`
- `git diff --check`
- ダブルス対戦表一覧の画面確認
  - 未確定表示
  - 確定済みの進行状況表示
  - 作成日の表示
  - 過去履歴を開いた際のローカル履歴更新