### PR TITLE
🗑️ Add selection and hide flow to doubles schedule history refs #140

### DIFF
--- a/lib/features/doubles_scheduler/data/local_schedule_history_item.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_item.dart
@@ -11,6 +11,7 @@ class LocalScheduleHistoryItem {
     this.isAdopted,
     this.completedMatchCount,
     this.totalMatchCount,
+    this.isPendingRemoval = false,
   });
 
   final String publicId;
@@ -24,6 +25,7 @@ class LocalScheduleHistoryItem {
   final bool? isAdopted;
   final int? completedMatchCount;
   final int? totalMatchCount;
+  final bool isPendingRemoval;
 
   Map<String, dynamic> toJson() {
     return {
@@ -38,11 +40,11 @@ class LocalScheduleHistoryItem {
       'is_adopted': isAdopted,
       'completed_match_count': completedMatchCount,
       'total_match_count': totalMatchCount,
+      'is_pending_removal': isPendingRemoval,
     };
   }
 
   static LocalScheduleHistoryItem fromJson(Map<String, dynamic> json) {
-    // TODO(ver0.2): Remove the legacy participant_count fallback.
     final rawPlayerCount = json['player_count'] ?? json['participant_count'];
     final fallbackNow = DateTime.now();
     final lastOpenedAt =
@@ -71,6 +73,7 @@ class LocalScheduleHistoryItem {
       isAdopted: json['is_adopted'] as bool?,
       completedMatchCount: json['completed_match_count'] as int?,
       totalMatchCount: json['total_match_count'] as int?,
+      isPendingRemoval: json['is_pending_removal'] as bool? ?? false,
     );
   }
 }

--- a/lib/features/doubles_scheduler/data/local_schedule_history_policy.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_policy.dart
@@ -1,0 +1,6 @@
+class LocalScheduleHistoryPolicy {
+  const LocalScheduleHistoryPolicy._();
+
+  static const displayLimit = 20;
+  static const storageLimit = 100;
+}

--- a/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
@@ -179,18 +179,16 @@ class LocalScheduleHistoryStore {
   Future<int> suppressPendingRemoval() async {
     final prefs = await SharedPreferences.getInstance();
     final current = await _readAll(prefs);
-    final pending = current
-        .where((item) => item.isPendingRemoval)
-        .toList(growable: false);
+    final pending =
+        current.where((item) => item.isPendingRemoval).toList(growable: false);
     if (pending.isEmpty) {
       return 0;
     }
 
     final suppressedPublicIds = _readSuppressedPublicIds(prefs)
       ..addAll(pending.map((item) => _normalizePublicId(item.publicId)));
-    final retained = current
-        .where((item) => !item.isPendingRemoval)
-        .toList(growable: false);
+    final retained =
+        current.where((item) => !item.isPendingRemoval).toList(growable: false);
 
     await _saveSuppressedPublicIds(prefs, suppressedPublicIds);
     await _saveRetained(prefs, retained);

--- a/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
@@ -3,15 +3,22 @@ import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'local_schedule_history_item.dart';
+import 'local_schedule_history_policy.dart';
 
 class LocalScheduleHistoryStore {
   static const _key = 'lanske_recent_schedules';
-  static const _maxItems = 20;
+  static const _suppressedKey = 'lanske_suppressed_schedule_ids';
 
   Future<List<LocalScheduleHistoryItem>> findAll() async {
-    final items = await _readAll();
-
-    return items
+    final prefs = await SharedPreferences.getInstance();
+    final suppressedPublicIds = _readSuppressedPublicIds(prefs);
+    final items = await _readAll(prefs);
+    final visibleItems = items
+        .where(
+          (item) =>
+              !suppressedPublicIds.contains(_normalizePublicId(item.publicId)),
+        )
+        .toList(growable: true)
       ..sort((a, b) {
         final createdAtComparison = b.createdAt.compareTo(a.createdAt);
         if (createdAtComparison != 0) {
@@ -19,11 +26,20 @@ class LocalScheduleHistoryStore {
         }
         return b.lastOpenedAt.compareTo(a.lastOpenedAt);
       });
+
+    return visibleItems
+        .take(LocalScheduleHistoryPolicy.displayLimit)
+        .toList(growable: false);
   }
 
   Future<void> upsert(LocalScheduleHistoryItem item) async {
     final prefs = await SharedPreferences.getInstance();
-    final current = await _readAll();
+    final normalizedPublicId = _normalizePublicId(item.publicId);
+    if (_readSuppressedPublicIds(prefs).contains(normalizedPublicId)) {
+      return;
+    }
+
+    final current = await _readAll(prefs);
     final existing = {
       for (final currentItem in current) currentItem.publicId: currentItem,
     };
@@ -57,6 +73,8 @@ class LocalScheduleHistoryStore {
           : sameGeneratedSchedule
               ? previous.totalMatchCount
               : null,
+      isPendingRemoval:
+          (previous?.isPendingRemoval ?? false) || item.isPendingRemoval,
     );
 
     await _saveRetained(prefs, existing.values);
@@ -69,16 +87,20 @@ class LocalScheduleHistoryStore {
     required int totalMatchCount,
     DateTime? lastOpenedAt,
   }) async {
-    final normalizedPublicId = publicId.trim().toUpperCase();
+    final normalizedPublicId = _normalizePublicId(publicId);
     final normalizedGeneratedScheduleId = generatedScheduleId.trim();
     if (normalizedPublicId.isEmpty || normalizedGeneratedScheduleId.isEmpty) {
       return;
     }
 
     final prefs = await SharedPreferences.getInstance();
-    final current = await _readAll();
+    if (_readSuppressedPublicIds(prefs).contains(normalizedPublicId)) {
+      return;
+    }
+
+    final current = await _readAll(prefs);
     final index = current.indexWhere(
-      (item) => item.publicId.trim().toUpperCase() == normalizedPublicId,
+      (item) => _normalizePublicId(item.publicId) == normalizedPublicId,
     );
     if (index < 0) {
       return;
@@ -104,40 +126,123 @@ class LocalScheduleHistoryStore {
       isAdopted: true,
       completedMatchCount: completedMatchCount,
       totalMatchCount: totalMatchCount,
+      isPendingRemoval: item.isPendingRemoval,
     );
 
     await _saveRetained(prefs, current);
   }
 
+  Future<void> setPendingRemoval({
+    required String publicId,
+    required bool isPendingRemoval,
+  }) async {
+    await setPendingRemovalForPublicIds(
+      [publicId],
+      isPendingRemoval: isPendingRemoval,
+    );
+  }
+
+  Future<void> setPendingRemovalForPublicIds(
+    Iterable<String> publicIds, {
+    required bool isPendingRemoval,
+  }) async {
+    final normalizedPublicIds = publicIds
+        .map(_normalizePublicId)
+        .where((publicId) => publicId.isNotEmpty)
+        .toSet();
+    if (normalizedPublicIds.isEmpty) {
+      return;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    final current = await _readAll(prefs);
+    var changed = false;
+
+    for (var index = 0; index < current.length; index += 1) {
+      final item = current[index];
+      if (!normalizedPublicIds.contains(_normalizePublicId(item.publicId)) ||
+          item.isPendingRemoval == isPendingRemoval) {
+        continue;
+      }
+
+      current[index] = _copyWithPendingRemoval(item, isPendingRemoval);
+      changed = true;
+    }
+
+    if (!changed) {
+      return;
+    }
+
+    await _saveRetained(prefs, current);
+  }
+
+  Future<int> suppressPendingRemoval() async {
+    final prefs = await SharedPreferences.getInstance();
+    final current = await _readAll(prefs);
+    final pending = current
+        .where((item) => item.isPendingRemoval)
+        .toList(growable: false);
+    if (pending.isEmpty) {
+      return 0;
+    }
+
+    final suppressedPublicIds = _readSuppressedPublicIds(prefs)
+      ..addAll(pending.map((item) => _normalizePublicId(item.publicId)));
+    final retained = current
+        .where((item) => !item.isPendingRemoval)
+        .toList(growable: false);
+
+    await _saveSuppressedPublicIds(prefs, suppressedPublicIds);
+    await _saveRetained(prefs, retained);
+    return pending.length;
+  }
+
   Future<void> clearAll() async {
     final prefs = await SharedPreferences.getInstance();
+    final current = await _readAll(prefs);
+    if (current.isEmpty) {
+      await prefs.remove(_key);
+      return;
+    }
+
+    final suppressedPublicIds = _readSuppressedPublicIds(prefs)
+      ..addAll(current.map((item) => _normalizePublicId(item.publicId)));
+    await _saveSuppressedPublicIds(prefs, suppressedPublicIds);
     await prefs.remove(_key);
   }
 
   Future<void> clearExceptPublicId(String publicId) async {
-    final keepPublicId = publicId.trim().toUpperCase();
+    final keepPublicId = _normalizePublicId(publicId);
     if (keepPublicId.isEmpty) {
       await clearAll();
       return;
     }
 
     final prefs = await SharedPreferences.getInstance();
-    final current = await _readAll();
-    final kept = current
-        .where((item) => item.publicId.trim().toUpperCase() == keepPublicId)
-        .map((item) => item.toJson())
-        .toList(growable: false);
+    final current = await _readAll(prefs);
+    final suppressedPublicIds = _readSuppressedPublicIds(prefs);
+    final kept = <LocalScheduleHistoryItem>[];
 
+    for (final item in current) {
+      if (_normalizePublicId(item.publicId) == keepPublicId) {
+        kept.add(item);
+      } else {
+        suppressedPublicIds.add(_normalizePublicId(item.publicId));
+      }
+    }
+
+    await _saveSuppressedPublicIds(prefs, suppressedPublicIds);
     if (kept.isEmpty) {
       await prefs.remove(_key);
       return;
     }
 
-    await prefs.setString(_key, jsonEncode(kept));
+    await _saveRetained(prefs, kept);
   }
 
-  Future<List<LocalScheduleHistoryItem>> _readAll() async {
-    final prefs = await SharedPreferences.getInstance();
+  Future<List<LocalScheduleHistoryItem>> _readAll(
+    SharedPreferences prefs,
+  ) async {
     final raw = prefs.getString(_key);
     if (raw == null || raw.isEmpty) return <LocalScheduleHistoryItem>[];
 
@@ -151,6 +256,21 @@ class LocalScheduleHistoryStore {
         .toList(growable: true);
   }
 
+  Set<String> _readSuppressedPublicIds(SharedPreferences prefs) {
+    return (prefs.getStringList(_suppressedKey) ?? const <String>[])
+        .map(_normalizePublicId)
+        .where((publicId) => publicId.isNotEmpty)
+        .toSet();
+  }
+
+  Future<void> _saveSuppressedPublicIds(
+    SharedPreferences prefs,
+    Set<String> publicIds,
+  ) async {
+    final values = publicIds.toList(growable: false)..sort();
+    await prefs.setStringList(_suppressedKey, values);
+  }
+
   Future<void> _saveRetained(
     SharedPreferences prefs,
     Iterable<LocalScheduleHistoryItem> items,
@@ -158,10 +278,39 @@ class LocalScheduleHistoryStore {
     final retained = items.toList(growable: false)
       ..sort((a, b) => b.lastOpenedAt.compareTo(a.lastOpenedAt));
     final encoded = retained
-        .take(_maxItems)
+        .take(LocalScheduleHistoryPolicy.storageLimit)
         .map((item) => item.toJson())
         .toList(growable: false);
 
+    if (encoded.isEmpty) {
+      await prefs.remove(_key);
+      return;
+    }
+
     await prefs.setString(_key, jsonEncode(encoded));
+  }
+
+  LocalScheduleHistoryItem _copyWithPendingRemoval(
+    LocalScheduleHistoryItem item,
+    bool isPendingRemoval,
+  ) {
+    return LocalScheduleHistoryItem(
+      publicId: item.publicId,
+      title: item.title,
+      courtCount: item.courtCount,
+      playerCount: item.playerCount,
+      createdAt: item.createdAt,
+      firstSavedAt: item.firstSavedAt,
+      lastOpenedAt: item.lastOpenedAt,
+      generatedScheduleId: item.generatedScheduleId,
+      isAdopted: item.isAdopted,
+      completedMatchCount: item.completedMatchCount,
+      totalMatchCount: item.totalMatchCount,
+      isPendingRemoval: isPendingRemoval,
+    );
+  }
+
+  String _normalizePublicId(String publicId) {
+    return publicId.trim().toUpperCase();
   }
 }

--- a/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
+++ b/lib/features/doubles_scheduler/data/local_schedule_history_store.dart
@@ -132,6 +132,87 @@ class LocalScheduleHistoryStore {
     await _saveRetained(prefs, current);
   }
 
+  Future<void> replacePendingRemovalForPublicIds({
+    required Iterable<String> visiblePublicIds,
+    required Iterable<String> pendingPublicIds,
+  }) async {
+    final normalizedVisiblePublicIds = visiblePublicIds
+        .map(_normalizePublicId)
+        .where((publicId) => publicId.isNotEmpty)
+        .toSet();
+    if (normalizedVisiblePublicIds.isEmpty) {
+      return;
+    }
+
+    final normalizedPendingPublicIds = pendingPublicIds
+        .map(_normalizePublicId)
+        .where(normalizedVisiblePublicIds.contains)
+        .toSet();
+    final prefs = await SharedPreferences.getInstance();
+    final current = await _readAll(prefs);
+    var changed = false;
+
+    for (var index = 0; index < current.length; index += 1) {
+      final item = current[index];
+      final normalizedPublicId = _normalizePublicId(item.publicId);
+      if (!normalizedVisiblePublicIds.contains(normalizedPublicId)) {
+        continue;
+      }
+
+      final isPendingRemoval =
+          normalizedPendingPublicIds.contains(normalizedPublicId);
+      if (item.isPendingRemoval == isPendingRemoval) {
+        continue;
+      }
+
+      current[index] = _copyWithPendingRemoval(item, isPendingRemoval);
+      changed = true;
+    }
+
+    if (!changed) {
+      return;
+    }
+
+    await _saveRetained(prefs, current);
+  }
+
+  Future<int> suppressPublicIds(Iterable<String> publicIds) async {
+    final normalizedPublicIds = publicIds
+        .map(_normalizePublicId)
+        .where((publicId) => publicId.isNotEmpty)
+        .toSet();
+    if (normalizedPublicIds.isEmpty) {
+      return 0;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    final current = await _readAll(prefs);
+    final targets = current
+        .where(
+          (item) => normalizedPublicIds.contains(
+            _normalizePublicId(item.publicId),
+          ),
+        )
+        .toList(growable: false);
+    if (targets.isEmpty) {
+      return 0;
+    }
+
+    final suppressedPublicIds = _readSuppressedPublicIds(prefs)
+      ..addAll(targets.map((item) => _normalizePublicId(item.publicId)));
+    final retained = current
+        .where(
+          (item) => !normalizedPublicIds.contains(
+            _normalizePublicId(item.publicId),
+          ),
+        )
+        .toList(growable: false);
+
+    await _saveSuppressedPublicIds(prefs, suppressedPublicIds);
+    await _saveRetained(prefs, retained);
+    return targets.length;
+  }
+
   Future<void> setPendingRemoval({
     required String publicId,
     required bool isPendingRemoval,
@@ -179,20 +260,12 @@ class LocalScheduleHistoryStore {
   Future<int> suppressPendingRemoval() async {
     final prefs = await SharedPreferences.getInstance();
     final current = await _readAll(prefs);
-    final pending =
-        current.where((item) => item.isPendingRemoval).toList(growable: false);
-    if (pending.isEmpty) {
-      return 0;
-    }
+    final pendingPublicIds = current
+        .where((item) => item.isPendingRemoval)
+        .map((item) => item.publicId)
+        .toList(growable: false);
 
-    final suppressedPublicIds = _readSuppressedPublicIds(prefs)
-      ..addAll(pending.map((item) => _normalizePublicId(item.publicId)));
-    final retained =
-        current.where((item) => !item.isPendingRemoval).toList(growable: false);
-
-    await _saveSuppressedPublicIds(prefs, suppressedPublicIds);
-    await _saveRetained(prefs, retained);
-    return pending.length;
+    return suppressPublicIds(pendingPublicIds);
   }
 
   Future<void> clearAll() async {

--- a/lib/features/doubles_scheduler/presentation/doubles_schedule_list_drawer.dart
+++ b/lib/features/doubles_scheduler/presentation/doubles_schedule_list_drawer.dart
@@ -1,10 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
 
 import '../data/local_schedule_history_item.dart';
 import 'widgets/schedule_history_list_view.dart';
 
-class DoublesScheduleListDrawer extends StatelessWidget {
+class DoublesScheduleListDrawer extends StatefulWidget {
   const DoublesScheduleListDrawer({
     super.key,
     required this.onOpenSchedule,
@@ -20,14 +22,40 @@ class DoublesScheduleListDrawer extends StatelessWidget {
   }
 
   @override
+  State<DoublesScheduleListDrawer> createState() =>
+      _DoublesScheduleListDrawerState();
+}
+
+class _DoublesScheduleListDrawerState extends State<DoublesScheduleListDrawer> {
+  final _historyController = ScheduleHistoryListController();
+
+  @override
+  void dispose() {
+    unawaited(_historyController.flushSelection());
+    super.dispose();
+  }
+
+  Future<void> _closeDrawer() async {
+    await _historyController.flushSelection();
+    if (!mounted) return;
+    Navigator.of(context).pop();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Drawer(
-      width: widthFor(context),
-      child: SafeArea(
-        child: DoublesScheduleListPanel(
-          reloadToken: reloadToken,
-          onBack: () => Navigator.of(context).pop(),
-          onOpenSchedule: onOpenSchedule,
+    return PopScope(
+      onPopInvokedWithResult: (_, __) {
+        unawaited(_historyController.flushSelection());
+      },
+      child: Drawer(
+        width: DoublesScheduleListDrawer.widthFor(context),
+        child: SafeArea(
+          child: DoublesScheduleListPanel(
+            reloadToken: widget.reloadToken,
+            historyController: _historyController,
+            onBack: _closeDrawer,
+            onOpenSchedule: widget.onOpenSchedule,
+          ),
         ),
       ),
     );
@@ -40,11 +68,13 @@ class DoublesScheduleListPanel extends StatelessWidget {
     required this.onBack,
     required this.onOpenSchedule,
     this.reloadToken = 0,
+    this.historyController,
   });
 
   final VoidCallback onBack;
   final ValueChanged<LocalScheduleHistoryItem> onOpenSchedule;
   final int reloadToken;
+  final ScheduleHistoryListController? historyController;
 
   @override
   Widget build(BuildContext context) {
@@ -68,6 +98,7 @@ class DoublesScheduleListPanel extends StatelessWidget {
           child: ScheduleHistoryListView(
             padding: const EdgeInsets.all(12),
             reloadToken: reloadToken,
+            controller: historyController,
             onOpenSchedule: onOpenSchedule,
           ),
         ),

--- a/lib/features/doubles_scheduler/presentation/event_list_page.dart
+++ b/lib/features/doubles_scheduler/presentation/event_list_page.dart
@@ -83,7 +83,6 @@ class _EventListPageState extends State<EventListPage> {
       builder: (context) {
         return AlertDialog(
           title: Text(l10n.clearScheduleHistoryConfirmTitle),
-          content: Text(l10n.clearScheduleHistoryConfirmBody),
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(context, false),

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
 import 'package:srp_lanske/shared/presentation/app_message_type.dart';
@@ -6,6 +8,25 @@ import 'package:srp_lanske/shared/presentation/app_snack_bar.dart';
 import '../../data/local_schedule_history_item.dart';
 import '../../data/local_schedule_history_store.dart';
 
+class ScheduleHistoryListController {
+  Future<void> Function()? _flushSelection;
+
+  Future<void> flushSelection() async {
+    final flushSelection = _flushSelection;
+    if (flushSelection != null) {
+      await flushSelection();
+    }
+  }
+
+  void _attach(Future<void> Function() flushSelection) {
+    _flushSelection = flushSelection;
+  }
+
+  void _detach() {
+    _flushSelection = null;
+  }
+}
+
 class ScheduleHistoryListView extends StatefulWidget {
   const ScheduleHistoryListView({
     super.key,
@@ -13,12 +34,14 @@ class ScheduleHistoryListView extends StatefulWidget {
     this.padding = const EdgeInsets.all(16),
     this.reloadToken = 0,
     this.onItemsLoaded,
+    this.controller,
   });
 
   final ValueChanged<LocalScheduleHistoryItem> onOpenSchedule;
   final EdgeInsetsGeometry padding;
   final int reloadToken;
   final ValueChanged<List<LocalScheduleHistoryItem>>? onItemsLoaded;
+  final ScheduleHistoryListController? controller;
 
   @override
   State<ScheduleHistoryListView> createState() =>
@@ -27,28 +50,56 @@ class ScheduleHistoryListView extends StatefulWidget {
 
 class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
   final LocalScheduleHistoryStore _historyStore = LocalScheduleHistoryStore();
+  final Set<String> _draftPendingPublicIds = <String>{};
+  final Set<String> _persistedPendingPublicIds = <String>{};
+  Set<String> _visiblePublicIds = <String>{};
 
   late Future<List<LocalScheduleHistoryItem>> _itemsFuture;
   bool _selectionMode = false;
   bool _isUpdating = false;
+  bool _selectionDraftInitialized = false;
 
   @override
   void initState() {
     super.initState();
-    _itemsFuture = _loadItems();
+    widget.controller?._attach(_persistDraftSelection);
+    _itemsFuture = _loadItems(resetDraft: true);
   }
 
   @override
   void didUpdateWidget(covariant ScheduleHistoryListView oldWidget) {
     super.didUpdateWidget(oldWidget);
 
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller?._detach();
+      widget.controller?._attach(_persistDraftSelection);
+    }
+
     if (oldWidget.reloadToken != widget.reloadToken) {
-      _itemsFuture = _loadItems();
+      _itemsFuture = _reloadAfterPersist();
     }
   }
 
-  Future<List<LocalScheduleHistoryItem>> _loadItems() async {
+  @override
+  void dispose() {
+    unawaited(_persistDraftSelection());
+    widget.controller?._detach();
+    super.dispose();
+  }
+
+  Future<List<LocalScheduleHistoryItem>> _loadItems({
+    bool resetDraft = false,
+  }) async {
     final items = await _historyStore.findAll();
+
+    if (resetDraft || !_selectionDraftInitialized) {
+      _resetDraftFromItems(items);
+    } else {
+      _visiblePublicIds = items
+          .map((item) => _normalizePublicId(item.publicId))
+          .where((publicId) => publicId.isNotEmpty)
+          .toSet();
+    }
 
     if (mounted) {
       widget.onItemsLoaded?.call(items);
@@ -57,14 +108,20 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
     return items;
   }
 
+  Future<List<LocalScheduleHistoryItem>> _reloadAfterPersist() async {
+    await _persistDraftSelection();
+    _selectionDraftInitialized = false;
+    return _loadItems(resetDraft: true);
+  }
+
   void _reloadItems() {
     setState(() {
-      _itemsFuture = _loadItems();
+      _itemsFuture = _reloadAfterPersist();
     });
   }
 
   Future<void> _refreshItems() async {
-    final future = _loadItems();
+    final future = _reloadAfterPersist();
 
     setState(() {
       _itemsFuture = future;
@@ -73,83 +130,120 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
     await future;
   }
 
-  Future<void> _setPendingRemoval(
-    LocalScheduleHistoryItem item,
-    bool isPendingRemoval,
-  ) async {
-    if (_isUpdating) return;
+  void _resetDraftFromItems(List<LocalScheduleHistoryItem> items) {
+    _visiblePublicIds = items
+        .map((item) => _normalizePublicId(item.publicId))
+        .where((publicId) => publicId.isNotEmpty)
+        .toSet();
+    final pendingPublicIds = items
+        .where((item) => item.isPendingRemoval)
+        .map((item) => _normalizePublicId(item.publicId))
+        .where((publicId) => publicId.isNotEmpty)
+        .toSet();
 
-    setState(() {
-      _isUpdating = true;
-    });
-    try {
-      await _historyStore.setPendingRemoval(
-        publicId: item.publicId,
-        isPendingRemoval: isPendingRemoval,
-      );
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isUpdating = false;
-          _itemsFuture = _loadItems();
-        });
-      }
-    }
+    _draftPendingPublicIds
+      ..clear()
+      ..addAll(pendingPublicIds);
+    _persistedPendingPublicIds
+      ..clear()
+      ..addAll(pendingPublicIds);
+    _selectionDraftInitialized = true;
   }
 
-  Future<void> _markAllUnconfirmed(
-    List<LocalScheduleHistoryItem> items,
-  ) async {
+  bool get _hasDraftChanges {
+    if (!_selectionDraftInitialized) {
+      return false;
+    }
+
+    for (final publicId in _visiblePublicIds) {
+      if (_draftPendingPublicIds.contains(publicId) !=
+          _persistedPendingPublicIds.contains(publicId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  Future<void> _persistDraftSelection() async {
+    if (!_hasDraftChanges || _visiblePublicIds.isEmpty) {
+      return;
+    }
+
+    await _historyStore.replacePendingRemovalForPublicIds(
+      visiblePublicIds: _visiblePublicIds,
+      pendingPublicIds: _draftPendingPublicIds,
+    );
+
+    _persistedPendingPublicIds
+      ..removeAll(_visiblePublicIds)
+      ..addAll(_draftPendingPublicIds.where(_visiblePublicIds.contains));
+  }
+
+  void _setDraftPendingRemoval(
+    LocalScheduleHistoryItem item,
+    bool isPendingRemoval,
+  ) {
+    if (_isUpdating) return;
+
+    final publicId = _normalizePublicId(item.publicId);
+    if (publicId.isEmpty) return;
+
+    setState(() {
+      if (isPendingRemoval) {
+        _draftPendingPublicIds.add(publicId);
+      } else {
+        _draftPendingPublicIds.remove(publicId);
+      }
+    });
+  }
+
+  void _markAllUnconfirmed(List<LocalScheduleHistoryItem> items) {
     if (_isUpdating) return;
 
     final publicIds = items
         .where((item) => item.isAdopted == false)
-        .map((item) => item.publicId)
-        .toList(growable: false);
+        .map((item) => _normalizePublicId(item.publicId))
+        .where((publicId) => publicId.isNotEmpty)
+        .toSet();
     if (publicIds.isEmpty) return;
 
     setState(() {
-      _isUpdating = true;
+      _draftPendingPublicIds.addAll(publicIds);
     });
-    try {
-      await _historyStore.setPendingRemovalForPublicIds(
-        publicIds,
-        isPendingRemoval: true,
-      );
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isUpdating = false;
-          _itemsFuture = _loadItems();
-        });
-      }
-    }
   }
 
-  Future<void> _clearPendingRemoval(
-    List<LocalScheduleHistoryItem> items,
-  ) async {
+  void _clearDraftSelection() {
     if (_isUpdating) return;
 
-    final publicIds = items
-        .where((item) => item.isPendingRemoval)
-        .map((item) => item.publicId)
-        .toList(growable: false);
-    if (publicIds.isEmpty) return;
+    setState(() {
+      _draftPendingPublicIds.removeAll(_visiblePublicIds);
+    });
+  }
+
+  Future<void> _confirmSelection() async {
+    if (_isUpdating) return;
+
+    if (!_hasDraftChanges) {
+      setState(() {
+        _selectionMode = false;
+      });
+      return;
+    }
 
     setState(() {
       _isUpdating = true;
     });
     try {
-      await _historyStore.setPendingRemovalForPublicIds(
-        publicIds,
-        isPendingRemoval: false,
-      );
+      await _persistDraftSelection();
+      if (mounted) {
+        setState(() {
+          _selectionMode = false;
+        });
+      }
     } finally {
       if (mounted) {
         setState(() {
           _isUpdating = false;
-          _itemsFuture = _loadItems();
         });
       }
     }
@@ -157,6 +251,11 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
 
   Future<void> _confirmSuppressPending() async {
     if (_isUpdating) return;
+
+    final selectedPublicIds = _draftPendingPublicIds
+        .where(_visiblePublicIds.contains)
+        .toSet();
+    if (selectedPublicIds.isEmpty) return;
 
     final l10n = AppLocalizations.of(context);
     final confirmed = await showDialog<bool>(
@@ -184,13 +283,21 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
     });
     var suppressedCount = 0;
     try {
-      suppressedCount = await _historyStore.suppressPendingRemoval();
+      await _historyStore.replacePendingRemovalForPublicIds(
+        visiblePublicIds: _visiblePublicIds,
+        pendingPublicIds: _draftPendingPublicIds,
+      );
+      suppressedCount =
+          await _historyStore.suppressPublicIds(selectedPublicIds);
+      _draftPendingPublicIds.removeAll(selectedPublicIds);
+      _persistedPendingPublicIds.removeAll(selectedPublicIds);
+      _selectionDraftInitialized = false;
     } finally {
       if (mounted) {
         setState(() {
           _isUpdating = false;
           _selectionMode = false;
-          _itemsFuture = _loadItems();
+          _itemsFuture = _loadItems(resetDraft: true);
         });
       }
     }
@@ -201,6 +308,14 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
       message: l10n.scheduleHistorySelectedRemovedMessage,
       type: AppMessageType.success,
     );
+  }
+
+  bool _isDraftPendingRemoval(String publicId) {
+    return _draftPendingPublicIds.contains(_normalizePublicId(publicId));
+  }
+
+  String _normalizePublicId(String publicId) {
+    return publicId.trim().toUpperCase();
   }
 
   @override
@@ -232,8 +347,9 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
           );
         }
 
-        final pendingCount =
-            items.where((item) => item.isPendingRemoval).length;
+        final pendingCount = items
+            .where((item) => _isDraftPendingRemoval(item.publicId))
+            .length;
         final hasUnconfirmed = items.any((item) => item.isAdopted == false);
 
         return Column(
@@ -256,20 +372,13 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
                     ),
                   if (_selectionMode && pendingCount > 0)
                     TextButton.icon(
-                      onPressed:
-                          _isUpdating ? null : () => _clearPendingRemoval(items),
+                      onPressed: _isUpdating ? null : _clearDraftSelection,
                       icon: const Icon(Icons.remove_done),
                       label: Text(l10n.scheduleHistoryClearSelectionAction),
                     ),
                   if (_selectionMode)
                     TextButton.icon(
-                      onPressed: _isUpdating
-                          ? null
-                          : () {
-                              setState(() {
-                                _selectionMode = false;
-                              });
-                            },
+                      onPressed: _isUpdating ? null : _confirmSelection,
                       icon: const Icon(Icons.check),
                       label: Text(l10n.confirmButton),
                     )
@@ -304,19 +413,22 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
                   separatorBuilder: (_, __) => const SizedBox(height: 12),
                   itemBuilder: (context, index) {
                     final item = items[index];
+                    final isPendingRemoval =
+                        _isDraftPendingRemoval(item.publicId);
 
                     return _ScheduleHistoryListItem(
                       item: item,
                       selectionMode: _selectionMode,
+                      isPendingRemoval: isPendingRemoval,
                       onTap: () {
                         if (_selectionMode) {
-                          _setPendingRemoval(item, !item.isPendingRemoval);
+                          _setDraftPendingRemoval(item, !isPendingRemoval);
                           return;
                         }
                         widget.onOpenSchedule(item);
                       },
                       onSelectionChanged: (value) {
-                        _setPendingRemoval(item, value);
+                        _setDraftPendingRemoval(item, value);
                       },
                     );
                   },
@@ -334,12 +446,14 @@ class _ScheduleHistoryListItem extends StatelessWidget {
   const _ScheduleHistoryListItem({
     required this.item,
     required this.selectionMode,
+    required this.isPendingRemoval,
     required this.onTap,
     required this.onSelectionChanged,
   });
 
   final LocalScheduleHistoryItem item;
   final bool selectionMode;
+  final bool isPendingRemoval;
   final VoidCallback onTap;
   final ValueChanged<bool> onSelectionChanged;
 
@@ -349,7 +463,7 @@ class _ScheduleHistoryListItem extends StatelessWidget {
 
     return Card(
       clipBehavior: Clip.antiAlias,
-      color: item.isPendingRemoval ? colorScheme.surfaceContainerHighest : null,
+      color: isPendingRemoval ? colorScheme.surfaceContainerHighest : null,
       child: InkWell(
         onTap: onTap,
         child: Padding(
@@ -359,7 +473,7 @@ class _ScheduleHistoryListItem extends StatelessWidget {
             children: [
               if (selectionMode) ...[
                 Checkbox(
-                  value: item.isPendingRemoval,
+                  value: isPendingRemoval,
                   onChanged: (value) {
                     if (value != null) {
                       onSelectionChanged(value);
@@ -370,7 +484,7 @@ class _ScheduleHistoryListItem extends StatelessWidget {
               ],
               Expanded(
                 child: Opacity(
-                  opacity: item.isPendingRemoval ? 0.55 : 1,
+                  opacity: isPendingRemoval ? 0.55 : 1,
                   child: _ScheduleHistoryListItemBody(item: item),
                 ),
               ),

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
@@ -88,11 +88,12 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
         isPendingRemoval: isPendingRemoval,
       );
     } finally {
-      if (!mounted) return;
-      setState(() {
-        _isUpdating = false;
-        _itemsFuture = _loadItems();
-      });
+      if (mounted) {
+        setState(() {
+          _isUpdating = false;
+          _itemsFuture = _loadItems();
+        });
+      }
     }
   }
 
@@ -116,11 +117,12 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
         isPendingRemoval: true,
       );
     } finally {
-      if (!mounted) return;
-      setState(() {
-        _isUpdating = false;
-        _itemsFuture = _loadItems();
-      });
+      if (mounted) {
+        setState(() {
+          _isUpdating = false;
+          _itemsFuture = _loadItems();
+        });
+      }
     }
   }
 
@@ -155,12 +157,13 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
     try {
       suppressedCount = await _historyStore.suppressPendingRemoval();
     } finally {
-      if (!mounted) return;
-      setState(() {
-        _isUpdating = false;
-        _selectionMode = false;
-        _itemsFuture = _loadItems();
-      });
+      if (mounted) {
+        setState(() {
+          _isUpdating = false;
+          _selectionMode = false;
+          _itemsFuture = _loadItems();
+        });
+      }
     }
 
     if (!mounted || suppressedCount <= 0) return;
@@ -217,9 +220,8 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
                 children: [
                   if (_selectionMode && hasUnconfirmed)
                     TextButton.icon(
-                      onPressed: _isUpdating
-                          ? null
-                          : () => _markAllUnconfirmed(items),
+                      onPressed:
+                          _isUpdating ? null : () => _markAllUnconfirmed(items),
                       icon: const Icon(Icons.select_all),
                       label: Text(l10n.scheduleHistoryUnconfirmedLabel),
                     ),

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
@@ -252,9 +252,8 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
   Future<void> _confirmSuppressPending() async {
     if (_isUpdating) return;
 
-    final selectedPublicIds = _draftPendingPublicIds
-        .where(_visiblePublicIds.contains)
-        .toSet();
+    final selectedPublicIds =
+        _draftPendingPublicIds.where(_visiblePublicIds.contains).toSet();
     if (selectedPublicIds.isEmpty) return;
 
     final l10n = AppLocalizations.of(context);
@@ -347,9 +346,8 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
           );
         }
 
-        final pendingCount = items
-            .where((item) => _isDraftPendingRemoval(item.publicId))
-            .length;
+        final pendingCount =
+            items.where((item) => _isDraftPendingRemoval(item.publicId)).length;
         final hasUnconfirmed = items.any((item) => item.isAdopted == false);
 
         return Column(

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
@@ -126,6 +126,35 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
     }
   }
 
+  Future<void> _clearPendingRemoval(
+    List<LocalScheduleHistoryItem> items,
+  ) async {
+    if (_isUpdating) return;
+
+    final publicIds = items
+        .where((item) => item.isPendingRemoval)
+        .map((item) => item.publicId)
+        .toList(growable: false);
+    if (publicIds.isEmpty) return;
+
+    setState(() {
+      _isUpdating = true;
+    });
+    try {
+      await _historyStore.setPendingRemovalForPublicIds(
+        publicIds,
+        isPendingRemoval: false,
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isUpdating = false;
+          _itemsFuture = _loadItems();
+        });
+      }
+    }
+  }
+
   Future<void> _confirmSuppressPending() async {
     if (_isUpdating) return;
 
@@ -134,7 +163,7 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: Text(l10n.clearScheduleHistoryConfirmTitle),
+          title: Text(l10n.scheduleHistorySelectedRemoveConfirmTitle),
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(context, false),
@@ -142,7 +171,7 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
             ),
             FilledButton(
               onPressed: () => Navigator.pop(context, true),
-              child: Text(l10n.clearScheduleHistoryActionButton),
+              child: Text(l10n.scheduleHistoryRemoveFromListAction),
             ),
           ],
         );
@@ -169,7 +198,7 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
     if (!mounted || suppressedCount <= 0) return;
     AppSnackBar.show(
       context,
-      message: l10n.scheduleHistoryClearedMessage,
+      message: l10n.scheduleHistorySelectedRemovedMessage,
       type: AppMessageType.success,
     );
   }
@@ -223,7 +252,14 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
                       onPressed:
                           _isUpdating ? null : () => _markAllUnconfirmed(items),
                       icon: const Icon(Icons.select_all),
-                      label: Text(l10n.scheduleHistoryUnconfirmedLabel),
+                      label: Text(l10n.scheduleHistorySelectUnconfirmedAction),
+                    ),
+                  if (_selectionMode && pendingCount > 0)
+                    TextButton.icon(
+                      onPressed:
+                          _isUpdating ? null : () => _clearPendingRemoval(items),
+                      icon: const Icon(Icons.remove_done),
+                      label: Text(l10n.scheduleHistoryClearSelectionAction),
                     ),
                   if (_selectionMode)
                     TextButton.icon(
@@ -253,7 +289,7 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
                     FilledButton.tonalIcon(
                       onPressed: _isUpdating ? null : _confirmSuppressPending,
                       icon: const Icon(Icons.delete_sweep_outlined),
-                      label: Text(l10n.clearScheduleHistoryActionButton),
+                      label: Text(l10n.scheduleHistoryRemoveFromListAction),
                     ),
                 ],
               ),

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_history_list_view.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:srp_lanske/l10n/l10n.dart';
+import 'package:srp_lanske/shared/presentation/app_message_type.dart';
+import 'package:srp_lanske/shared/presentation/app_snack_bar.dart';
 
 import '../../data/local_schedule_history_item.dart';
 import '../../data/local_schedule_history_store.dart';
@@ -27,6 +29,8 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
   final LocalScheduleHistoryStore _historyStore = LocalScheduleHistoryStore();
 
   late Future<List<LocalScheduleHistoryItem>> _itemsFuture;
+  bool _selectionMode = false;
+  bool _isUpdating = false;
 
   @override
   void initState() {
@@ -69,6 +73,104 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
     await future;
   }
 
+  Future<void> _setPendingRemoval(
+    LocalScheduleHistoryItem item,
+    bool isPendingRemoval,
+  ) async {
+    if (_isUpdating) return;
+
+    setState(() {
+      _isUpdating = true;
+    });
+    try {
+      await _historyStore.setPendingRemoval(
+        publicId: item.publicId,
+        isPendingRemoval: isPendingRemoval,
+      );
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isUpdating = false;
+        _itemsFuture = _loadItems();
+      });
+    }
+  }
+
+  Future<void> _markAllUnconfirmed(
+    List<LocalScheduleHistoryItem> items,
+  ) async {
+    if (_isUpdating) return;
+
+    final publicIds = items
+        .where((item) => item.isAdopted == false)
+        .map((item) => item.publicId)
+        .toList(growable: false);
+    if (publicIds.isEmpty) return;
+
+    setState(() {
+      _isUpdating = true;
+    });
+    try {
+      await _historyStore.setPendingRemovalForPublicIds(
+        publicIds,
+        isPendingRemoval: true,
+      );
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isUpdating = false;
+        _itemsFuture = _loadItems();
+      });
+    }
+  }
+
+  Future<void> _confirmSuppressPending() async {
+    if (_isUpdating) return;
+
+    final l10n = AppLocalizations.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(l10n.clearScheduleHistoryConfirmTitle),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: Text(l10n.cancelButton),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: Text(l10n.clearScheduleHistoryActionButton),
+            ),
+          ],
+        );
+      },
+    );
+    if (!mounted || confirmed != true) return;
+
+    setState(() {
+      _isUpdating = true;
+    });
+    var suppressedCount = 0;
+    try {
+      suppressedCount = await _historyStore.suppressPendingRemoval();
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isUpdating = false;
+        _selectionMode = false;
+        _itemsFuture = _loadItems();
+      });
+    }
+
+    if (!mounted || suppressedCount <= 0) return;
+    AppSnackBar.show(
+      context,
+      message: l10n.scheduleHistoryClearedMessage,
+      type: AppMessageType.success,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
@@ -98,22 +200,92 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
           );
         }
 
-        return RefreshIndicator(
-          onRefresh: _refreshItems,
-          child: ListView.separated(
-            padding: widget.padding,
-            physics: const AlwaysScrollableScrollPhysics(),
-            itemCount: items.length,
-            separatorBuilder: (_, __) => const SizedBox(height: 12),
-            itemBuilder: (context, index) {
-              final item = items[index];
+        final pendingCount =
+            items.where((item) => item.isPendingRemoval).length;
+        final hasUnconfirmed = items.any((item) => item.isAdopted == false);
 
-              return _ScheduleHistoryListItem(
-                item: item,
-                onTap: () => widget.onOpenSchedule(item),
-              );
-            },
-          ),
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+              child: Wrap(
+                alignment: WrapAlignment.end,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                spacing: 8,
+                runSpacing: 4,
+                children: [
+                  if (_selectionMode && hasUnconfirmed)
+                    TextButton.icon(
+                      onPressed: _isUpdating
+                          ? null
+                          : () => _markAllUnconfirmed(items),
+                      icon: const Icon(Icons.select_all),
+                      label: Text(l10n.scheduleHistoryUnconfirmedLabel),
+                    ),
+                  if (_selectionMode)
+                    TextButton.icon(
+                      onPressed: _isUpdating
+                          ? null
+                          : () {
+                              setState(() {
+                                _selectionMode = false;
+                              });
+                            },
+                      icon: const Icon(Icons.check),
+                      label: Text(l10n.confirmButton),
+                    )
+                  else
+                    IconButton(
+                      onPressed: _isUpdating
+                          ? null
+                          : () {
+                              setState(() {
+                                _selectionMode = true;
+                              });
+                            },
+                      icon: const Icon(Icons.delete_outline),
+                      tooltip: l10n.clearScheduleHistoryTooltip,
+                    ),
+                  if (pendingCount > 0)
+                    FilledButton.tonalIcon(
+                      onPressed: _isUpdating ? null : _confirmSuppressPending,
+                      icon: const Icon(Icons.delete_sweep_outlined),
+                      label: Text(l10n.clearScheduleHistoryActionButton),
+                    ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: RefreshIndicator(
+                onRefresh: _refreshItems,
+                child: ListView.separated(
+                  padding: widget.padding,
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  itemCount: items.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 12),
+                  itemBuilder: (context, index) {
+                    final item = items[index];
+
+                    return _ScheduleHistoryListItem(
+                      item: item,
+                      selectionMode: _selectionMode,
+                      onTap: () {
+                        if (_selectionMode) {
+                          _setPendingRemoval(item, !item.isPendingRemoval);
+                          return;
+                        }
+                        widget.onOpenSchedule(item);
+                      },
+                      onSelectionChanged: (value) {
+                        _setPendingRemoval(item, value);
+                      },
+                    );
+                  },
+                ),
+              ),
+            ),
+          ],
         );
       },
     );
@@ -123,11 +295,15 @@ class _ScheduleHistoryListViewState extends State<ScheduleHistoryListView> {
 class _ScheduleHistoryListItem extends StatelessWidget {
   const _ScheduleHistoryListItem({
     required this.item,
+    required this.selectionMode,
     required this.onTap,
+    required this.onSelectionChanged,
   });
 
   final LocalScheduleHistoryItem item;
+  final bool selectionMode;
   final VoidCallback onTap;
+  final ValueChanged<bool> onSelectionChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -135,6 +311,7 @@ class _ScheduleHistoryListItem extends StatelessWidget {
 
     return Card(
       clipBehavior: Clip.antiAlias,
+      color: item.isPendingRemoval ? colorScheme.surfaceContainerHighest : null,
       child: InkWell(
         onTap: onTap,
         child: Padding(
@@ -142,14 +319,30 @@ class _ScheduleHistoryListItem extends StatelessWidget {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              if (selectionMode) ...[
+                Checkbox(
+                  value: item.isPendingRemoval,
+                  onChanged: (value) {
+                    if (value != null) {
+                      onSelectionChanged(value);
+                    }
+                  },
+                ),
+                const SizedBox(width: 4),
+              ],
               Expanded(
-                child: _ScheduleHistoryListItemBody(item: item),
+                child: Opacity(
+                  opacity: item.isPendingRemoval ? 0.55 : 1,
+                  child: _ScheduleHistoryListItemBody(item: item),
+                ),
               ),
-              const SizedBox(width: 8),
-              Icon(
-                Icons.chevron_right,
-                color: colorScheme.onSurfaceVariant,
-              ),
+              if (!selectionMode) ...[
+                const SizedBox(width: 8),
+                Icon(
+                  Icons.chevron_right,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ],
             ],
           ),
         ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -908,7 +908,7 @@
   },
   "restoringTeamScheduleMessage": "Loading saved team match table...",
   "@restoringTeamScheduleMessage": {
-    "description": "Message shown while restoring a team schedule."
+    "description": "Loading message while restoring a team schedule."
   },
   "savingTeamScheduleDisplayMessage": "Saving display names...",
   "@savingTeamScheduleDisplayMessage": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -346,6 +346,26 @@
   "@scheduleHistoryUnconfirmedLabel": {
     "description": "Label shown for a saved doubles schedule that has not been confirmed."
   },
+  "scheduleHistorySelectUnconfirmedAction": "Select unconfirmed",
+  "@scheduleHistorySelectUnconfirmedAction": {
+    "description": "Action label for selecting all visible unconfirmed doubles schedules."
+  },
+  "scheduleHistoryClearSelectionAction": "Clear selection",
+  "@scheduleHistoryClearSelectionAction": {
+    "description": "Action label for clearing selected doubles schedules."
+  },
+  "scheduleHistorySelectedRemoveConfirmTitle": "Remove selected match tables from the list?",
+  "@scheduleHistorySelectedRemoveConfirmTitle": {
+    "description": "Dialog title for removing selected doubles schedules from the local list."
+  },
+  "scheduleHistoryRemoveFromListAction": "Remove from list",
+  "@scheduleHistoryRemoveFromListAction": {
+    "description": "Action label for removing selected doubles schedules from the local list."
+  },
+  "scheduleHistorySelectedRemovedMessage": "Selected match tables removed from the list",
+  "@scheduleHistorySelectedRemovedMessage": {
+    "description": "Snack bar message shown after selected doubles schedules are removed from the local list."
+  },
   "scheduleHistoryCompletedMatchesLabel": "{completedMatchCount} / {totalMatchCount} matches completed",
   "@scheduleHistoryCompletedMatchesLabel": {
     "description": "Progress label showing completed and total match counts in doubles schedule history.",
@@ -888,7 +908,7 @@
   },
   "restoringTeamScheduleMessage": "Loading saved team match table...",
   "@restoringTeamScheduleMessage": {
-    "description": "Loading message while restoring a team schedule."
+    "description": "Message shown while restoring a team schedule."
   },
   "savingTeamScheduleDisplayMessage": "Saving display names...",
   "@savingTeamScheduleDisplayMessage": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -848,7 +848,7 @@
   },
   "teamScheduleBulkEditMembersSection": "メンバー名",
   "@teamScheduleBulkEditMembersSection": {
-    "description": "Section title for team names in the bulk edit dialog."
+    "description": "Section title for member names in the bulk edit dialog."
   },
   "teamScheduleTeamNameLabel": "チーム{teamSlot}",
   "@teamScheduleTeamNameLabel": {
@@ -992,7 +992,7 @@
   },
   "teamScheduleShareUrlCopiedMessage": "共有URLをコピーしました",
   "@teamScheduleShareUrlCopiedMessage": {
-    "description": "Message shown after copying the team schedule share URL."
+    "description": "Message shown after copying a team schedule share URL."
   },
   "nextTeamMatchTitle": "次の対戦",
   "@nextTeamMatchTitle": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -346,6 +346,26 @@
   "@scheduleHistoryUnconfirmedLabel": {
     "description": "Label shown for a saved doubles schedule that has not been confirmed."
   },
+  "scheduleHistorySelectUnconfirmedAction": "未確定を選択",
+  "@scheduleHistorySelectUnconfirmedAction": {
+    "description": "Action label for selecting all visible unconfirmed doubles schedules."
+  },
+  "scheduleHistoryClearSelectionAction": "選択を解除",
+  "@scheduleHistoryClearSelectionAction": {
+    "description": "Action label for clearing selected doubles schedules."
+  },
+  "scheduleHistorySelectedRemoveConfirmTitle": "選択した対戦表を一覧から削除しますか？",
+  "@scheduleHistorySelectedRemoveConfirmTitle": {
+    "description": "Dialog title for removing selected doubles schedules from the local list."
+  },
+  "scheduleHistoryRemoveFromListAction": "一覧から削除",
+  "@scheduleHistoryRemoveFromListAction": {
+    "description": "Action label for removing selected doubles schedules from the local list."
+  },
+  "scheduleHistorySelectedRemovedMessage": "選択した対戦表を一覧から削除しました",
+  "@scheduleHistorySelectedRemovedMessage": {
+    "description": "Snack bar message shown after selected doubles schedules are removed from the local list."
+  },
   "scheduleHistoryCompletedMatchesLabel": "{completedMatchCount} / {totalMatchCount} 試合終了",
   "@scheduleHistoryCompletedMatchesLabel": {
     "description": "Progress label showing completed and total match counts in doubles schedule history.",
@@ -828,7 +848,7 @@
   },
   "teamScheduleBulkEditMembersSection": "メンバー名",
   "@teamScheduleBulkEditMembersSection": {
-    "description": "Section title for member names in the bulk edit dialog."
+    "description": "Section title for team names in the bulk edit dialog."
   },
   "teamScheduleTeamNameLabel": "チーム{teamSlot}",
   "@teamScheduleTeamNameLabel": {
@@ -972,7 +992,7 @@
   },
   "teamScheduleShareUrlCopiedMessage": "共有URLをコピーしました",
   "@teamScheduleShareUrlCopiedMessage": {
-    "description": "Message shown after copying a team schedule share URL."
+    "description": "Message shown after copying the team schedule share URL."
   },
   "nextTeamMatchTitle": "次の対戦",
   "@nextTeamMatchTitle": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -518,6 +518,36 @@ abstract class AppLocalizations {
   /// **'未確定'**
   String get scheduleHistoryUnconfirmedLabel;
 
+  /// Action label for selecting all visible unconfirmed doubles schedules.
+  ///
+  /// In ja, this message translates to:
+  /// **'未確定を選択'**
+  String get scheduleHistorySelectUnconfirmedAction;
+
+  /// Action label for clearing selected doubles schedules.
+  ///
+  /// In ja, this message translates to:
+  /// **'選択を解除'**
+  String get scheduleHistoryClearSelectionAction;
+
+  /// Dialog title for removing selected doubles schedules from the local list.
+  ///
+  /// In ja, this message translates to:
+  /// **'選択した対戦表を一覧から削除しますか？'**
+  String get scheduleHistorySelectedRemoveConfirmTitle;
+
+  /// Action label for removing selected doubles schedules from the local list.
+  ///
+  /// In ja, this message translates to:
+  /// **'一覧から削除'**
+  String get scheduleHistoryRemoveFromListAction;
+
+  /// Snack bar message shown after selected doubles schedules are removed from the local list.
+  ///
+  /// In ja, this message translates to:
+  /// **'選択した対戦表を一覧から削除しました'**
+  String get scheduleHistorySelectedRemovedMessage;
+
   /// Progress label showing completed and total match counts in doubles schedule history.
   ///
   /// In ja, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -249,6 +249,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get scheduleHistoryUnconfirmedLabel => 'Unconfirmed';
 
   @override
+  String get scheduleHistorySelectUnconfirmedAction => 'Select unconfirmed';
+
+  @override
+  String get scheduleHistoryClearSelectionAction => 'Clear selection';
+
+  @override
+  String get scheduleHistorySelectedRemoveConfirmTitle =>
+      'Remove selected match tables from the list?';
+
+  @override
+  String get scheduleHistoryRemoveFromListAction => 'Remove from list';
+
+  @override
+  String get scheduleHistorySelectedRemovedMessage =>
+      'Selected match tables removed from the list';
+
+  @override
   String scheduleHistoryCompletedMatchesLabel(
       int completedMatchCount, int totalMatchCount) {
     return '$completedMatchCount / $totalMatchCount matches completed';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -242,6 +242,21 @@ class AppLocalizationsJa extends AppLocalizations {
   String get scheduleHistoryUnconfirmedLabel => '未確定';
 
   @override
+  String get scheduleHistorySelectUnconfirmedAction => '未確定を選択';
+
+  @override
+  String get scheduleHistoryClearSelectionAction => '選択を解除';
+
+  @override
+  String get scheduleHistorySelectedRemoveConfirmTitle => '選択した対戦表を一覧から削除しますか？';
+
+  @override
+  String get scheduleHistoryRemoveFromListAction => '一覧から削除';
+
+  @override
+  String get scheduleHistorySelectedRemovedMessage => '選択した対戦表を一覧から削除しました';
+
+  @override
   String scheduleHistoryCompletedMatchesLabel(
       int completedMatchCount, int totalMatchCount) {
     return '$completedMatchCount / $totalMatchCount 試合終了';

--- a/test/features/doubles_scheduler/data/local_schedule_history_item_test.dart
+++ b/test/features/doubles_scheduler/data/local_schedule_history_item_test.dart
@@ -15,6 +15,7 @@ void main() {
       isAdopted: true,
       completedMatchCount: 8,
       totalMatchCount: 12,
+      isPendingRemoval: true,
     );
 
     final restored = LocalScheduleHistoryItem.fromJson(item.toJson());
@@ -24,9 +25,10 @@ void main() {
     expect(restored.completedMatchCount, 8);
     expect(restored.totalMatchCount, 12);
     expect(restored.createdAt, item.createdAt);
+    expect(restored.isPendingRemoval, isTrue);
   });
 
-  test('keeps new metadata nullable for legacy history', () {
+  test('keeps new metadata compatible for legacy history', () {
     final restored = LocalScheduleHistoryItem.fromJson({
       'public_id': 'ABCDEFGH',
       'title': 'Legacy event',
@@ -41,6 +43,7 @@ void main() {
     expect(restored.isAdopted, isNull);
     expect(restored.completedMatchCount, isNull);
     expect(restored.totalMatchCount, isNull);
+    expect(restored.isPendingRemoval, isFalse);
   });
 
   test('uses last opened time as stable legacy created-at fallback', () {

--- a/test/features/doubles_scheduler/data/local_schedule_history_store_test.dart
+++ b/test/features/doubles_scheduler/data/local_schedule_history_store_test.dart
@@ -30,26 +30,48 @@ void main() {
     expect(items.map((item) => item.publicId), ['NEWER', 'OLDER']);
   });
 
-  test('retains the 20 most recently opened items', () async {
+  test('shows 20 items while retaining older history for later display', () async {
     final store = LocalScheduleHistoryStore();
+    await store.upsert(
+      _item(
+        publicId: 'CONFIRMED',
+        createdAt: DateTime(2026, 8, 1),
+        lastOpenedAt: DateTime(2026, 8, 1),
+        isAdopted: true,
+      ),
+    );
 
-    for (var i = 0; i < 21; i += 1) {
+    for (var i = 0; i < 20; i += 1) {
       await store.upsert(
         _item(
-          publicId: 'ID$i',
-          createdAt: DateTime(2026, 8, 1).add(Duration(days: i)),
-          lastOpenedAt: DateTime(2026, 8, 1).add(Duration(hours: i)),
+          publicId: 'UNCONFIRMED$i',
+          createdAt: DateTime(2026, 8, 2).add(Duration(hours: i)),
+          lastOpenedAt: DateTime(2026, 8, 2).add(Duration(hours: i)),
+          isAdopted: false,
         ),
       );
     }
 
-    final items = await store.findAll();
+    final visible = await store.findAll();
+    expect(visible, hasLength(20));
+    expect(visible.any((item) => item.publicId == 'CONFIRMED'), isFalse);
 
-    expect(items, hasLength(20));
-    expect(items.any((item) => item.publicId == 'ID0'), isFalse);
+    await store.setPendingRemovalForPublicIds(
+      visible.map((item) => item.publicId),
+      isPendingRemoval: true,
+    );
+    expect((await store.findAll()).every((item) => item.isPendingRemoval), isTrue);
+
+    final suppressedCount = await store.suppressPendingRemoval();
+    expect(suppressedCount, 20);
+
+    final remaining = await store.findAll();
+    expect(remaining, hasLength(1));
+    expect(remaining.single.publicId, 'CONFIRMED');
   });
 
-  test('upsert preserves progress for the same generated schedule', () async {
+  test('upsert preserves progress and pending state for the same schedule',
+      () async {
     final store = LocalScheduleHistoryStore();
     await store.upsert(
       _item(
@@ -61,6 +83,10 @@ void main() {
         completedMatchCount: 4,
         totalMatchCount: 12,
       ),
+    );
+    await store.setPendingRemoval(
+      publicId: 'ABCDEFGH',
+      isPendingRemoval: true,
     );
 
     await store.upsert(
@@ -76,9 +102,10 @@ void main() {
     final item = (await store.findAll()).single;
     expect(item.completedMatchCount, 4);
     expect(item.totalMatchCount, 12);
+    expect(item.isPendingRemoval, isTrue);
   });
 
-  test('upsert clears stale progress when generated schedule changes',
+  test('upsert clears stale progress but preserves pending state after regeneration',
       () async {
     final store = LocalScheduleHistoryStore();
     await store.upsert(
@@ -90,6 +117,7 @@ void main() {
         isAdopted: false,
         completedMatchCount: 4,
         totalMatchCount: 12,
+        isPendingRemoval: true,
       ),
     );
 
@@ -107,6 +135,7 @@ void main() {
     expect(item.generatedScheduleId, 'schedule-2');
     expect(item.completedMatchCount, isNull);
     expect(item.totalMatchCount, isNull);
+    expect(item.isPendingRemoval, isTrue);
   });
 
   test('updateProgress updates matching schedule without changing metadata',
@@ -124,6 +153,7 @@ void main() {
         isAdopted: true,
         completedMatchCount: 0,
         totalMatchCount: 12,
+        isPendingRemoval: true,
       ),
     );
 
@@ -143,6 +173,7 @@ void main() {
     expect(item.completedMatchCount, 5);
     expect(item.totalMatchCount, 12);
     expect(item.isAdopted, isTrue);
+    expect(item.isPendingRemoval, isTrue);
   });
 
   test('updateProgress ignores a stale generated schedule', () async {
@@ -170,6 +201,67 @@ void main() {
     expect(item.totalMatchCount, isNull);
     expect(item.isAdopted, isFalse);
   });
+
+  test('suppressed history is not restored by normal upsert', () async {
+    final store = LocalScheduleHistoryStore();
+    final item = _item(
+      publicId: 'ABCDEFGH',
+      createdAt: DateTime(2026, 8, 10),
+      lastOpenedAt: DateTime(2026, 8, 10),
+      isAdopted: false,
+    );
+    await store.upsert(item);
+    await store.setPendingRemoval(
+      publicId: item.publicId,
+      isPendingRemoval: true,
+    );
+    expect(await store.suppressPendingRemoval(), 1);
+    expect(await store.findAll(), isEmpty);
+
+    await store.upsert(
+      _item(
+        publicId: 'ABCDEFGH',
+        createdAt: DateTime(2026, 8, 10),
+        lastOpenedAt: DateTime(2026, 8, 14),
+        isAdopted: true,
+      ),
+    );
+
+    expect(await store.findAll(), isEmpty);
+  });
+
+  test('clearExceptPublicId keeps current history and suppresses the others',
+      () async {
+    final store = LocalScheduleHistoryStore();
+    await store.upsert(
+      _item(
+        publicId: 'KEEP',
+        createdAt: DateTime(2026, 8, 10),
+        lastOpenedAt: DateTime(2026, 8, 10),
+      ),
+    );
+    await store.upsert(
+      _item(
+        publicId: 'OTHER',
+        createdAt: DateTime(2026, 8, 11),
+        lastOpenedAt: DateTime(2026, 8, 11),
+      ),
+    );
+
+    await store.clearExceptPublicId('KEEP');
+
+    final remaining = await store.findAll();
+    expect(remaining.map((item) => item.publicId), ['KEEP']);
+
+    await store.upsert(
+      _item(
+        publicId: 'OTHER',
+        createdAt: DateTime(2026, 8, 11),
+        lastOpenedAt: DateTime(2026, 8, 14),
+      ),
+    );
+    expect((await store.findAll()).map((item) => item.publicId), ['KEEP']);
+  });
 }
 
 LocalScheduleHistoryItem _item({
@@ -181,6 +273,7 @@ LocalScheduleHistoryItem _item({
   bool? isAdopted,
   int? completedMatchCount,
   int? totalMatchCount,
+  bool isPendingRemoval = false,
 }) {
   return LocalScheduleHistoryItem(
     publicId: publicId,
@@ -194,5 +287,6 @@ LocalScheduleHistoryItem _item({
     isAdopted: isAdopted,
     completedMatchCount: completedMatchCount,
     totalMatchCount: totalMatchCount,
+    isPendingRemoval: isPendingRemoval,
   );
 }

--- a/test/features/doubles_scheduler/data/local_schedule_history_store_test.dart
+++ b/test/features/doubles_scheduler/data/local_schedule_history_store_test.dart
@@ -30,7 +30,8 @@ void main() {
     expect(items.map((item) => item.publicId), ['NEWER', 'OLDER']);
   });
 
-  test('shows 20 items while retaining older history for later display', () async {
+  test('shows 20 items while retaining older history for later display',
+      () async {
     final store = LocalScheduleHistoryStore();
     await store.upsert(
       _item(
@@ -60,7 +61,8 @@ void main() {
       visible.map((item) => item.publicId),
       isPendingRemoval: true,
     );
-    expect((await store.findAll()).every((item) => item.isPendingRemoval), isTrue);
+    expect(
+        (await store.findAll()).every((item) => item.isPendingRemoval), isTrue);
 
     final suppressedCount = await store.suppressPendingRemoval();
     expect(suppressedCount, 20);
@@ -105,7 +107,8 @@ void main() {
     expect(item.isPendingRemoval, isTrue);
   });
 
-  test('upsert clears stale progress but preserves pending state after regeneration',
+  test(
+      'upsert clears stale progress but preserves pending state after regeneration',
       () async {
     final store = LocalScheduleHistoryStore();
     await store.upsert(

--- a/test/features/doubles_scheduler/data/local_schedule_history_store_test.dart
+++ b/test/features/doubles_scheduler/data/local_schedule_history_store_test.dart
@@ -57,19 +57,62 @@ void main() {
     expect(visible, hasLength(20));
     expect(visible.any((item) => item.publicId == 'CONFIRMED'), isFalse);
 
-    await store.setPendingRemovalForPublicIds(
-      visible.map((item) => item.publicId),
-      isPendingRemoval: true,
+    final visiblePublicIds = visible.map((item) => item.publicId).toList();
+    await store.replacePendingRemovalForPublicIds(
+      visiblePublicIds: visiblePublicIds,
+      pendingPublicIds: visiblePublicIds,
     );
     expect(
-        (await store.findAll()).every((item) => item.isPendingRemoval), isTrue);
+      (await store.findAll()).every((item) => item.isPendingRemoval),
+      isTrue,
+    );
 
-    final suppressedCount = await store.suppressPendingRemoval();
+    final suppressedCount = await store.suppressPublicIds(visiblePublicIds);
     expect(suppressedCount, 20);
 
     final remaining = await store.findAll();
     expect(remaining, hasLength(1));
     expect(remaining.single.publicId, 'CONFIRMED');
+  });
+
+  test('replaces pending removal only for the supplied visible history',
+      () async {
+    final store = LocalScheduleHistoryStore();
+    await store.upsert(
+      _item(
+        publicId: 'FIRST',
+        createdAt: DateTime(2026, 8, 10),
+        lastOpenedAt: DateTime(2026, 8, 10),
+        isPendingRemoval: true,
+      ),
+    );
+    await store.upsert(
+      _item(
+        publicId: 'SECOND',
+        createdAt: DateTime(2026, 8, 11),
+        lastOpenedAt: DateTime(2026, 8, 11),
+      ),
+    );
+    await store.upsert(
+      _item(
+        publicId: 'OUTSIDE',
+        createdAt: DateTime(2026, 8, 12),
+        lastOpenedAt: DateTime(2026, 8, 12),
+        isPendingRemoval: true,
+      ),
+    );
+
+    await store.replacePendingRemovalForPublicIds(
+      visiblePublicIds: const ['FIRST', 'SECOND'],
+      pendingPublicIds: const ['SECOND'],
+    );
+
+    final byId = {
+      for (final item in await store.findAll()) item.publicId: item,
+    };
+    expect(byId['FIRST']!.isPendingRemoval, isFalse);
+    expect(byId['SECOND']!.isPendingRemoval, isTrue);
+    expect(byId['OUTSIDE']!.isPendingRemoval, isTrue);
   });
 
   test('upsert preserves progress and pending state for the same schedule',
@@ -214,11 +257,7 @@ void main() {
       isAdopted: false,
     );
     await store.upsert(item);
-    await store.setPendingRemoval(
-      publicId: item.publicId,
-      isPendingRemoval: true,
-    );
-    expect(await store.suppressPendingRemoval(), 1);
+    expect(await store.suppressPublicIds([item.publicId]), 1);
     expect(await store.findAll(), isEmpty);
 
     await store.upsert(

--- a/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
+++ b/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
@@ -88,6 +88,85 @@ void main() {
 
     expect(openedItem?.publicId, 'ABCDEFGH');
   });
+
+  testWidgets('marks unconfirmed schedules and removes them from the local list',
+      (tester) async {
+    final unconfirmed = LocalScheduleHistoryItem(
+      publicId: 'UNCONFIRMED',
+      title: '未確定イベント',
+      courtCount: 1,
+      playerCount: 6,
+      createdAt: DateTime(2026, 8, 14, 8),
+      firstSavedAt: DateTime(2026, 8, 14, 8),
+      lastOpenedAt: DateTime(2026, 8, 14, 8),
+      generatedScheduleId: 'schedule-unconfirmed',
+      isAdopted: false,
+      completedMatchCount: 0,
+      totalMatchCount: 10,
+    );
+    final confirmed = LocalScheduleHistoryItem(
+      publicId: 'CONFIRMED',
+      title: '確定済みイベント',
+      courtCount: 1,
+      playerCount: 6,
+      createdAt: DateTime(2026, 8, 13, 8),
+      firstSavedAt: DateTime(2026, 8, 13, 8),
+      lastOpenedAt: DateTime(2026, 8, 13, 8),
+      generatedScheduleId: 'schedule-confirmed',
+      isAdopted: true,
+      completedMatchCount: 3,
+      totalMatchCount: 10,
+    );
+    SharedPreferences.setMockInitialValues({
+      'lanske_recent_schedules': jsonEncode([
+        unconfirmed.toJson(),
+        confirmed.toJson(),
+      ]),
+    });
+
+    await _pumpDrawer(tester, width: 340);
+
+    await tester.tap(find.byIcon(Icons.delete_outline));
+    await tester.pumpAndSettle();
+    expect(find.byType(Checkbox), findsNWidgets(2));
+
+    await tester.tap(find.byIcon(Icons.select_all));
+    await tester.pumpAndSettle();
+
+    final prefsAfterMark = await SharedPreferences.getInstance();
+    final rawAfterMark = jsonDecode(
+      prefsAfterMark.getString('lanske_recent_schedules')!,
+    ) as List<dynamic>;
+    final markedById = {
+      for (final value in rawAfterMark.cast<Map<String, dynamic>>())
+        value['public_id'] as String: value['is_pending_removal'] as bool,
+    };
+    expect(markedById['UNCONFIRMED'], isTrue);
+    expect(markedById['CONFIRMED'], isFalse);
+
+    await tester.tap(find.text('決定'));
+    await tester.pumpAndSettle();
+    expect(find.byType(Checkbox), findsNothing);
+    expect(find.text('未確定イベント'), findsOneWidget);
+
+    await tester.tap(find.text('履歴を削除'));
+    await tester.pumpAndSettle();
+    expect(find.text('対戦表表示履歴を削除しますか？'), findsOneWidget);
+
+    await tester.tap(
+      find.widgetWithText(FilledButton, '履歴を削除').last,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('未確定イベント'), findsNothing);
+    expect(find.text('確定済みイベント'), findsOneWidget);
+
+    final prefsAfterSuppress = await SharedPreferences.getInstance();
+    expect(
+      prefsAfterSuppress.getStringList('lanske_suppressed_schedule_ids'),
+      contains('UNCONFIRMED'),
+    );
+  });
 }
 
 Future<void> _pumpDrawer(

--- a/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
+++ b/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
@@ -89,8 +89,7 @@ void main() {
     expect(openedItem?.publicId, 'ABCDEFGH');
   });
 
-  testWidgets(
-      'keeps selection as draft until confirmation and then removes it',
+  testWidgets('keeps selection as draft until confirmation and then removes it',
       (tester) async {
     final unconfirmed = LocalScheduleHistoryItem(
       publicId: 'UNCONFIRMED',

--- a/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
+++ b/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
@@ -90,7 +90,7 @@ void main() {
   });
 
   testWidgets(
-      'marks unconfirmed schedules and removes them from the local list',
+      'keeps selection as draft until confirmation and then removes it',
       (tester) async {
     final unconfirmed = LocalScheduleHistoryItem(
       publicId: 'UNCONFIRMED',
@@ -137,28 +137,15 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('選択を解除'), findsOneWidget);
 
-    final prefsAfterMark = await SharedPreferences.getInstance();
-    var rawAfterMark = jsonDecode(
-      prefsAfterMark.getString('lanske_recent_schedules')!,
-    ) as List<dynamic>;
-    var markedById = {
-      for (final value in rawAfterMark.cast<Map<String, dynamic>>())
-        value['public_id'] as String: value['is_pending_removal'] as bool,
-    };
-    expect(markedById['UNCONFIRMED'], isTrue);
+    var markedById = await _readPendingById();
+    expect(markedById['UNCONFIRMED'], isFalse);
     expect(markedById['CONFIRMED'], isFalse);
 
     await tester.tap(find.text('選択を解除'));
     await tester.pumpAndSettle();
     expect(find.text('選択を解除'), findsNothing);
 
-    rawAfterMark = jsonDecode(
-      prefsAfterMark.getString('lanske_recent_schedules')!,
-    ) as List<dynamic>;
-    markedById = {
-      for (final value in rawAfterMark.cast<Map<String, dynamic>>())
-        value['public_id'] as String: value['is_pending_removal'] as bool,
-    };
+    markedById = await _readPendingById();
     expect(markedById['UNCONFIRMED'], isFalse);
     expect(markedById['CONFIRMED'], isFalse);
 
@@ -169,6 +156,10 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(Checkbox), findsNothing);
     expect(find.text('未確定イベント'), findsOneWidget);
+
+    markedById = await _readPendingById();
+    expect(markedById['UNCONFIRMED'], isTrue);
+    expect(markedById['CONFIRMED'], isFalse);
 
     await tester.tap(find.text('一覧から削除'));
     await tester.pumpAndSettle();
@@ -188,6 +179,54 @@ void main() {
       contains('UNCONFIRMED'),
     );
   });
+
+  testWidgets('persists draft selection when tapping outside the drawer',
+      (tester) async {
+    final item = LocalScheduleHistoryItem(
+      publicId: 'UNCONFIRMED',
+      title: '未確定イベント',
+      courtCount: 1,
+      playerCount: 6,
+      createdAt: DateTime(2026, 8, 14, 8),
+      firstSavedAt: DateTime(2026, 8, 14, 8),
+      lastOpenedAt: DateTime(2026, 8, 14, 8),
+      generatedScheduleId: 'schedule-unconfirmed',
+      isAdopted: false,
+      completedMatchCount: 0,
+      totalMatchCount: 10,
+    );
+    SharedPreferences.setMockInitialValues({
+      'lanske_recent_schedules': jsonEncode([item.toJson()]),
+    });
+
+    await _pumpDrawer(tester, width: 400);
+    await tester.tap(find.byIcon(Icons.delete_outline));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(Checkbox));
+    await tester.pumpAndSettle();
+
+    var markedById = await _readPendingById();
+    expect(markedById['UNCONFIRMED'], isFalse);
+
+    await tester.tapAt(const Offset(20, 400));
+    await tester.pumpAndSettle();
+    expect(find.byType(Drawer), findsNothing);
+
+    markedById = await _readPendingById();
+    expect(markedById['UNCONFIRMED'], isTrue);
+  });
+}
+
+Future<Map<String, bool>> _readPendingById() async {
+  final prefs = await SharedPreferences.getInstance();
+  final raw = jsonDecode(
+    prefs.getString('lanske_recent_schedules')!,
+  ) as List<dynamic>;
+
+  return {
+    for (final value in raw.cast<Map<String, dynamic>>())
+      value['public_id'] as String: value['is_pending_removal'] as bool,
+  };
 }
 
 Future<void> _pumpDrawer(

--- a/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
+++ b/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
@@ -210,7 +210,6 @@ void main() {
 
     await tester.tapAt(const Offset(20, 400));
     await tester.pumpAndSettle();
-    expect(find.byType(Drawer), findsNothing);
 
     markedById = await _readPendingById();
     expect(markedById['UNCONFIRMED'], isTrue);

--- a/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
+++ b/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
@@ -89,7 +89,8 @@ void main() {
     expect(openedItem?.publicId, 'ABCDEFGH');
   });
 
-  testWidgets('marks unconfirmed schedules and removes them from the local list',
+  testWidgets(
+      'marks unconfirmed schedules and removes them from the local list',
       (tester) async {
     final unconfirmed = LocalScheduleHistoryItem(
       publicId: 'UNCONFIRMED',

--- a/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
+++ b/test/features/doubles_scheduler/presentation/doubles_schedule_list_drawer_test.dart
@@ -130,32 +130,52 @@ void main() {
     await tester.tap(find.byIcon(Icons.delete_outline));
     await tester.pumpAndSettle();
     expect(find.byType(Checkbox), findsNWidgets(2));
+    expect(find.text('未確定を選択'), findsOneWidget);
+    expect(find.text('選択を解除'), findsNothing);
 
-    await tester.tap(find.byIcon(Icons.select_all));
+    await tester.tap(find.text('未確定を選択'));
     await tester.pumpAndSettle();
+    expect(find.text('選択を解除'), findsOneWidget);
 
     final prefsAfterMark = await SharedPreferences.getInstance();
-    final rawAfterMark = jsonDecode(
+    var rawAfterMark = jsonDecode(
       prefsAfterMark.getString('lanske_recent_schedules')!,
     ) as List<dynamic>;
-    final markedById = {
+    var markedById = {
       for (final value in rawAfterMark.cast<Map<String, dynamic>>())
         value['public_id'] as String: value['is_pending_removal'] as bool,
     };
     expect(markedById['UNCONFIRMED'], isTrue);
     expect(markedById['CONFIRMED'], isFalse);
 
+    await tester.tap(find.text('選択を解除'));
+    await tester.pumpAndSettle();
+    expect(find.text('選択を解除'), findsNothing);
+
+    rawAfterMark = jsonDecode(
+      prefsAfterMark.getString('lanske_recent_schedules')!,
+    ) as List<dynamic>;
+    markedById = {
+      for (final value in rawAfterMark.cast<Map<String, dynamic>>())
+        value['public_id'] as String: value['is_pending_removal'] as bool,
+    };
+    expect(markedById['UNCONFIRMED'], isFalse);
+    expect(markedById['CONFIRMED'], isFalse);
+
+    await tester.tap(find.text('未確定を選択'));
+    await tester.pumpAndSettle();
+
     await tester.tap(find.text('決定'));
     await tester.pumpAndSettle();
     expect(find.byType(Checkbox), findsNothing);
     expect(find.text('未確定イベント'), findsOneWidget);
 
-    await tester.tap(find.text('履歴を削除'));
+    await tester.tap(find.text('一覧から削除'));
     await tester.pumpAndSettle();
-    expect(find.text('対戦表表示履歴を削除しますか？'), findsOneWidget);
+    expect(find.text('選択した対戦表を一覧から削除しますか？'), findsOneWidget);
 
     await tester.tap(
-      find.widgetWithText(FilledButton, '履歴を削除').last,
+      find.widgetWithText(FilledButton, '一覧から削除').last,
     );
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary

ダブルス対戦表一覧で、不要な対戦表を選択して一覧から非表示にできるようにしました。

- 対戦表一覧に削除対象の選択モードを追加
- 選択した対戦表をグレーアウトして削除対象を明示
- 「未確定を選択」で表示中の未確定対戦表を一括選択
- 「選択を解除」で選択状態を一括解除
- 選択状態をローカルに保持し、一覧を閉じても維持
- チェック操作中はメモリ上のdraftだけを更新し、決定・Drawerを閉じる操作などでまとめて保存
- 選択した対戦表を確認ダイアログ経由で一覧から非表示
- Firestore上のイベントデータは削除せず、ローカル一覧からのみ非表示
- 非表示済みの対戦表は通常の履歴更新では自動的に一覧へ復帰しない
- ローカル履歴の内部保存上限を100件、一覧表示上限を20件に分離
- 上位20件を非表示にした場合、保持している古い履歴を一覧へ繰り上げ表示
- 旧ローカル履歴との互換性を維持
- 日本語・英語の表示文言を追加

## Verification

- `flutter gen-l10n`
- `dart format lib/ test/`
- `flutter analyze`
- `flutter test`
- `git diff --check`
- ダブルス対戦表一覧の画面確認
  - 個別選択 / 解除
  - 未確定の一括選択
  - 選択の一括解除
  - 選択状態のグレーアウト
  - 決定後の選択状態維持
  - 選択対象の一覧からの削除
  - Drawerを閉じた場合の選択状態保存
  - 狭い画面幅での折り返し表示

Closes #140