### PR TITLE
🎨 Finalize ver0.1.6 UI and release metadata refs #177

### DIFF
--- a/docs/doubles-event-display-persistence.md
+++ b/docs/doubles-event-display-persistence.md
@@ -87,7 +87,9 @@ base、最新値、入力値を比較する高度な競合解消は別Issueで�
 
 ダブルス機能のサービス名は「らんすけ：ダブルス乱数表」とし、編集対象のイベントタイトルとは分離して表示する。
 
-アプリ共通フッターには、現在公開済みのrelease versionを表示する。ver0.1.6の完了前は `© 2026 S.R.P. · ver.0.1.5` とする。
+アプリ共通フッターには、現在公開しているrelease versionを表示する。表示値の正本は `AppConfig.releaseVersion` とし、Flutter package versionの `pubspec.yaml` も原則として同じrelease versionへ合わせる。
+
+ver0.1.6では途中版として `0.1.6+2` を公開した後、正式完了時に `0.1.6` へ統一する。
 
 ## 将来拡張
 

--- a/docs/release-checklist-ver0.1.md
+++ b/docs/release-checklist-ver0.1.md
@@ -68,6 +68,12 @@
 
 ## 3. web deploy 確認
 
+### release version
+
+- [ ] `AppConfig.releaseVersion` が今回の正式release versionになっている
+- [ ] `pubspec.yaml` の `version` が `AppConfig.releaseVersion` と整合している
+- [ ] 共通フッターに今回の正式release versionが表示される
+
 ### Firebase Hosting
 
 - [ ] Firebase project を確認した

--- a/docs/ui-navigation-guidelines.md
+++ b/docs/ui-navigation-guidelines.md
@@ -91,6 +91,8 @@ Lanske の AppBar、ナビゲーション Drawer、画面内操作を追加・�
 
 サービス名が画面内に常時出ない場合でもアプリ名を識別できるよう、表示は次の構成とする。
 
-`Lanske · © 2026 S.R.P. · ver.<release version>`
+`Lanske · © 2026 S.R.P. · ver.<releaseVersion>`
+
+`<releaseVersion>` は `AppConfig.releaseVersion` を正本とし、l10n の `appFooterText` でも同じ `releaseVersion` 名のplaceholderを使用する。`pubspec.yaml` の `version` も原則として同じrelease versionへ合わせる。
 
 フッターの表示タイミングやスクロール末尾判定は、文言変更を理由に個別画面で上書きしない。

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -37,6 +37,7 @@ class _AppState extends State<App> {
   Widget build(BuildContext context) {
     final uri = Uri.base;
     final publicId = uri.queryParameters['sid']?.trim();
+    final isTeamRoute = uri.path == '/team' || uri.path.startsWith('/team/');
 
     final home = publicId == null || publicId.isEmpty
         ? _homeForPath(uri.path)
@@ -48,7 +49,7 @@ class _AppState extends State<App> {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       locale: const Locale('ja'),
-      theme: appTheme,
+      theme: isTeamRoute ? appTheme : doublesAppTheme,
       navigatorObservers: [_footerNavigatorObserver],
       builder: (context, child) {
         return AppFooterHost(

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -3,6 +3,8 @@ import 'package:srp_lanske/l10n/l10n.dart';
 
 import '../features/doubles_scheduler/presentation/event_setup_page.dart';
 import '../features/doubles_scheduler/presentation/restored_schedule_page.dart';
+import '../features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart'
+    show doublesFloatingNavigationRouteObserver;
 import '../features/team_scheduler/presentation/team_schedule_list_page.dart';
 import '../features/team_scheduler/presentation/team_schedule_page.dart';
 import '../features/team_scheduler/presentation/team_setup_page.dart';
@@ -50,7 +52,10 @@ class _AppState extends State<App> {
       supportedLocales: AppLocalizations.supportedLocales,
       locale: const Locale('ja'),
       theme: isTeamRoute ? appTheme : doublesAppTheme,
-      navigatorObservers: [_footerNavigatorObserver],
+      navigatorObservers: [
+        _footerNavigatorObserver,
+        doublesFloatingNavigationRouteObserver,
+      ],
       builder: (context, child) {
         return AppFooterHost(
           controller: _footerController,

--- a/lib/app/config/app_config.dart
+++ b/lib/app/config/app_config.dart
@@ -1,6 +1,6 @@
 class AppConfig {
   static const String appName = 'Lanske';
-  static const String releaseVersion = '0.1.6+2';
+  static const String releaseVersion = '0.1.6';
 
   static const String coreApiBaseUrl = String.fromEnvironment(
     'LANSKE_CORE_API_BASE_URL',

--- a/lib/app/theme/app_theme.dart
+++ b/lib/app/theme/app_theme.dart
@@ -9,14 +9,16 @@ final ThemeData _baseTheme = ThemeData(
 final TextTheme _textTheme =
     GoogleFonts.notoSansJpTextTheme(_baseTheme.textTheme);
 
+final TextStyle _appBarTitleTextStyle = GoogleFonts.notoSansJp(
+  fontSize: 22,
+  fontWeight: FontWeight.w500,
+  color: _baseTheme.colorScheme.onSurface,
+);
+
 final ThemeData appTheme = _baseTheme.copyWith(
   textTheme: _textTheme,
   appBarTheme: AppBarTheme(
-    titleTextStyle: GoogleFonts.notoSansJp(
-      fontSize: 22,
-      fontWeight: FontWeight.w500,
-      color: _baseTheme.colorScheme.onSurface,
-    ),
+    titleTextStyle: _appBarTitleTextStyle,
   ),
   filledButtonTheme: FilledButtonThemeData(
     style: FilledButton.styleFrom(
@@ -37,6 +39,16 @@ final ThemeData appTheme = _baseTheme.copyWith(
     elevation: 6,
     shape: RoundedRectangleBorder(
       borderRadius: BorderRadius.circular(20),
+    ),
+  ),
+);
+
+final ThemeData doublesAppTheme = appTheme.copyWith(
+  appBarTheme: appTheme.appBarTheme.copyWith(
+    titleTextStyle: _appBarTitleTextStyle.copyWith(
+      color: _baseTheme.colorScheme.onPrimaryContainer,
+      backgroundColor:
+          _baseTheme.colorScheme.primaryContainer.withValues(alpha: 0.92),
     ),
   ),
 );

--- a/lib/features/doubles_scheduler/presentation/widgets/doubles_match_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/doubles_match_card.dart
@@ -54,37 +54,53 @@ class DoublesMatchCardContent extends StatelessWidget {
       matchPositionLabel,
     );
 
-    final statusSummary = hasAdoptedSchedule
-        ? Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Chip(
-                key: ValueKey('match-status-${status.value}'),
-                visualDensity: VisualDensity.compact,
-                backgroundColor: visualStyle.statusBackgroundColor,
-                side: BorderSide(color: visualStyle.statusBorderColor),
-                labelStyle: TextStyle(
-                  color: visualStyle.statusForegroundColor,
-                  fontWeight: FontWeight.w600,
-                ),
-                label: Text(statusLabel),
+    final scoreWidget = scores.length >= 2
+        ? FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: Alignment.centerRight,
+            child: Text(
+              '${scores[0]} - ${scores[1]}',
+              key: const ValueKey('match-score'),
+              style: const TextStyle(
+                fontWeight: FontWeight.w700,
+                fontSize: 16,
               ),
-              if (scores.length >= 2) ...[
-                const SizedBox(width: 8),
-                Text(
-                  '${scores[0]} - ${scores[1]}',
-                  key: const ValueKey('match-score'),
-                  style: const TextStyle(
-                    fontWeight: FontWeight.w700,
-                    fontSize: 16,
+            ),
+          )
+        : null;
+    final noteWidget = progress?.note.trim().isNotEmpty ?? false
+        ? const Icon(Icons.note_alt_outlined, size: 18)
+        : null;
+
+    final statusSummary = hasAdoptedSchedule
+        ? SizedBox(
+            width: 146,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox(
+                  width: 46,
+                  child: scoreWidget,
+                ),
+                const SizedBox(width: 4),
+                Chip(
+                  key: ValueKey('match-status-${status.value}'),
+                  visualDensity: VisualDensity.compact,
+                  backgroundColor: visualStyle.statusBackgroundColor,
+                  side: BorderSide(color: visualStyle.statusBorderColor),
+                  labelStyle: TextStyle(
+                    color: visualStyle.statusForegroundColor,
+                    fontWeight: FontWeight.w600,
                   ),
+                  label: Text(statusLabel),
+                ),
+                const SizedBox(width: 4),
+                SizedBox(
+                  width: 22,
+                  child: noteWidget,
                 ),
               ],
-              if (progress?.note.trim().isNotEmpty ?? false) ...[
-                const SizedBox(width: 6),
-                const Icon(Icons.note_alt_outlined, size: 18),
-              ],
-            ],
+            ),
           )
         : null;
 
@@ -111,14 +127,7 @@ class DoublesMatchCardContent extends StatelessWidget {
                   ),
                 ),
               ),
-              if (statusSummary != null)
-                ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 132),
-                  child: FittedBox(
-                    fit: BoxFit.scaleDown,
-                    child: statusSummary,
-                  ),
-                ),
+              if (statusSummary != null) statusSummary,
               if (headerTrailing != null)
                 Align(
                   alignment: Alignment.centerRight,

--- a/lib/features/doubles_scheduler/presentation/widgets/doubles_match_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/doubles_match_card.dart
@@ -74,32 +74,39 @@ class DoublesMatchCardContent extends StatelessWidget {
 
     final statusSummary = hasAdoptedSchedule
         ? SizedBox(
-            width: 146,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                SizedBox(
-                  width: 46,
-                  child: scoreWidget,
+            key: const ValueKey('match-status-summary'),
+            width: 152,
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: SizedBox(
+                width: 156,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SizedBox(
+                      width: 46,
+                      child: scoreWidget,
+                    ),
+                    const SizedBox(width: 4),
+                    Chip(
+                      key: ValueKey('match-status-${status.value}'),
+                      visualDensity: VisualDensity.compact,
+                      backgroundColor: visualStyle.statusBackgroundColor,
+                      side: BorderSide(color: visualStyle.statusBorderColor),
+                      labelStyle: TextStyle(
+                        color: visualStyle.statusForegroundColor,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      label: Text(statusLabel),
+                    ),
+                    const SizedBox(width: 4),
+                    SizedBox(
+                      width: 22,
+                      child: noteWidget,
+                    ),
+                  ],
                 ),
-                const SizedBox(width: 4),
-                Chip(
-                  key: ValueKey('match-status-${status.value}'),
-                  visualDensity: VisualDensity.compact,
-                  backgroundColor: visualStyle.statusBackgroundColor,
-                  side: BorderSide(color: visualStyle.statusBorderColor),
-                  labelStyle: TextStyle(
-                    color: visualStyle.statusForegroundColor,
-                    fontWeight: FontWeight.w600,
-                  ),
-                  label: Text(statusLabel),
-                ),
-                const SizedBox(width: 4),
-                SizedBox(
-                  width: 22,
-                  child: noteWidget,
-                ),
-              ],
+              ),
             ),
           )
         : null;
@@ -127,7 +134,11 @@ class DoublesMatchCardContent extends StatelessWidget {
                   ),
                 ),
               ),
-              if (statusSummary != null) statusSummary,
+              if (statusSummary != null)
+                Transform.translate(
+                  offset: const Offset(-4, 0),
+                  child: statusSummary,
+                ),
               if (headerTrailing != null)
                 Align(
                   alignment: Alignment.centerRight,

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card.dart
@@ -333,7 +333,8 @@ class _ScheduleEventSummaryCardState extends State<ScheduleEventSummaryCard> {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Text(
-                        title,
+                        '$title：$position',
+                        key: const ValueKey('doubles-progress-position'),
                         style: Theme.of(context).textTheme.titleSmall,
                       ),
                       if (isInProgress &&
@@ -346,11 +347,6 @@ class _ScheduleEventSummaryCardState extends State<ScheduleEventSummaryCard> {
                     ],
                   ),
                   const SizedBox(height: 2),
-                  Text(
-                    position,
-                    key: const ValueKey('doubles-progress-position'),
-                    style: Theme.of(context).textTheme.bodyMedium,
-                  ),
                   Text(
                     opponents,
                     key: const ValueKey('doubles-progress-opponents'),
@@ -399,6 +395,7 @@ class _ScheduleEventSummaryCardState extends State<ScheduleEventSummaryCard> {
                   Expanded(
                     child: Tooltip(
                       message: event.title,
+                      triggerMode: TooltipTriggerMode.tap,
                       child: Text(
                         event.title,
                         maxLines: 1,

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
@@ -46,8 +46,8 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
   DoublesMatchSaveRegistration? _saveRegistration;
   ScrollPosition? _parentScrollPosition;
   OverlayEntry? _floatingNavigationEntry;
+  Animation<double>? _routeSecondaryAnimation;
   bool _floatingVisibilityCheckScheduled = false;
-  bool _isRouteCurrent = true;
 
   @override
   void initState() {
@@ -62,7 +62,7 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _isRouteCurrent = ModalRoute.of(context)?.isCurrent ?? true;
+    _syncRouteTransitionListener();
     _syncParentScrollPosition();
     _scheduleFloatingNavigationVisibilityCheck();
   }
@@ -79,6 +79,7 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
     DoublesMatchSaveRegistry.unregister(_saveRegistration);
     DoublesProgressUiStore.navigation.removeListener(_handleNavigationChanged);
     DoublesProgressUiStore.setCompletedNavigation(null);
+    _routeSecondaryAnimation?.removeListener(_handleRouteTransition);
     _parentScrollPosition?.removeListener(_handleParentScroll);
     _floatingNavigationEntry?.remove();
     _floatingNavigationEntry = null;
@@ -129,6 +130,21 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
       generatedScheduleId: generatedScheduleId,
       onSave: _saveMatch,
     );
+  }
+
+  void _syncRouteTransitionListener() {
+    final nextAnimation = ModalRoute.of(context)?.secondaryAnimation;
+    if (identical(nextAnimation, _routeSecondaryAnimation)) {
+      return;
+    }
+
+    _routeSecondaryAnimation?.removeListener(_handleRouteTransition);
+    _routeSecondaryAnimation = nextAnimation;
+    _routeSecondaryAnimation?.addListener(_handleRouteTransition);
+  }
+
+  void _handleRouteTransition() {
+    _scheduleFloatingNavigationVisibilityCheck();
   }
 
   void _syncParentScrollPosition() {
@@ -199,7 +215,7 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
   }
 
   void _updateFloatingNavigationVisibility() {
-    if (!_isRouteCurrent) {
+    if (!(ModalRoute.of(context)?.isCurrent ?? true)) {
       _setFloatingNavigationVisible(false);
       return;
     }

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
@@ -13,8 +13,21 @@ import 'schedule_rounds_view_impl.dart' as impl;
 export 'doubles_match_card.dart';
 export 'schedule_rounds_view_impl.dart' hide ScheduleRoundsView;
 
-final RouteObserver<ModalRoute<dynamic>> doublesFloatingNavigationRouteObserver =
-    RouteObserver<ModalRoute<dynamic>>();
+final DoublesFloatingNavigationRouteObserver
+    doublesFloatingNavigationRouteObserver =
+    DoublesFloatingNavigationRouteObserver();
+
+class DoublesFloatingNavigationRouteObserver extends NavigatorObserver {
+  final ValueNotifier<bool> isPopupRouteTop = ValueNotifier(false);
+
+  @override
+  void didChangeTop(
+    Route<dynamic> topRoute,
+    Route<dynamic>? previousTopRoute,
+  ) {
+    isPopupRouteTop.value = topRoute is PopupRoute<dynamic>;
+  }
+}
 
 class ScheduleRoundsView extends StatefulWidget {
   const ScheduleRoundsView({
@@ -38,8 +51,7 @@ class ScheduleRoundsView extends StatefulWidget {
   State<ScheduleRoundsView> createState() => _ScheduleRoundsViewState();
 }
 
-class _ScheduleRoundsViewState extends State<ScheduleRoundsView>
-    with RouteAware {
+class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
   static const _floatingNavigationRevealTop = 240.0;
   static const _floatingNavigationHideOffset = 48.0;
 
@@ -50,9 +62,7 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView>
   DoublesMatchSaveRegistration? _saveRegistration;
   ScrollPosition? _parentScrollPosition;
   OverlayEntry? _floatingNavigationEntry;
-  ModalRoute<dynamic>? _subscribedRoute;
   bool _floatingVisibilityCheckScheduled = false;
-  bool _isCoveredByRoute = false;
 
   @override
   void initState() {
@@ -61,13 +71,15 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView>
       repository: appScheduleProgressRepository,
     );
     DoublesProgressUiStore.navigation.addListener(_handleNavigationChanged);
+    doublesFloatingNavigationRouteObserver.isPopupRouteTop.addListener(
+      _handlePopupRouteChanged,
+    );
     _syncSaveRegistration();
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _syncRouteObserver();
     _syncParentScrollPosition();
     _scheduleFloatingNavigationVisibilityCheck();
   }
@@ -84,7 +96,9 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView>
     DoublesMatchSaveRegistry.unregister(_saveRegistration);
     DoublesProgressUiStore.navigation.removeListener(_handleNavigationChanged);
     DoublesProgressUiStore.setCompletedNavigation(null);
-    doublesFloatingNavigationRouteObserver.unsubscribe(this);
+    doublesFloatingNavigationRouteObserver.isPopupRouteTop.removeListener(
+      _handlePopupRouteChanged,
+    );
     _parentScrollPosition?.removeListener(_handleParentScroll);
     _floatingNavigationEntry?.remove();
     _floatingNavigationEntry = null;
@@ -137,37 +151,6 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView>
     );
   }
 
-  void _syncRouteObserver() {
-    final nextRoute = ModalRoute.of(context);
-    if (identical(nextRoute, _subscribedRoute)) {
-      return;
-    }
-
-    doublesFloatingNavigationRouteObserver.unsubscribe(this);
-    _subscribedRoute = nextRoute;
-    if (nextRoute != null) {
-      doublesFloatingNavigationRouteObserver.subscribe(this, nextRoute);
-    }
-  }
-
-  @override
-  void didPush() {
-    _isCoveredByRoute = false;
-    _scheduleFloatingNavigationVisibilityCheck();
-  }
-
-  @override
-  void didPushNext() {
-    _isCoveredByRoute = true;
-    _setFloatingNavigationVisible(false);
-  }
-
-  @override
-  void didPopNext() {
-    _isCoveredByRoute = false;
-    _scheduleFloatingNavigationVisibilityCheck();
-  }
-
   void _syncParentScrollPosition() {
     final nextPosition = Scrollable.maybeOf(context)?.position;
     if (identical(nextPosition, _parentScrollPosition)) {
@@ -190,6 +173,14 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView>
           ? _scrollToBottom
           : null,
     );
+    _scheduleFloatingNavigationVisibilityCheck();
+  }
+
+  void _handlePopupRouteChanged() {
+    if (doublesFloatingNavigationRouteObserver.isPopupRouteTop.value) {
+      _setFloatingNavigationVisible(false);
+      return;
+    }
     _scheduleFloatingNavigationVisibilityCheck();
   }
 
@@ -236,7 +227,7 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView>
   }
 
   void _updateFloatingNavigationVisibility() {
-    if (_isCoveredByRoute) {
+    if (doublesFloatingNavigationRouteObserver.isPopupRouteTop.value) {
       _setFloatingNavigationVisible(false);
       return;
     }

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
@@ -13,6 +13,9 @@ import 'schedule_rounds_view_impl.dart' as impl;
 export 'doubles_match_card.dart';
 export 'schedule_rounds_view_impl.dart' hide ScheduleRoundsView;
 
+final RouteObserver<ModalRoute<dynamic>> doublesFloatingNavigationRouteObserver =
+    RouteObserver<ModalRoute<dynamic>>();
+
 class ScheduleRoundsView extends StatefulWidget {
   const ScheduleRoundsView({
     super.key,
@@ -35,7 +38,8 @@ class ScheduleRoundsView extends StatefulWidget {
   State<ScheduleRoundsView> createState() => _ScheduleRoundsViewState();
 }
 
-class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
+class _ScheduleRoundsViewState extends State<ScheduleRoundsView>
+    with RouteAware {
   static const _floatingNavigationRevealTop = 240.0;
   static const _floatingNavigationHideOffset = 48.0;
 
@@ -46,8 +50,9 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
   DoublesMatchSaveRegistration? _saveRegistration;
   ScrollPosition? _parentScrollPosition;
   OverlayEntry? _floatingNavigationEntry;
-  Animation<double>? _routeSecondaryAnimation;
+  ModalRoute<dynamic>? _subscribedRoute;
   bool _floatingVisibilityCheckScheduled = false;
+  bool _isCoveredByRoute = false;
 
   @override
   void initState() {
@@ -62,7 +67,7 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _syncRouteTransitionListener();
+    _syncRouteObserver();
     _syncParentScrollPosition();
     _scheduleFloatingNavigationVisibilityCheck();
   }
@@ -79,7 +84,7 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
     DoublesMatchSaveRegistry.unregister(_saveRegistration);
     DoublesProgressUiStore.navigation.removeListener(_handleNavigationChanged);
     DoublesProgressUiStore.setCompletedNavigation(null);
-    _routeSecondaryAnimation?.removeListener(_handleRouteTransition);
+    doublesFloatingNavigationRouteObserver.unsubscribe(this);
     _parentScrollPosition?.removeListener(_handleParentScroll);
     _floatingNavigationEntry?.remove();
     _floatingNavigationEntry = null;
@@ -132,18 +137,34 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
     );
   }
 
-  void _syncRouteTransitionListener() {
-    final nextAnimation = ModalRoute.of(context)?.secondaryAnimation;
-    if (identical(nextAnimation, _routeSecondaryAnimation)) {
+  void _syncRouteObserver() {
+    final nextRoute = ModalRoute.of(context);
+    if (identical(nextRoute, _subscribedRoute)) {
       return;
     }
 
-    _routeSecondaryAnimation?.removeListener(_handleRouteTransition);
-    _routeSecondaryAnimation = nextAnimation;
-    _routeSecondaryAnimation?.addListener(_handleRouteTransition);
+    doublesFloatingNavigationRouteObserver.unsubscribe(this);
+    _subscribedRoute = nextRoute;
+    if (nextRoute != null) {
+      doublesFloatingNavigationRouteObserver.subscribe(this, nextRoute);
+    }
   }
 
-  void _handleRouteTransition() {
+  @override
+  void didPush() {
+    _isCoveredByRoute = false;
+    _scheduleFloatingNavigationVisibilityCheck();
+  }
+
+  @override
+  void didPushNext() {
+    _isCoveredByRoute = true;
+    _setFloatingNavigationVisible(false);
+  }
+
+  @override
+  void didPopNext() {
+    _isCoveredByRoute = false;
     _scheduleFloatingNavigationVisibilityCheck();
   }
 
@@ -215,7 +236,7 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
   }
 
   void _updateFloatingNavigationVisibility() {
-    if (!(ModalRoute.of(context)?.isCurrent ?? true)) {
+    if (_isCoveredByRoute) {
       _setFloatingNavigationVisible(false);
       return;
     }

--- a/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
+++ b/lib/features/doubles_scheduler/presentation/widgets/schedule_rounds_view.dart
@@ -47,6 +47,7 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
   ScrollPosition? _parentScrollPosition;
   OverlayEntry? _floatingNavigationEntry;
   bool _floatingVisibilityCheckScheduled = false;
+  bool _isRouteCurrent = true;
 
   @override
   void initState() {
@@ -61,6 +62,7 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    _isRouteCurrent = ModalRoute.of(context)?.isCurrent ?? true;
     _syncParentScrollPosition();
     _scheduleFloatingNavigationVisibilityCheck();
   }
@@ -197,6 +199,11 @@ class _ScheduleRoundsViewState extends State<ScheduleRoundsView> {
   }
 
   void _updateFloatingNavigationVisibility() {
+    if (!_isRouteCurrent) {
+      _setFloatingNavigationVisible(false);
+      return;
+    }
+
     final navigation = DoublesProgressUiStore.navigation.value;
     final anchorContext = _floatingNavigationAnchorKey.currentContext;
     final renderObject = anchorContext?.findRenderObject();

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -210,7 +210,7 @@
   },
   "shareUrlCopiedMessage": "URL copied.",
   "@shareUrlCopiedMessage": {
-    "description": "Message shown after copying the schedule URL."
+    "description": "Message shown when the share URL was copied."
   },
   "generateScheduleFailedMessage": "Could not generate the match table: {error}",
   "@generateScheduleFailedMessage": {
@@ -1000,7 +1000,7 @@
   },
   "teamScheduleShareUrlCopiedMessage": "Copied share URL.",
   "@teamScheduleShareUrlCopiedMessage": {
-    "description": "Message shown after copying a team schedule share URL."
+    "description": "Message shown after copying the team schedule share URL."
   },
   "nextTeamMatchTitle": "Next match",
   "@nextTeamMatchTitle": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -210,7 +210,7 @@
   },
   "shareUrlCopiedMessage": "URL copied.",
   "@shareUrlCopiedMessage": {
-    "description": "Message shown when the share URL was copied."
+    "description": "Message shown after copying the schedule URL."
   },
   "generateScheduleFailedMessage": "Could not generate the match table: {error}",
   "@generateScheduleFailedMessage": {
@@ -1000,7 +1000,7 @@
   },
   "teamScheduleShareUrlCopiedMessage": "Copied share URL.",
   "@teamScheduleShareUrlCopiedMessage": {
-    "description": "Message shown after copying the team schedule share URL."
+    "description": "Message shown after copying a team schedule share URL."
   },
   "nextTeamMatchTitle": "Next match",
   "@nextTeamMatchTitle": {
@@ -1564,13 +1564,13 @@
       }
     }
   },
-  "appFooterText": "© 2026 S.R.P. · ver.{version}",
+  "appFooterText": "© 2026 S.R.P. · ver.{releaseVersion}",
   "@appFooterText": {
     "description": "Common application footer with release version.",
     "placeholders": {
-      "version": {
+      "releaseVersion": {
         "type": "String",
-        "example": "0.1.5"
+        "example": "0.1.6"
       }
     }
   },

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -18,7 +18,7 @@
   },
   "supportMenuTitle": "サポート",
   "@supportMenuTitle": {
-    "description": "Menu item title for opening the support page link."
+    "description": "Menu item title for opening the support page."
   },
   "supportMenuSubtitle": "フィードバックもこちらから",
   "@supportMenuSubtitle": {
@@ -100,15 +100,15 @@
   },
   "eventInfoLoadFailedMessage": "取得できませんでした。URLを確認して再度お試しください",
   "@eventInfoLoadFailedMessage": {
-    "description": "Message shown when event information import failed."
+    "description": "Snack bar message shown when event information import failed."
   },
   "clipboardUrlNotFoundMessage": "クリップボードにURLがありません",
   "@clipboardUrlNotFoundMessage": {
-    "description": "Message shown when clipboard has no URL."
+    "description": "Snack bar message shown when clipboard has no URL."
   },
   "pasteTennisbearEventUrlMessage": "テニスベアのイベントURLを貼り付けてください",
   "@pasteTennisbearEventUrlMessage": {
-    "description": "Message shown when pasted text is not a TennisBear event URL."
+    "description": "Snack bar message shown when pasted text is not a TennisBear event URL."
   },
   "tennisbearEventUrlLabel": "テニスベアのイベントURL",
   "@tennisbearEventUrlLabel": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -18,7 +18,7 @@
   },
   "supportMenuTitle": "サポート",
   "@supportMenuTitle": {
-    "description": "Menu item title for opening the support page."
+    "description": "Menu item title for opening the support page link."
   },
   "supportMenuSubtitle": "フィードバックもこちらから",
   "@supportMenuSubtitle": {
@@ -100,15 +100,15 @@
   },
   "eventInfoLoadFailedMessage": "取得できませんでした。URLを確認して再度お試しください",
   "@eventInfoLoadFailedMessage": {
-    "description": "Snack bar message shown when event information import failed."
+    "description": "Message shown when event information import failed."
   },
   "clipboardUrlNotFoundMessage": "クリップボードにURLがありません",
   "@clipboardUrlNotFoundMessage": {
-    "description": "Snack bar message shown when clipboard has no URL."
+    "description": "Message shown when clipboard has no URL."
   },
   "pasteTennisbearEventUrlMessage": "テニスベアのイベントURLを貼り付けてください",
   "@pasteTennisbearEventUrlMessage": {
-    "description": "Snack bar message shown when pasted text is not a TennisBear event URL."
+    "description": "Message shown when pasted text is not a TennisBear event URL."
   },
   "tennisbearEventUrlLabel": "テニスベアのイベントURL",
   "@tennisbearEventUrlLabel": {
@@ -1564,13 +1564,13 @@
       }
     }
   },
-  "appFooterText": "© 2026 S.R.P. · ver.{version}",
+  "appFooterText": "© 2026 S.R.P. · ver.{releaseVersion}",
   "@appFooterText": {
     "description": "Common application footer with release version.",
     "placeholders": {
-      "version": {
+      "releaseVersion": {
         "type": "String",
-        "example": "0.1.5"
+        "example": "0.1.6"
       }
     }
   },

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1881,8 +1881,8 @@ abstract class AppLocalizations {
   /// Common application footer with release version.
   ///
   /// In ja, this message translates to:
-  /// **'© 2026 S.R.P. · ver.{version}'**
-  String appFooterText(String version);
+  /// **'© 2026 S.R.P. · ver.{releaseVersion}'**
+  String appFooterText(String releaseVersion);
 
   /// Button label for editing doubles event information.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1062,8 +1062,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String appFooterText(String version) {
-    return '© 2026 S.R.P. · ver.$version';
+  String appFooterText(String releaseVersion) {
+    return '© 2026 S.R.P. · ver.$releaseVersion';
   }
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1023,8 +1023,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String appFooterText(String version) {
-    return '© 2026 S.R.P. · ver.$version';
+  String appFooterText(String releaseVersion) {
+    return '© 2026 S.R.P. · ver.$releaseVersion';
   }
 
   @override

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -8,7 +8,8 @@ extension DoublesMatchNavigationLocalizations on AppLocalizations {
   }
 
   String doublesProgressPositionLabel(int roundNo, String courtLabel) {
-    return '${teamRoundTitle(roundNo)}$teamMatchGroupSeparator$courtLabel';
+    final courtTitle = teamCourtTitle(0).replaceFirst('0', courtLabel);
+    return '${teamRoundTitle(roundNo)}$teamMatchGroupSeparator$courtTitle';
   }
 
   String get doublesProgressInProgressTitle =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: srp_lanske
 description: Lanske app
 publish_to: "none"
-version: 0.1.0+1
+version: 0.1.6
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/test/features/doubles_scheduler/presentation/widgets/doubles_match_card_test.dart
+++ b/test/features/doubles_scheduler/presentation/widgets/doubles_match_card_test.dart
@@ -55,6 +55,40 @@ void main() {
     );
   });
 
+  testWidgets('compact header keeps score, status, note, and rest action separated',
+      (tester) async {
+    await tester.pumpWidget(
+      _TestApp(
+        hasAdoptedSchedule: true,
+        status: ScheduleMatchStatus.inProgress,
+        progress: _progress(
+          status: ScheduleMatchStatus.inProgress,
+          scores: const <int>[0, 2],
+          note: 'メモ',
+        ),
+        headerTrailing: const SizedBox(
+          key: ValueKey('test-header-trailing'),
+          width: 96,
+          child: Center(child: Text('休憩：2人')),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('0 - 2'), findsOneWidget);
+    expect(find.text('試合中'), findsOneWidget);
+    expect(find.byIcon(Icons.note_alt_outlined), findsOneWidget);
+
+    final statusRect = tester.getRect(
+      find.byKey(const ValueKey('match-status-summary')),
+    );
+    final trailingRect = tester.getRect(
+      find.byKey(const ValueKey('test-header-trailing')),
+    );
+    expect(statusRect.right, lessThanOrEqualTo(trailingRect.left));
+  });
+
   testWidgets('completed card overlays one WIN and one LOSE without added size',
       (
     tester,
@@ -185,6 +219,7 @@ void main() {
 ScheduleMatchProgress _progress({
   required ScheduleMatchStatus status,
   List<int>? scores,
+  String note = '',
 }) {
   final now = DateTime(2026, 8, 5, 20);
 
@@ -198,7 +233,7 @@ ScheduleMatchProgress _progress({
     status: status,
     result:
         scores == null ? null : ScheduleMatchResultSummary.simpleScore(scores),
-    note: '',
+    note: note,
     startedAt: status == ScheduleMatchStatus.scheduled ? null : now,
     finishedAt: status == ScheduleMatchStatus.completed ? now : null,
     createdAt: now,
@@ -212,11 +247,13 @@ class _TestApp extends StatelessWidget {
     required this.hasAdoptedSchedule,
     required this.status,
     this.progress,
+    this.headerTrailing,
   });
 
   final bool hasAdoptedSchedule;
   final ScheduleMatchStatus status;
   final ScheduleMatchProgress? progress;
+  final Widget? headerTrailing;
 
   @override
   Widget build(BuildContext context) {
@@ -230,6 +267,7 @@ class _TestApp extends StatelessWidget {
                 return DoublesMatchCardContent(
                   hasAdoptedSchedule: hasAdoptedSchedule,
                   matchPositionLabel: 'R 1 / C A',
+                  headerTrailing: headerTrailing,
                   side1: const SizedBox(
                     width: 120,
                     height: 56,

--- a/test/features/doubles_scheduler/presentation/widgets/doubles_match_card_test.dart
+++ b/test/features/doubles_scheduler/presentation/widgets/doubles_match_card_test.dart
@@ -55,7 +55,8 @@ void main() {
     );
   });
 
-  testWidgets('compact header keeps score, status, note, and rest action separated',
+  testWidgets(
+      'compact header keeps score, status, note, and rest action separated',
       (tester) async {
     await tester.pumpWidget(
       _TestApp(

--- a/test/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card_test.dart
+++ b/test/features/doubles_scheduler/presentation/widgets/schedule_event_summary_card_test.dart
@@ -64,6 +64,24 @@ void main() {
     expect(refreshCount, 1);
   });
 
+  testWidgets('uses tap trigger for the event title tooltip', (tester) async {
+    final aggregate = _aggregate();
+    final repository = _FakeEventRepository(aggregate);
+
+    await tester.pumpWidget(
+      _testApp(
+        ScheduleEventSummaryCard(
+          aggregate: aggregate,
+          repository: repository,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+    expect(tooltip.triggerMode, TooltipTriggerMode.tap);
+  });
+
   testWidgets('hides progress UI before the schedule is adopted',
       (tester) async {
     final aggregate = _aggregate();
@@ -135,8 +153,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('0 / 15'), findsOneWidget);
-    expect(find.text('次の対戦'), findsNWidgets(2));
-    expect(find.text('第2ラウンド / A'), findsOneWidget);
+    expect(find.text('次の対戦'), findsOneWidget);
+    expect(find.text('次の対戦：第2ラウンド / Aコート'), findsOneWidget);
     expect(find.text('参加者1 / 参加者2 vs 参加者3 / 参加者4'), findsOneWidget);
 
     await tester.tap(
@@ -174,7 +192,8 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('試合中'), findsNWidgets(2));
+    expect(find.text('試合中'), findsOneWidget);
+    expect(find.text('試合中：第3ラウンド / 2コート'), findsOneWidget);
     expect(find.byType(Badge), findsOneWidget);
     expect(find.text('2'), findsOneWidget);
 

--- a/test/features/doubles_scheduler/presentation/widgets/schedule_rounds_floating_navigation_test.dart
+++ b/test/features/doubles_scheduler/presentation/widgets/schedule_rounds_floating_navigation_test.dart
@@ -199,6 +199,7 @@ Widget _testApp({required ScrollController scrollController}) {
     locale: const Locale('ja'),
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
+    navigatorObservers: [doublesFloatingNavigationRouteObserver],
     home: Scaffold(
       body: ListView(
         controller: scrollController,

--- a/test/features/doubles_scheduler/presentation/widgets/schedule_rounds_floating_navigation_test.dart
+++ b/test/features/doubles_scheduler/presentation/widgets/schedule_rounds_floating_navigation_test.dart
@@ -71,6 +71,62 @@ void main() {
     );
   });
 
+  testWidgets('hides floating navigation while a dialog route is open',
+      (tester) async {
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      _testApp(
+        scrollController: scrollController,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    DoublesProgressUiStore.setNavigation(
+      DoublesProgressNavigationUiState(
+        kind: DoublesProgressNavigationUiKind.inProgress,
+        roundNo: 3,
+        courtLabel: '1',
+        side1PlayerNames: const ['1', '2'],
+        side2PlayerNames: const ['3', '4'],
+        inProgressMatchCount: 1,
+        targetKey: '3_1',
+        onNavigate: () async {},
+      ),
+    );
+    scrollController.jumpTo(500);
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('doubles-schedule-floating-navigation')),
+      findsOneWidget,
+    );
+
+    showDialog<void>(
+      context: tester.element(find.byType(ScheduleRoundsView)),
+      builder: (context) => const AlertDialog(
+        content: Text('dialog'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('dialog'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('doubles-schedule-floating-navigation')),
+      findsNothing,
+    );
+
+    Navigator.of(tester.element(find.byType(AlertDialog))).pop();
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('doubles-schedule-floating-navigation')),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('completed floating navigation scrolls to page bottom',
       (tester) async {
     final scrollController = ScrollController();


### PR DESCRIPTION
## Summary

- finalize public release version metadata for ver0.1.6
- align release/version documentation with the current production policy
- refine doubles schedule progress summary and event title interactions
- stabilize match status/score/note placement on match cards
- add doubles AppBar title highlighting
- hide floating progress navigation while dialogs are open and restore it after closing
- add/update widget tests for the final UI refinements

## Verification

- `flutter gen-l10n`
- `dart format lib/ test/`
- `flutter analyze`
- `flutter test`
- `git diff --check`
- mobile/desktop screen checks
- real-use operation check

## Release steps remaining

- Firebase Hosting Preview final smoke check
- merge to `main`
- production build/deploy
- production smoke check
- close #177 / umbrella #142 after release confirmation

refs #177